### PR TITLE
add `queryId` to `CompiledQuery` to allow async communication between more components.

### DIFF
--- a/src/dialect/mssql/mssql-driver.ts
+++ b/src/dialect/mssql/mssql-driver.ts
@@ -339,7 +339,6 @@ class MssqlRequest<O> {
     (event: 'completed' | 'chunkReady' | 'error', error?: unknown) => void
   >
   readonly #tedious: Tedious
-  #error: Error | any[] | undefined
   #rowCount: number | undefined
 
   constructor(props: MssqlRequestProps<O>) {

--- a/src/dialect/mysql/mysql-driver.ts
+++ b/src/dialect/mysql/mysql-driver.ts
@@ -7,6 +7,7 @@ import { parseSavepointCommand } from '../../parser/savepoint-parser.js'
 import { CompiledQuery } from '../../query-compiler/compiled-query.js'
 import { QueryCompiler } from '../../query-compiler/query-compiler.js'
 import { isFunction, isObject, freeze } from '../../util/object-utils.js'
+import { createQueryId } from '../../util/query-id.js'
 import { extendStackTrace } from '../../util/stack-trace-utils.js'
 import {
   MysqlDialectConfig,
@@ -98,7 +99,10 @@ export class MysqlDriver implements Driver {
     compileQuery: QueryCompiler['compileQuery'],
   ): Promise<void> {
     await connection.executeQuery(
-      compileQuery(parseSavepointCommand('savepoint', savepointName)),
+      compileQuery(
+        parseSavepointCommand('savepoint', savepointName),
+        createQueryId(),
+      ),
     )
   }
 
@@ -108,7 +112,10 @@ export class MysqlDriver implements Driver {
     compileQuery: QueryCompiler['compileQuery'],
   ): Promise<void> {
     await connection.executeQuery(
-      compileQuery(parseSavepointCommand('rollback to', savepointName)),
+      compileQuery(
+        parseSavepointCommand('rollback to', savepointName),
+        createQueryId(),
+      ),
     )
   }
 
@@ -118,7 +125,10 @@ export class MysqlDriver implements Driver {
     compileQuery: QueryCompiler['compileQuery'],
   ): Promise<void> {
     await connection.executeQuery(
-      compileQuery(parseSavepointCommand('release savepoint', savepointName)),
+      compileQuery(
+        parseSavepointCommand('release savepoint', savepointName),
+        createQueryId(),
+      ),
     )
   }
 

--- a/src/dialect/mysql/mysql-driver.ts
+++ b/src/dialect/mysql/mysql-driver.ts
@@ -167,16 +167,6 @@ class MysqlConnection implements DatabaseConnection {
       if (isOkPacket(result)) {
         const { insertId, affectedRows, changedRows } = result
 
-        const numAffectedRows =
-          affectedRows !== undefined && affectedRows !== null
-            ? BigInt(affectedRows)
-            : undefined
-
-        const numChangedRows =
-          changedRows !== undefined && changedRows !== null
-            ? BigInt(changedRows)
-            : undefined
-
         return {
           insertId:
             insertId !== undefined &&
@@ -184,10 +174,14 @@ class MysqlConnection implements DatabaseConnection {
             insertId.toString() !== '0'
               ? BigInt(insertId)
               : undefined,
-          // TODO: remove.
-          numUpdatedOrDeletedRows: numAffectedRows,
-          numAffectedRows,
-          numChangedRows,
+          numAffectedRows:
+            affectedRows !== undefined && affectedRows !== null
+              ? BigInt(affectedRows)
+              : undefined,
+          numChangedRows:
+            changedRows !== undefined && changedRows !== null
+              ? BigInt(changedRows)
+              : undefined,
           rows: [],
         }
       } else if (Array.isArray(result)) {

--- a/src/dialect/postgres/postgres-driver.ts
+++ b/src/dialect/postgres/postgres-driver.ts
@@ -3,14 +3,9 @@ import {
   QueryResult,
 } from '../../driver/database-connection.js'
 import { Driver, TransactionSettings } from '../../driver/driver.js'
-import { IdentifierNode } from '../../operation-node/identifier-node.js'
-import { RawNode } from '../../operation-node/raw-node.js'
 import { parseSavepointCommand } from '../../parser/savepoint-parser.js'
 import { CompiledQuery } from '../../query-compiler/compiled-query.js'
-import {
-  QueryCompiler,
-  RootOperationNode,
-} from '../../query-compiler/query-compiler.js'
+import { QueryCompiler } from '../../query-compiler/query-compiler.js'
 import { isFunction, freeze } from '../../util/object-utils.js'
 import { createQueryId } from '../../util/query-id.js'
 import { extendStackTrace } from '../../util/stack-trace-utils.js'
@@ -153,28 +148,20 @@ class PostgresConnection implements DatabaseConnection {
 
   async executeQuery<O>(compiledQuery: CompiledQuery): Promise<QueryResult<O>> {
     try {
-      const result = await this.#client.query<O>(compiledQuery.sql, [
-        ...compiledQuery.parameters,
-      ])
-
-      if (
-        result.command === 'INSERT' ||
-        result.command === 'UPDATE' ||
-        result.command === 'DELETE' ||
-        result.command === 'MERGE'
-      ) {
-        const numAffectedRows = BigInt(result.rowCount)
-
-        return {
-          // TODO: remove.
-          numUpdatedOrDeletedRows: numAffectedRows,
-          numAffectedRows,
-          rows: result.rows ?? [],
-        }
-      }
+      const { command, rowCount, rows } = await this.#client.query<O>(
+        compiledQuery.sql,
+        [...compiledQuery.parameters],
+      )
 
       return {
-        rows: result.rows ?? [],
+        numAffectedRows:
+          command === 'INSERT' ||
+          command === 'UPDATE' ||
+          command === 'DELETE' ||
+          command === 'MERGE'
+            ? BigInt(rowCount)
+            : undefined,
+        rows: rows ?? [],
       }
     } catch (err) {
       throw extendStackTrace(err, new Error())

--- a/src/dialect/postgres/postgres-driver.ts
+++ b/src/dialect/postgres/postgres-driver.ts
@@ -12,6 +12,7 @@ import {
   RootOperationNode,
 } from '../../query-compiler/query-compiler.js'
 import { isFunction, freeze } from '../../util/object-utils.js'
+import { createQueryId } from '../../util/query-id.js'
 import { extendStackTrace } from '../../util/stack-trace-utils.js'
 import {
   PostgresCursorConstructor,
@@ -91,7 +92,10 @@ export class PostgresDriver implements Driver {
     compileQuery: QueryCompiler['compileQuery'],
   ): Promise<void> {
     await connection.executeQuery(
-      compileQuery(parseSavepointCommand('savepoint', savepointName)),
+      compileQuery(
+        parseSavepointCommand('savepoint', savepointName),
+        createQueryId(),
+      ),
     )
   }
 
@@ -101,7 +105,10 @@ export class PostgresDriver implements Driver {
     compileQuery: QueryCompiler['compileQuery'],
   ): Promise<void> {
     await connection.executeQuery(
-      compileQuery(parseSavepointCommand('rollback to', savepointName)),
+      compileQuery(
+        parseSavepointCommand('rollback to', savepointName),
+        createQueryId(),
+      ),
     )
   }
 
@@ -111,7 +118,10 @@ export class PostgresDriver implements Driver {
     compileQuery: QueryCompiler['compileQuery'],
   ): Promise<void> {
     await connection.executeQuery(
-      compileQuery(parseSavepointCommand('release', savepointName)),
+      compileQuery(
+        parseSavepointCommand('release', savepointName),
+        createQueryId(),
+      ),
     )
   }
 

--- a/src/dialect/sqlite/sqlite-driver.ts
+++ b/src/dialect/sqlite/sqlite-driver.ts
@@ -116,23 +116,19 @@ class SqliteConnection implements DatabaseConnection {
       return Promise.resolve({
         rows: stmt.all(parameters) as O[],
       })
-    } else {
-      const { changes, lastInsertRowid } = stmt.run(parameters)
-
-      const numAffectedRows =
-        changes !== undefined && changes !== null ? BigInt(changes) : undefined
-
-      return Promise.resolve({
-        // TODO: remove.
-        numUpdatedOrDeletedRows: numAffectedRows,
-        numAffectedRows,
-        insertId:
-          lastInsertRowid !== undefined && lastInsertRowid !== null
-            ? BigInt(lastInsertRowid)
-            : undefined,
-        rows: [],
-      })
     }
+
+    const { changes, lastInsertRowid } = stmt.run(parameters)
+
+    return Promise.resolve({
+      numAffectedRows:
+        changes !== undefined && changes !== null ? BigInt(changes) : undefined,
+      insertId:
+        lastInsertRowid !== undefined && lastInsertRowid !== null
+          ? BigInt(lastInsertRowid)
+          : undefined,
+      rows: [],
+    })
   }
 
   async *streamQuery<R>(

--- a/src/dialect/sqlite/sqlite-driver.ts
+++ b/src/dialect/sqlite/sqlite-driver.ts
@@ -8,6 +8,7 @@ import { parseSavepointCommand } from '../../parser/savepoint-parser.js'
 import { CompiledQuery } from '../../query-compiler/compiled-query.js'
 import { QueryCompiler } from '../../query-compiler/query-compiler.js'
 import { freeze, isFunction } from '../../util/object-utils.js'
+import { createQueryId } from '../../util/query-id.js'
 import { SqliteDatabase, SqliteDialectConfig } from './sqlite-dialect-config.js'
 
 export class SqliteDriver implements Driver {
@@ -58,7 +59,10 @@ export class SqliteDriver implements Driver {
     compileQuery: QueryCompiler['compileQuery'],
   ): Promise<void> {
     await connection.executeQuery(
-      compileQuery(parseSavepointCommand('savepoint', savepointName)),
+      compileQuery(
+        parseSavepointCommand('savepoint', savepointName),
+        createQueryId(),
+      ),
     )
   }
 
@@ -68,7 +72,10 @@ export class SqliteDriver implements Driver {
     compileQuery: QueryCompiler['compileQuery'],
   ): Promise<void> {
     await connection.executeQuery(
-      compileQuery(parseSavepointCommand('rollback to', savepointName)),
+      compileQuery(
+        parseSavepointCommand('rollback to', savepointName),
+        createQueryId(),
+      ),
     )
   }
 
@@ -78,7 +85,10 @@ export class SqliteDriver implements Driver {
     compileQuery: QueryCompiler['compileQuery'],
   ): Promise<void> {
     await connection.executeQuery(
-      compileQuery(parseSavepointCommand('release', savepointName)),
+      compileQuery(
+        parseSavepointCommand('release', savepointName),
+        createQueryId(),
+      ),
     )
   }
 

--- a/src/driver/database-connection.ts
+++ b/src/driver/database-connection.ts
@@ -15,12 +15,6 @@ export interface DatabaseConnection {
 
 export interface QueryResult<O> {
   /**
-   * @deprecated use {@link QueryResult.numAffectedRows} instead.
-   */
-  // TODO: remove.
-  readonly numUpdatedOrDeletedRows?: bigint
-
-  /**
    * This is defined for insert, update, delete and merge queries and contains
    * the number of rows the query inserted/updated/deleted.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,6 +238,7 @@ export {
 } from './util/type-utils.js'
 export * from './util/infer-result.js'
 export { logOnce } from './util/log-once.js'
+export { createQueryId, QueryId } from './util/query-id.js'
 
 export {
   SelectExpression,

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -97,6 +97,7 @@ import { OutputNode } from './output-node.js'
 import { RefreshMaterializedViewNode } from './refresh-materialized-view-node.js'
 import { OrActionNode } from './or-action-node.js'
 import { CollateNode } from './collate-node.js'
+import { QueryId } from '../util/query-id.js'
 
 /**
  * Transforms an operation node tree into another one.
@@ -136,7 +137,11 @@ import { CollateNode } from './collate-node.js'
 export class OperationNodeTransformer {
   protected readonly nodeStack: OperationNode[] = []
 
-  readonly #transformers: Record<OperationNodeKind, Function> = freeze({
+  readonly #transformers: Record<
+    OperationNodeKind,
+    // TODO: make `queryId` required in v0.29 ?
+    (node: any, queryId?: QueryId) => any
+  > = freeze({
     AliasNode: this.transformAlias.bind(this),
     ColumnNode: this.transformColumn.bind(this),
     IdentifierNode: this.transformIdentifier.bind(this),
@@ -237,381 +242,446 @@ export class OperationNodeTransformer {
     CollateNode: this.transformCollate.bind(this),
   })
 
-  transformNode<T extends OperationNode | undefined>(node: T): T {
+  transformNode<T extends OperationNode | undefined>(
+    node: T,
+    queryId?: QueryId,
+  ): T {
     if (!node) {
       return node
     }
 
     this.nodeStack.push(node)
-    const out = this.transformNodeImpl(node)
+    const out = this.transformNodeImpl(node, queryId)
     this.nodeStack.pop()
 
     return freeze(out) as T
   }
 
-  protected transformNodeImpl<T extends OperationNode>(node: T): T {
-    return this.#transformers[node.kind](node)
+  protected transformNodeImpl<T extends OperationNode>(
+    node: T,
+    queryId?: QueryId,
+  ): T {
+    return this.#transformers[node.kind](node, queryId)
   }
 
   protected transformNodeList<
     T extends ReadonlyArray<OperationNode> | undefined,
-  >(list: T): T {
+  >(list: T, queryId?: QueryId): T {
     if (!list) {
       return list
     }
 
-    return freeze(list.map((node) => this.transformNode(node))) as T
+    return freeze(list.map((node) => this.transformNode(node, queryId))) as T
   }
 
-  protected transformSelectQuery(node: SelectQueryNode): SelectQueryNode {
+  protected transformSelectQuery(
+    node: SelectQueryNode,
+    queryId?: QueryId,
+  ): SelectQueryNode {
     return requireAllProps<SelectQueryNode>({
       kind: 'SelectQueryNode',
-      from: this.transformNode(node.from),
-      selections: this.transformNodeList(node.selections),
-      distinctOn: this.transformNodeList(node.distinctOn),
-      joins: this.transformNodeList(node.joins),
-      groupBy: this.transformNode(node.groupBy),
-      orderBy: this.transformNode(node.orderBy),
-      where: this.transformNode(node.where),
-      frontModifiers: this.transformNodeList(node.frontModifiers),
-      endModifiers: this.transformNodeList(node.endModifiers),
-      limit: this.transformNode(node.limit),
-      offset: this.transformNode(node.offset),
-      with: this.transformNode(node.with),
-      having: this.transformNode(node.having),
-      explain: this.transformNode(node.explain),
-      setOperations: this.transformNodeList(node.setOperations),
-      fetch: this.transformNode(node.fetch),
-      top: this.transformNode(node.top),
+      from: this.transformNode(node.from, queryId),
+      selections: this.transformNodeList(node.selections, queryId),
+      distinctOn: this.transformNodeList(node.distinctOn, queryId),
+      joins: this.transformNodeList(node.joins, queryId),
+      groupBy: this.transformNode(node.groupBy, queryId),
+      orderBy: this.transformNode(node.orderBy, queryId),
+      where: this.transformNode(node.where, queryId),
+      frontModifiers: this.transformNodeList(node.frontModifiers, queryId),
+      endModifiers: this.transformNodeList(node.endModifiers, queryId),
+      limit: this.transformNode(node.limit, queryId),
+      offset: this.transformNode(node.offset, queryId),
+      with: this.transformNode(node.with, queryId),
+      having: this.transformNode(node.having, queryId),
+      explain: this.transformNode(node.explain, queryId),
+      setOperations: this.transformNodeList(node.setOperations, queryId),
+      fetch: this.transformNode(node.fetch, queryId),
+      top: this.transformNode(node.top, queryId),
     })
   }
 
-  protected transformSelection(node: SelectionNode): SelectionNode {
+  protected transformSelection(
+    node: SelectionNode,
+    queryId?: QueryId,
+  ): SelectionNode {
     return requireAllProps<SelectionNode>({
       kind: 'SelectionNode',
-      selection: this.transformNode(node.selection),
+      selection: this.transformNode(node.selection, queryId),
     })
   }
 
-  protected transformColumn(node: ColumnNode): ColumnNode {
+  protected transformColumn(node: ColumnNode, queryId?: QueryId): ColumnNode {
     return requireAllProps<ColumnNode>({
       kind: 'ColumnNode',
-      column: this.transformNode(node.column),
+      column: this.transformNode(node.column, queryId),
     })
   }
 
-  protected transformAlias(node: AliasNode): AliasNode {
+  protected transformAlias(node: AliasNode, queryId?: QueryId): AliasNode {
     return requireAllProps<AliasNode>({
       kind: 'AliasNode',
-      node: this.transformNode(node.node),
-      alias: this.transformNode(node.alias),
+      node: this.transformNode(node.node, queryId),
+      alias: this.transformNode(node.alias, queryId),
     })
   }
 
-  protected transformTable(node: TableNode): TableNode {
+  protected transformTable(node: TableNode, queryId?: QueryId): TableNode {
     return requireAllProps<TableNode>({
       kind: 'TableNode',
-      table: this.transformNode(node.table),
+      table: this.transformNode(node.table, queryId),
     })
   }
 
-  protected transformFrom(node: FromNode): FromNode {
+  protected transformFrom(node: FromNode, queryId?: QueryId): FromNode {
     return requireAllProps<FromNode>({
       kind: 'FromNode',
-      froms: this.transformNodeList(node.froms),
+      froms: this.transformNodeList(node.froms, queryId),
     })
   }
 
-  protected transformReference(node: ReferenceNode): ReferenceNode {
+  protected transformReference(
+    node: ReferenceNode,
+    queryId?: QueryId,
+  ): ReferenceNode {
     return requireAllProps<ReferenceNode>({
       kind: 'ReferenceNode',
-      column: this.transformNode(node.column),
-      table: this.transformNode(node.table),
+      column: this.transformNode(node.column, queryId),
+      table: this.transformNode(node.table, queryId),
     })
   }
 
-  protected transformAnd(node: AndNode): AndNode {
+  protected transformAnd(node: AndNode, queryId?: QueryId): AndNode {
     return requireAllProps<AndNode>({
       kind: 'AndNode',
-      left: this.transformNode(node.left),
-      right: this.transformNode(node.right),
+      left: this.transformNode(node.left, queryId),
+      right: this.transformNode(node.right, queryId),
     })
   }
 
-  protected transformOr(node: OrNode): OrNode {
+  protected transformOr(node: OrNode, queryId?: QueryId): OrNode {
     return requireAllProps<OrNode>({
       kind: 'OrNode',
-      left: this.transformNode(node.left),
-      right: this.transformNode(node.right),
+      left: this.transformNode(node.left, queryId),
+      right: this.transformNode(node.right, queryId),
     })
   }
 
-  protected transformValueList(node: ValueListNode): ValueListNode {
+  protected transformValueList(
+    node: ValueListNode,
+    queryId?: QueryId,
+  ): ValueListNode {
     return requireAllProps<ValueListNode>({
       kind: 'ValueListNode',
-      values: this.transformNodeList(node.values),
+      values: this.transformNodeList(node.values, queryId),
     })
   }
 
-  protected transformParens(node: ParensNode): ParensNode {
+  protected transformParens(node: ParensNode, queryId?: QueryId): ParensNode {
     return requireAllProps<ParensNode>({
       kind: 'ParensNode',
-      node: this.transformNode(node.node),
+      node: this.transformNode(node.node, queryId),
     })
   }
 
-  protected transformJoin(node: JoinNode): JoinNode {
+  protected transformJoin(node: JoinNode, queryId?: QueryId): JoinNode {
     return requireAllProps<JoinNode>({
       kind: 'JoinNode',
       joinType: node.joinType,
-      table: this.transformNode(node.table),
-      on: this.transformNode(node.on),
+      table: this.transformNode(node.table, queryId),
+      on: this.transformNode(node.on, queryId),
     })
   }
 
-  protected transformRaw(node: RawNode): RawNode {
+  protected transformRaw(node: RawNode, queryId?: QueryId): RawNode {
     return requireAllProps<RawNode>({
       kind: 'RawNode',
       sqlFragments: freeze([...node.sqlFragments]),
-      parameters: this.transformNodeList(node.parameters),
+      parameters: this.transformNodeList(node.parameters, queryId),
     })
   }
 
-  protected transformWhere(node: WhereNode): WhereNode {
+  protected transformWhere(node: WhereNode, queryId?: QueryId): WhereNode {
     return requireAllProps<WhereNode>({
       kind: 'WhereNode',
-      where: this.transformNode(node.where),
+      where: this.transformNode(node.where, queryId),
     })
   }
 
-  protected transformInsertQuery(node: InsertQueryNode): InsertQueryNode {
+  protected transformInsertQuery(
+    node: InsertQueryNode,
+    queryId?: QueryId,
+  ): InsertQueryNode {
     return requireAllProps<InsertQueryNode>({
       kind: 'InsertQueryNode',
-      into: this.transformNode(node.into),
-      columns: this.transformNodeList(node.columns),
-      values: this.transformNode(node.values),
-      returning: this.transformNode(node.returning),
-      onConflict: this.transformNode(node.onConflict),
-      onDuplicateKey: this.transformNode(node.onDuplicateKey),
-      endModifiers: this.transformNodeList(node.endModifiers),
-      with: this.transformNode(node.with),
+      into: this.transformNode(node.into, queryId),
+      columns: this.transformNodeList(node.columns, queryId),
+      values: this.transformNode(node.values, queryId),
+      returning: this.transformNode(node.returning, queryId),
+      onConflict: this.transformNode(node.onConflict, queryId),
+      onDuplicateKey: this.transformNode(node.onDuplicateKey, queryId),
+      endModifiers: this.transformNodeList(node.endModifiers, queryId),
+      with: this.transformNode(node.with, queryId),
       ignore: node.ignore,
-      orAction: this.transformNode(node.orAction),
+      orAction: this.transformNode(node.orAction, queryId),
       replace: node.replace,
-      explain: this.transformNode(node.explain),
+      explain: this.transformNode(node.explain, queryId),
       defaultValues: node.defaultValues,
-      top: this.transformNode(node.top),
-      output: this.transformNode(node.output),
+      top: this.transformNode(node.top, queryId),
+      output: this.transformNode(node.output, queryId),
     })
   }
 
-  protected transformValues(node: ValuesNode): ValuesNode {
+  protected transformValues(node: ValuesNode, queryId?: QueryId): ValuesNode {
     return requireAllProps<ValuesNode>({
       kind: 'ValuesNode',
-      values: this.transformNodeList(node.values),
+      values: this.transformNodeList(node.values, queryId),
     })
   }
 
-  protected transformDeleteQuery(node: DeleteQueryNode): DeleteQueryNode {
+  protected transformDeleteQuery(
+    node: DeleteQueryNode,
+    queryId?: QueryId,
+  ): DeleteQueryNode {
     return requireAllProps<DeleteQueryNode>({
       kind: 'DeleteQueryNode',
-      from: this.transformNode(node.from),
-      using: this.transformNode(node.using),
-      joins: this.transformNodeList(node.joins),
-      where: this.transformNode(node.where),
-      returning: this.transformNode(node.returning),
-      endModifiers: this.transformNodeList(node.endModifiers),
-      with: this.transformNode(node.with),
-      orderBy: this.transformNode(node.orderBy),
-      limit: this.transformNode(node.limit),
-      explain: this.transformNode(node.explain),
-      top: this.transformNode(node.top),
-      output: this.transformNode(node.output),
+      from: this.transformNode(node.from, queryId),
+      using: this.transformNode(node.using, queryId),
+      joins: this.transformNodeList(node.joins, queryId),
+      where: this.transformNode(node.where, queryId),
+      returning: this.transformNode(node.returning, queryId),
+      endModifiers: this.transformNodeList(node.endModifiers, queryId),
+      with: this.transformNode(node.with, queryId),
+      orderBy: this.transformNode(node.orderBy, queryId),
+      limit: this.transformNode(node.limit, queryId),
+      explain: this.transformNode(node.explain, queryId),
+      top: this.transformNode(node.top, queryId),
+      output: this.transformNode(node.output, queryId),
     })
   }
 
-  protected transformReturning(node: ReturningNode): ReturningNode {
+  protected transformReturning(
+    node: ReturningNode,
+    queryId?: QueryId,
+  ): ReturningNode {
     return requireAllProps<ReturningNode>({
       kind: 'ReturningNode',
-      selections: this.transformNodeList(node.selections),
+      selections: this.transformNodeList(node.selections, queryId),
     })
   }
 
-  protected transformCreateTable(node: CreateTableNode): CreateTableNode {
+  protected transformCreateTable(
+    node: CreateTableNode,
+    queryId?: QueryId,
+  ): CreateTableNode {
     return requireAllProps<CreateTableNode>({
       kind: 'CreateTableNode',
-      table: this.transformNode(node.table),
-      columns: this.transformNodeList(node.columns),
-      constraints: this.transformNodeList(node.constraints),
+      table: this.transformNode(node.table, queryId),
+      columns: this.transformNodeList(node.columns, queryId),
+      constraints: this.transformNodeList(node.constraints, queryId),
       temporary: node.temporary,
       ifNotExists: node.ifNotExists,
       onCommit: node.onCommit,
-      frontModifiers: this.transformNodeList(node.frontModifiers),
-      endModifiers: this.transformNodeList(node.endModifiers),
-      selectQuery: this.transformNode(node.selectQuery),
+      frontModifiers: this.transformNodeList(node.frontModifiers, queryId),
+      endModifiers: this.transformNodeList(node.endModifiers, queryId),
+      selectQuery: this.transformNode(node.selectQuery, queryId),
     })
   }
 
   protected transformColumnDefinition(
     node: ColumnDefinitionNode,
+    queryId?: QueryId,
   ): ColumnDefinitionNode {
     return requireAllProps<ColumnDefinitionNode>({
       kind: 'ColumnDefinitionNode',
-      column: this.transformNode(node.column),
-      dataType: this.transformNode(node.dataType),
-      references: this.transformNode(node.references),
+      column: this.transformNode(node.column, queryId),
+      dataType: this.transformNode(node.dataType, queryId),
+      references: this.transformNode(node.references, queryId),
       primaryKey: node.primaryKey,
       autoIncrement: node.autoIncrement,
       unique: node.unique,
       notNull: node.notNull,
       unsigned: node.unsigned,
-      defaultTo: this.transformNode(node.defaultTo),
-      check: this.transformNode(node.check),
-      generated: this.transformNode(node.generated),
-      frontModifiers: this.transformNodeList(node.frontModifiers),
-      endModifiers: this.transformNodeList(node.endModifiers),
+      defaultTo: this.transformNode(node.defaultTo, queryId),
+      check: this.transformNode(node.check, queryId),
+      generated: this.transformNode(node.generated, queryId),
+      frontModifiers: this.transformNodeList(node.frontModifiers, queryId),
+      endModifiers: this.transformNodeList(node.endModifiers, queryId),
       nullsNotDistinct: node.nullsNotDistinct,
       identity: node.identity,
       ifNotExists: node.ifNotExists,
     })
   }
 
-  protected transformAddColumn(node: AddColumnNode): AddColumnNode {
+  protected transformAddColumn(
+    node: AddColumnNode,
+    queryId?: QueryId,
+  ): AddColumnNode {
     return requireAllProps<AddColumnNode>({
       kind: 'AddColumnNode',
-      column: this.transformNode(node.column),
+      column: this.transformNode(node.column, queryId),
     })
   }
 
-  protected transformDropTable(node: DropTableNode): DropTableNode {
+  protected transformDropTable(
+    node: DropTableNode,
+    queryId?: QueryId,
+  ): DropTableNode {
     return requireAllProps<DropTableNode>({
       kind: 'DropTableNode',
-      table: this.transformNode(node.table),
+      table: this.transformNode(node.table, queryId),
       ifExists: node.ifExists,
       cascade: node.cascade,
     })
   }
 
-  protected transformOrderBy(node: OrderByNode): OrderByNode {
+  protected transformOrderBy(
+    node: OrderByNode,
+    queryId?: QueryId,
+  ): OrderByNode {
     return requireAllProps<OrderByNode>({
       kind: 'OrderByNode',
-      items: this.transformNodeList(node.items),
+      items: this.transformNodeList(node.items, queryId),
     })
   }
 
-  protected transformOrderByItem(node: OrderByItemNode): OrderByItemNode {
+  protected transformOrderByItem(
+    node: OrderByItemNode,
+    queryId?: QueryId,
+  ): OrderByItemNode {
     return requireAllProps<OrderByItemNode>({
       kind: 'OrderByItemNode',
-      orderBy: this.transformNode(node.orderBy),
-      direction: this.transformNode(node.direction),
-      collation: this.transformNode(node.collation),
+      orderBy: this.transformNode(node.orderBy, queryId),
+      direction: this.transformNode(node.direction, queryId),
+      collation: this.transformNode(node.collation, queryId),
       nulls: node.nulls,
     })
   }
 
-  protected transformGroupBy(node: GroupByNode): GroupByNode {
+  protected transformGroupBy(
+    node: GroupByNode,
+    queryId?: QueryId,
+  ): GroupByNode {
     return requireAllProps<GroupByNode>({
       kind: 'GroupByNode',
-      items: this.transformNodeList(node.items),
+      items: this.transformNodeList(node.items, queryId),
     })
   }
 
-  protected transformGroupByItem(node: GroupByItemNode): GroupByItemNode {
+  protected transformGroupByItem(
+    node: GroupByItemNode,
+    queryId?: QueryId,
+  ): GroupByItemNode {
     return requireAllProps<GroupByItemNode>({
       kind: 'GroupByItemNode',
-      groupBy: this.transformNode(node.groupBy),
+      groupBy: this.transformNode(node.groupBy, queryId),
     })
   }
 
-  protected transformUpdateQuery(node: UpdateQueryNode): UpdateQueryNode {
+  protected transformUpdateQuery(
+    node: UpdateQueryNode,
+    queryId?: QueryId,
+  ): UpdateQueryNode {
     return requireAllProps<UpdateQueryNode>({
       kind: 'UpdateQueryNode',
-      table: this.transformNode(node.table),
-      from: this.transformNode(node.from),
-      joins: this.transformNodeList(node.joins),
-      where: this.transformNode(node.where),
-      updates: this.transformNodeList(node.updates),
-      returning: this.transformNode(node.returning),
-      endModifiers: this.transformNodeList(node.endModifiers),
-      with: this.transformNode(node.with),
-      explain: this.transformNode(node.explain),
-      limit: this.transformNode(node.limit),
-      top: this.transformNode(node.top),
-      output: this.transformNode(node.output),
-      orderBy: this.transformNode(node.orderBy),
+      table: this.transformNode(node.table, queryId),
+      from: this.transformNode(node.from, queryId),
+      joins: this.transformNodeList(node.joins, queryId),
+      where: this.transformNode(node.where, queryId),
+      updates: this.transformNodeList(node.updates, queryId),
+      returning: this.transformNode(node.returning, queryId),
+      endModifiers: this.transformNodeList(node.endModifiers, queryId),
+      with: this.transformNode(node.with, queryId),
+      explain: this.transformNode(node.explain, queryId),
+      limit: this.transformNode(node.limit, queryId),
+      top: this.transformNode(node.top, queryId),
+      output: this.transformNode(node.output, queryId),
+      orderBy: this.transformNode(node.orderBy, queryId),
     })
   }
 
-  protected transformColumnUpdate(node: ColumnUpdateNode): ColumnUpdateNode {
+  protected transformColumnUpdate(
+    node: ColumnUpdateNode,
+    queryId?: QueryId,
+  ): ColumnUpdateNode {
     return requireAllProps<ColumnUpdateNode>({
       kind: 'ColumnUpdateNode',
-      column: this.transformNode(node.column),
-      value: this.transformNode(node.value),
+      column: this.transformNode(node.column, queryId),
+      value: this.transformNode(node.value, queryId),
     })
   }
 
-  protected transformLimit(node: LimitNode): LimitNode {
+  protected transformLimit(node: LimitNode, queryId?: QueryId): LimitNode {
     return requireAllProps<LimitNode>({
       kind: 'LimitNode',
-      limit: this.transformNode(node.limit),
+      limit: this.transformNode(node.limit, queryId),
     })
   }
 
-  protected transformOffset(node: OffsetNode): OffsetNode {
+  protected transformOffset(node: OffsetNode, queryId?: QueryId): OffsetNode {
     return requireAllProps<OffsetNode>({
       kind: 'OffsetNode',
-      offset: this.transformNode(node.offset),
+      offset: this.transformNode(node.offset, queryId),
     })
   }
 
-  protected transformOnConflict(node: OnConflictNode): OnConflictNode {
+  protected transformOnConflict(
+    node: OnConflictNode,
+    queryId?: QueryId,
+  ): OnConflictNode {
     return requireAllProps<OnConflictNode>({
       kind: 'OnConflictNode',
-      columns: this.transformNodeList(node.columns),
-      constraint: this.transformNode(node.constraint),
-      indexExpression: this.transformNode(node.indexExpression),
-      indexWhere: this.transformNode(node.indexWhere),
-      updates: this.transformNodeList(node.updates),
-      updateWhere: this.transformNode(node.updateWhere),
+      columns: this.transformNodeList(node.columns, queryId),
+      constraint: this.transformNode(node.constraint, queryId),
+      indexExpression: this.transformNode(node.indexExpression, queryId),
+      indexWhere: this.transformNode(node.indexWhere, queryId),
+      updates: this.transformNodeList(node.updates, queryId),
+      updateWhere: this.transformNode(node.updateWhere, queryId),
       doNothing: node.doNothing,
     })
   }
 
   protected transformOnDuplicateKey(
     node: OnDuplicateKeyNode,
+    queryId?: QueryId,
   ): OnDuplicateKeyNode {
     return requireAllProps<OnDuplicateKeyNode>({
       kind: 'OnDuplicateKeyNode',
-      updates: this.transformNodeList(node.updates),
+      updates: this.transformNodeList(node.updates, queryId),
     })
   }
 
-  protected transformCreateIndex(node: CreateIndexNode): CreateIndexNode {
+  protected transformCreateIndex(
+    node: CreateIndexNode,
+    queryId?: QueryId,
+  ): CreateIndexNode {
     return requireAllProps<CreateIndexNode>({
       kind: 'CreateIndexNode',
-      name: this.transformNode(node.name),
-      table: this.transformNode(node.table),
-      columns: this.transformNodeList(node.columns),
+      name: this.transformNode(node.name, queryId),
+      table: this.transformNode(node.table, queryId),
+      columns: this.transformNodeList(node.columns, queryId),
       unique: node.unique,
-      using: this.transformNode(node.using),
+      using: this.transformNode(node.using, queryId),
       ifNotExists: node.ifNotExists,
-      where: this.transformNode(node.where),
+      where: this.transformNode(node.where, queryId),
       nullsNotDistinct: node.nullsNotDistinct,
     })
   }
 
-  protected transformList(node: ListNode): ListNode {
+  protected transformList(node: ListNode, queryId?: QueryId): ListNode {
     return requireAllProps<ListNode>({
       kind: 'ListNode',
-      items: this.transformNodeList(node.items),
+      items: this.transformNodeList(node.items, queryId),
     })
   }
 
-  protected transformDropIndex(node: DropIndexNode): DropIndexNode {
+  protected transformDropIndex(
+    node: DropIndexNode,
+    queryId?: QueryId,
+  ): DropIndexNode {
     return requireAllProps<DropIndexNode>({
       kind: 'DropIndexNode',
-      name: this.transformNode(node.name),
-      table: this.transformNode(node.table),
+      name: this.transformNode(node.name, queryId),
+      table: this.transformNode(node.table, queryId),
       ifExists: node.ifExists,
       cascade: node.cascade,
     })
@@ -619,52 +689,61 @@ export class OperationNodeTransformer {
 
   protected transformPrimaryKeyConstraint(
     node: PrimaryKeyConstraintNode,
+    queryId?: QueryId,
   ): PrimaryKeyConstraintNode {
     return requireAllProps<PrimaryKeyConstraintNode>({
       kind: 'PrimaryKeyConstraintNode',
-      columns: this.transformNodeList(node.columns),
-      name: this.transformNode(node.name),
+      columns: this.transformNodeList(node.columns, queryId),
+      name: this.transformNode(node.name, queryId),
     })
   }
 
   protected transformUniqueConstraint(
     node: UniqueConstraintNode,
+    queryId?: QueryId,
   ): UniqueConstraintNode {
     return requireAllProps<UniqueConstraintNode>({
       kind: 'UniqueConstraintNode',
-      columns: this.transformNodeList(node.columns),
-      name: this.transformNode(node.name),
+      columns: this.transformNodeList(node.columns, queryId),
+      name: this.transformNode(node.name, queryId),
       nullsNotDistinct: node.nullsNotDistinct,
     })
   }
 
   protected transformForeignKeyConstraint(
     node: ForeignKeyConstraintNode,
+    queryId?: QueryId,
   ): ForeignKeyConstraintNode {
     return requireAllProps<ForeignKeyConstraintNode>({
       kind: 'ForeignKeyConstraintNode',
-      columns: this.transformNodeList(node.columns),
-      references: this.transformNode(node.references),
-      name: this.transformNode(node.name),
+      columns: this.transformNodeList(node.columns, queryId),
+      references: this.transformNode(node.references, queryId),
+      name: this.transformNode(node.name, queryId),
       onDelete: node.onDelete,
       onUpdate: node.onUpdate,
     })
   }
 
-  protected transformSetOperation(node: SetOperationNode): SetOperationNode {
+  protected transformSetOperation(
+    node: SetOperationNode,
+    queryId?: QueryId,
+  ): SetOperationNode {
     return requireAllProps<SetOperationNode>({
       kind: 'SetOperationNode',
       operator: node.operator,
-      expression: this.transformNode(node.expression),
+      expression: this.transformNode(node.expression, queryId),
       all: node.all,
     })
   }
 
-  protected transformReferences(node: ReferencesNode): ReferencesNode {
+  protected transformReferences(
+    node: ReferencesNode,
+    queryId?: QueryId,
+  ): ReferencesNode {
     return requireAllProps<ReferencesNode>({
       kind: 'ReferencesNode',
-      table: this.transformNode(node.table),
-      columns: this.transformNodeList(node.columns),
+      table: this.transformNode(node.table, queryId),
+      columns: this.transformNodeList(node.columns, queryId),
       onDelete: node.onDelete,
       onUpdate: node.onUpdate,
     })
@@ -672,348 +751,422 @@ export class OperationNodeTransformer {
 
   protected transformCheckConstraint(
     node: CheckConstraintNode,
+    queryId?: QueryId,
   ): CheckConstraintNode {
     return requireAllProps<CheckConstraintNode>({
       kind: 'CheckConstraintNode',
-      expression: this.transformNode(node.expression),
-      name: this.transformNode(node.name),
+      expression: this.transformNode(node.expression, queryId),
+      name: this.transformNode(node.name, queryId),
     })
   }
 
-  protected transformWith(node: WithNode): WithNode {
+  protected transformWith(node: WithNode, queryId?: QueryId): WithNode {
     return requireAllProps<WithNode>({
       kind: 'WithNode',
-      expressions: this.transformNodeList(node.expressions),
+      expressions: this.transformNodeList(node.expressions, queryId),
       recursive: node.recursive,
     })
   }
 
   protected transformCommonTableExpression(
     node: CommonTableExpressionNode,
+    queryId?: QueryId,
   ): CommonTableExpressionNode {
     return requireAllProps<CommonTableExpressionNode>({
       kind: 'CommonTableExpressionNode',
-      name: this.transformNode(node.name),
+      name: this.transformNode(node.name, queryId),
       materialized: node.materialized,
-      expression: this.transformNode(node.expression),
+      expression: this.transformNode(node.expression, queryId),
     })
   }
 
   protected transformCommonTableExpressionName(
     node: CommonTableExpressionNameNode,
+    queryId?: QueryId,
   ): CommonTableExpressionNameNode {
     return requireAllProps<CommonTableExpressionNameNode>({
       kind: 'CommonTableExpressionNameNode',
-      table: this.transformNode(node.table),
-      columns: this.transformNodeList(node.columns),
+      table: this.transformNode(node.table, queryId),
+      columns: this.transformNodeList(node.columns, queryId),
     })
   }
 
-  protected transformHaving(node: HavingNode): HavingNode {
+  protected transformHaving(node: HavingNode, queryId?: QueryId): HavingNode {
     return requireAllProps<HavingNode>({
       kind: 'HavingNode',
-      having: this.transformNode(node.having),
+      having: this.transformNode(node.having, queryId),
     })
   }
 
-  protected transformCreateSchema(node: CreateSchemaNode): CreateSchemaNode {
+  protected transformCreateSchema(
+    node: CreateSchemaNode,
+    queryId?: QueryId,
+  ): CreateSchemaNode {
     return requireAllProps<CreateSchemaNode>({
       kind: 'CreateSchemaNode',
-      schema: this.transformNode(node.schema),
+      schema: this.transformNode(node.schema, queryId),
       ifNotExists: node.ifNotExists,
     })
   }
 
-  protected transformDropSchema(node: DropSchemaNode): DropSchemaNode {
+  protected transformDropSchema(
+    node: DropSchemaNode,
+    queryId?: QueryId,
+  ): DropSchemaNode {
     return requireAllProps<DropSchemaNode>({
       kind: 'DropSchemaNode',
-      schema: this.transformNode(node.schema),
+      schema: this.transformNode(node.schema, queryId),
       ifExists: node.ifExists,
       cascade: node.cascade,
     })
   }
 
-  protected transformAlterTable(node: AlterTableNode): AlterTableNode {
+  protected transformAlterTable(
+    node: AlterTableNode,
+    queryId?: QueryId,
+  ): AlterTableNode {
     return requireAllProps<AlterTableNode>({
       kind: 'AlterTableNode',
-      table: this.transformNode(node.table),
-      renameTo: this.transformNode(node.renameTo),
-      setSchema: this.transformNode(node.setSchema),
-      columnAlterations: this.transformNodeList(node.columnAlterations),
-      addConstraint: this.transformNode(node.addConstraint),
-      dropConstraint: this.transformNode(node.dropConstraint),
-      addIndex: this.transformNode(node.addIndex),
-      dropIndex: this.transformNode(node.dropIndex),
+      table: this.transformNode(node.table, queryId),
+      renameTo: this.transformNode(node.renameTo, queryId),
+      setSchema: this.transformNode(node.setSchema, queryId),
+      columnAlterations: this.transformNodeList(
+        node.columnAlterations,
+        queryId,
+      ),
+      addConstraint: this.transformNode(node.addConstraint, queryId),
+      dropConstraint: this.transformNode(node.dropConstraint, queryId),
+      addIndex: this.transformNode(node.addIndex, queryId),
+      dropIndex: this.transformNode(node.dropIndex, queryId),
     })
   }
 
-  protected transformDropColumn(node: DropColumnNode): DropColumnNode {
+  protected transformDropColumn(
+    node: DropColumnNode,
+    queryId?: QueryId,
+  ): DropColumnNode {
     return requireAllProps<DropColumnNode>({
       kind: 'DropColumnNode',
-      column: this.transformNode(node.column),
+      column: this.transformNode(node.column, queryId),
     })
   }
 
-  protected transformRenameColumn(node: RenameColumnNode): RenameColumnNode {
+  protected transformRenameColumn(
+    node: RenameColumnNode,
+    queryId?: QueryId,
+  ): RenameColumnNode {
     return requireAllProps<RenameColumnNode>({
       kind: 'RenameColumnNode',
-      column: this.transformNode(node.column),
-      renameTo: this.transformNode(node.renameTo),
+      column: this.transformNode(node.column, queryId),
+      renameTo: this.transformNode(node.renameTo, queryId),
     })
   }
 
-  protected transformAlterColumn(node: AlterColumnNode): AlterColumnNode {
+  protected transformAlterColumn(
+    node: AlterColumnNode,
+    queryId?: QueryId,
+  ): AlterColumnNode {
     return requireAllProps<AlterColumnNode>({
       kind: 'AlterColumnNode',
-      column: this.transformNode(node.column),
-      dataType: this.transformNode(node.dataType),
-      dataTypeExpression: this.transformNode(node.dataTypeExpression),
-      setDefault: this.transformNode(node.setDefault),
+      column: this.transformNode(node.column, queryId),
+      dataType: this.transformNode(node.dataType, queryId),
+      dataTypeExpression: this.transformNode(node.dataTypeExpression, queryId),
+      setDefault: this.transformNode(node.setDefault, queryId),
       dropDefault: node.dropDefault,
       setNotNull: node.setNotNull,
       dropNotNull: node.dropNotNull,
     })
   }
 
-  protected transformModifyColumn(node: ModifyColumnNode): ModifyColumnNode {
+  protected transformModifyColumn(
+    node: ModifyColumnNode,
+    queryId?: QueryId,
+  ): ModifyColumnNode {
     return requireAllProps<ModifyColumnNode>({
       kind: 'ModifyColumnNode',
-      column: this.transformNode(node.column),
+      column: this.transformNode(node.column, queryId),
     })
   }
 
-  protected transformAddConstraint(node: AddConstraintNode): AddConstraintNode {
+  protected transformAddConstraint(
+    node: AddConstraintNode,
+    queryId?: QueryId,
+  ): AddConstraintNode {
     return requireAllProps<AddConstraintNode>({
       kind: 'AddConstraintNode',
-      constraint: this.transformNode(node.constraint),
+      constraint: this.transformNode(node.constraint, queryId),
     })
   }
 
   protected transformDropConstraint(
     node: DropConstraintNode,
+    queryId?: QueryId,
   ): DropConstraintNode {
     return requireAllProps<DropConstraintNode>({
       kind: 'DropConstraintNode',
-      constraintName: this.transformNode(node.constraintName),
+      constraintName: this.transformNode(node.constraintName, queryId),
       ifExists: node.ifExists,
       modifier: node.modifier,
     })
   }
 
-  protected transformCreateView(node: CreateViewNode): CreateViewNode {
+  protected transformCreateView(
+    node: CreateViewNode,
+    queryId?: QueryId,
+  ): CreateViewNode {
     return requireAllProps<CreateViewNode>({
       kind: 'CreateViewNode',
-      name: this.transformNode(node.name),
+      name: this.transformNode(node.name, queryId),
       temporary: node.temporary,
       orReplace: node.orReplace,
       ifNotExists: node.ifNotExists,
       materialized: node.materialized,
-      columns: this.transformNodeList(node.columns),
-      as: this.transformNode(node.as),
+      columns: this.transformNodeList(node.columns, queryId),
+      as: this.transformNode(node.as, queryId),
     })
   }
 
   protected transformRefreshMaterializedView(
     node: RefreshMaterializedViewNode,
+    queryId?: QueryId,
   ): RefreshMaterializedViewNode {
     return requireAllProps<RefreshMaterializedViewNode>({
       kind: 'RefreshMaterializedViewNode',
-      name: this.transformNode(node.name),
+      name: this.transformNode(node.name, queryId),
       concurrently: node.concurrently,
       withNoData: node.withNoData,
     })
   }
 
-  protected transformDropView(node: DropViewNode): DropViewNode {
+  protected transformDropView(
+    node: DropViewNode,
+    queryId?: QueryId,
+  ): DropViewNode {
     return requireAllProps<DropViewNode>({
       kind: 'DropViewNode',
-      name: this.transformNode(node.name),
+      name: this.transformNode(node.name, queryId),
       ifExists: node.ifExists,
       materialized: node.materialized,
       cascade: node.cascade,
     })
   }
 
-  protected transformGenerated(node: GeneratedNode): GeneratedNode {
+  protected transformGenerated(
+    node: GeneratedNode,
+    queryId?: QueryId,
+  ): GeneratedNode {
     return requireAllProps<GeneratedNode>({
       kind: 'GeneratedNode',
       byDefault: node.byDefault,
       always: node.always,
       identity: node.identity,
       stored: node.stored,
-      expression: this.transformNode(node.expression),
+      expression: this.transformNode(node.expression, queryId),
     })
   }
 
-  protected transformDefaultValue(node: DefaultValueNode): DefaultValueNode {
+  protected transformDefaultValue(
+    node: DefaultValueNode,
+    queryId?: QueryId,
+  ): DefaultValueNode {
     return requireAllProps<DefaultValueNode>({
       kind: 'DefaultValueNode',
-      defaultValue: this.transformNode(node.defaultValue),
+      defaultValue: this.transformNode(node.defaultValue, queryId),
     })
   }
 
-  protected transformOn(node: OnNode): OnNode {
+  protected transformOn(node: OnNode, queryId?: QueryId): OnNode {
     return requireAllProps<OnNode>({
       kind: 'OnNode',
-      on: this.transformNode(node.on),
+      on: this.transformNode(node.on, queryId),
     })
   }
 
   protected transformSelectModifier(
     node: SelectModifierNode,
+    queryId?: QueryId,
   ): SelectModifierNode {
     return requireAllProps<SelectModifierNode>({
       kind: 'SelectModifierNode',
       modifier: node.modifier,
-      rawModifier: this.transformNode(node.rawModifier),
-      of: this.transformNodeList(node.of),
+      rawModifier: this.transformNode(node.rawModifier, queryId),
+      of: this.transformNodeList(node.of, queryId),
     })
   }
 
-  protected transformCreateType(node: CreateTypeNode): CreateTypeNode {
+  protected transformCreateType(
+    node: CreateTypeNode,
+    queryId?: QueryId,
+  ): CreateTypeNode {
     return requireAllProps<CreateTypeNode>({
       kind: 'CreateTypeNode',
-      name: this.transformNode(node.name),
-      enum: this.transformNode(node.enum),
+      name: this.transformNode(node.name, queryId),
+      enum: this.transformNode(node.enum, queryId),
     })
   }
 
-  protected transformDropType(node: DropTypeNode): DropTypeNode {
+  protected transformDropType(
+    node: DropTypeNode,
+    queryId?: QueryId,
+  ): DropTypeNode {
     return requireAllProps<DropTypeNode>({
       kind: 'DropTypeNode',
-      name: this.transformNode(node.name),
+      name: this.transformNode(node.name, queryId),
       ifExists: node.ifExists,
     })
   }
 
-  protected transformExplain(node: ExplainNode): ExplainNode {
+  protected transformExplain(
+    node: ExplainNode,
+    queryId?: QueryId,
+  ): ExplainNode {
     return requireAllProps({
       kind: 'ExplainNode',
       format: node.format,
-      options: this.transformNode(node.options),
+      options: this.transformNode(node.options, queryId),
     })
   }
 
   protected transformSchemableIdentifier(
     node: SchemableIdentifierNode,
+    queryId?: QueryId,
   ): SchemableIdentifierNode {
     return requireAllProps<SchemableIdentifierNode>({
       kind: 'SchemableIdentifierNode',
-      schema: this.transformNode(node.schema),
-      identifier: this.transformNode(node.identifier),
+      schema: this.transformNode(node.schema, queryId),
+      identifier: this.transformNode(node.identifier, queryId),
     })
   }
 
   protected transformAggregateFunction(
     node: AggregateFunctionNode,
+    queryId?: QueryId,
   ): AggregateFunctionNode {
     return requireAllProps({
       kind: 'AggregateFunctionNode',
       func: node.func,
-      aggregated: this.transformNodeList(node.aggregated),
+      aggregated: this.transformNodeList(node.aggregated, queryId),
       distinct: node.distinct,
-      orderBy: this.transformNode(node.orderBy),
-      withinGroup: this.transformNode(node.withinGroup),
-      filter: this.transformNode(node.filter),
-      over: this.transformNode(node.over),
+      orderBy: this.transformNode(node.orderBy, queryId),
+      withinGroup: this.transformNode(node.withinGroup, queryId),
+      filter: this.transformNode(node.filter, queryId),
+      over: this.transformNode(node.over, queryId),
     })
   }
 
-  protected transformOver(node: OverNode): OverNode {
+  protected transformOver(node: OverNode, queryId?: QueryId): OverNode {
     return requireAllProps({
       kind: 'OverNode',
-      orderBy: this.transformNode(node.orderBy),
-      partitionBy: this.transformNode(node.partitionBy),
+      orderBy: this.transformNode(node.orderBy, queryId),
+      partitionBy: this.transformNode(node.partitionBy, queryId),
     })
   }
 
-  protected transformPartitionBy(node: PartitionByNode): PartitionByNode {
+  protected transformPartitionBy(
+    node: PartitionByNode,
+    queryId?: QueryId,
+  ): PartitionByNode {
     return requireAllProps({
       kind: 'PartitionByNode',
-      items: this.transformNodeList(node.items),
+      items: this.transformNodeList(node.items, queryId),
     })
   }
 
   protected transformPartitionByItem(
     node: PartitionByItemNode,
+    queryId?: QueryId,
   ): PartitionByItemNode {
     return requireAllProps({
       kind: 'PartitionByItemNode',
-      partitionBy: this.transformNode(node.partitionBy),
+      partitionBy: this.transformNode(node.partitionBy, queryId),
     })
   }
 
   protected transformBinaryOperation(
     node: BinaryOperationNode,
+    queryId?: QueryId,
   ): BinaryOperationNode {
     return requireAllProps<BinaryOperationNode>({
       kind: 'BinaryOperationNode',
-      leftOperand: this.transformNode(node.leftOperand),
-      operator: this.transformNode(node.operator),
-      rightOperand: this.transformNode(node.rightOperand),
+      leftOperand: this.transformNode(node.leftOperand, queryId),
+      operator: this.transformNode(node.operator, queryId),
+      rightOperand: this.transformNode(node.rightOperand, queryId),
     })
   }
 
   protected transformUnaryOperation(
     node: UnaryOperationNode,
+    queryId?: QueryId,
   ): UnaryOperationNode {
     return requireAllProps<UnaryOperationNode>({
       kind: 'UnaryOperationNode',
-      operator: this.transformNode(node.operator),
-      operand: this.transformNode(node.operand),
+      operator: this.transformNode(node.operator, queryId),
+      operand: this.transformNode(node.operand, queryId),
     })
   }
 
-  protected transformUsing(node: UsingNode): UsingNode {
+  protected transformUsing(node: UsingNode, queryId?: QueryId): UsingNode {
     return requireAllProps<UsingNode>({
       kind: 'UsingNode',
-      tables: this.transformNodeList(node.tables),
+      tables: this.transformNodeList(node.tables, queryId),
     })
   }
 
-  protected transformFunction(node: FunctionNode): FunctionNode {
+  protected transformFunction(
+    node: FunctionNode,
+    queryId?: QueryId,
+  ): FunctionNode {
     return requireAllProps<FunctionNode>({
       kind: 'FunctionNode',
       func: node.func,
-      arguments: this.transformNodeList(node.arguments),
+      arguments: this.transformNodeList(node.arguments, queryId),
     })
   }
 
-  protected transformCase(node: CaseNode): CaseNode {
+  protected transformCase(node: CaseNode, queryId?: QueryId): CaseNode {
     return requireAllProps<CaseNode>({
       kind: 'CaseNode',
-      value: this.transformNode(node.value),
-      when: this.transformNodeList(node.when),
-      else: this.transformNode(node.else),
+      value: this.transformNode(node.value, queryId),
+      when: this.transformNodeList(node.when, queryId),
+      else: this.transformNode(node.else, queryId),
       isStatement: node.isStatement,
     })
   }
 
-  protected transformWhen(node: WhenNode): WhenNode {
+  protected transformWhen(node: WhenNode, queryId?: QueryId): WhenNode {
     return requireAllProps<WhenNode>({
       kind: 'WhenNode',
-      condition: this.transformNode(node.condition),
-      result: this.transformNode(node.result),
+      condition: this.transformNode(node.condition, queryId),
+      result: this.transformNode(node.result, queryId),
     })
   }
 
-  protected transformJSONReference(node: JSONReferenceNode): JSONReferenceNode {
+  protected transformJSONReference(
+    node: JSONReferenceNode,
+    queryId?: QueryId,
+  ): JSONReferenceNode {
     return requireAllProps<JSONReferenceNode>({
       kind: 'JSONReferenceNode',
-      reference: this.transformNode(node.reference),
-      traversal: this.transformNode(node.traversal),
+      reference: this.transformNode(node.reference, queryId),
+      traversal: this.transformNode(node.traversal, queryId),
     })
   }
 
-  protected transformJSONPath(node: JSONPathNode): JSONPathNode {
+  protected transformJSONPath(
+    node: JSONPathNode,
+    queryId?: QueryId,
+  ): JSONPathNode {
     return requireAllProps<JSONPathNode>({
       kind: 'JSONPathNode',
-      inOperator: this.transformNode(node.inOperator),
-      pathLegs: this.transformNodeList(node.pathLegs),
+      inOperator: this.transformNode(node.inOperator, queryId),
+      pathLegs: this.transformNodeList(node.pathLegs, queryId),
     })
   }
 
-  protected transformJSONPathLeg(node: JSONPathLegNode): JSONPathLegNode {
+  protected transformJSONPathLeg(
+    node: JSONPathLegNode,
+    _queryId?: QueryId,
+  ): JSONPathLegNode {
     return requireAllProps<JSONPathLegNode>({
       kind: 'JSONPathLegNode',
       type: node.type,
@@ -1023,36 +1176,43 @@ export class OperationNodeTransformer {
 
   protected transformJSONOperatorChain(
     node: JSONOperatorChainNode,
+    queryId?: QueryId,
   ): JSONOperatorChainNode {
     return requireAllProps<JSONOperatorChainNode>({
       kind: 'JSONOperatorChainNode',
-      operator: this.transformNode(node.operator),
-      values: this.transformNodeList(node.values),
+      operator: this.transformNode(node.operator, queryId),
+      values: this.transformNodeList(node.values, queryId),
     })
   }
 
-  protected transformTuple(node: TupleNode): TupleNode {
+  protected transformTuple(node: TupleNode, queryId?: QueryId): TupleNode {
     return requireAllProps<TupleNode>({
       kind: 'TupleNode',
-      values: this.transformNodeList(node.values),
+      values: this.transformNodeList(node.values, queryId),
     })
   }
 
-  protected transformMergeQuery(node: MergeQueryNode): MergeQueryNode {
+  protected transformMergeQuery(
+    node: MergeQueryNode,
+    queryId?: QueryId,
+  ): MergeQueryNode {
     return requireAllProps<MergeQueryNode>({
       kind: 'MergeQueryNode',
-      into: this.transformNode(node.into),
-      using: this.transformNode(node.using),
-      whens: this.transformNodeList(node.whens),
-      with: this.transformNode(node.with),
-      top: this.transformNode(node.top),
-      endModifiers: this.transformNodeList(node.endModifiers),
-      output: this.transformNode(node.output),
-      returning: this.transformNode(node.returning),
+      into: this.transformNode(node.into, queryId),
+      using: this.transformNode(node.using, queryId),
+      whens: this.transformNodeList(node.whens, queryId),
+      with: this.transformNode(node.with, queryId),
+      top: this.transformNode(node.top, queryId),
+      endModifiers: this.transformNodeList(node.endModifiers, queryId),
+      output: this.transformNode(node.output, queryId),
+      returning: this.transformNode(node.returning, queryId),
     })
   }
 
-  protected transformMatched(node: MatchedNode): MatchedNode {
+  protected transformMatched(
+    node: MatchedNode,
+    _queryId?: QueryId,
+  ): MatchedNode {
     return requireAllProps<MatchedNode>({
       kind: 'MatchedNode',
       not: node.not,
@@ -1060,34 +1220,37 @@ export class OperationNodeTransformer {
     })
   }
 
-  protected transformAddIndex(node: AddIndexNode): AddIndexNode {
+  protected transformAddIndex(
+    node: AddIndexNode,
+    queryId?: QueryId,
+  ): AddIndexNode {
     return requireAllProps<AddIndexNode>({
       kind: 'AddIndexNode',
-      name: this.transformNode(node.name),
-      columns: this.transformNodeList(node.columns),
+      name: this.transformNode(node.name, queryId),
+      columns: this.transformNodeList(node.columns, queryId),
       unique: node.unique,
-      using: this.transformNode(node.using),
+      using: this.transformNode(node.using, queryId),
       ifNotExists: node.ifNotExists,
     })
   }
 
-  protected transformCast(node: CastNode): CastNode {
+  protected transformCast(node: CastNode, queryId?: QueryId): CastNode {
     return requireAllProps<CastNode>({
       kind: 'CastNode',
-      expression: this.transformNode(node.expression),
-      dataType: this.transformNode(node.dataType),
+      expression: this.transformNode(node.expression, queryId),
+      dataType: this.transformNode(node.dataType, queryId),
     })
   }
 
-  protected transformFetch(node: FetchNode): FetchNode {
+  protected transformFetch(node: FetchNode, queryId?: QueryId): FetchNode {
     return requireAllProps<FetchNode>({
       kind: 'FetchNode',
-      rowCount: this.transformNode(node.rowCount),
+      rowCount: this.transformNode(node.rowCount, queryId),
       modifier: node.modifier,
     })
   }
 
-  protected transformTop(node: TopNode): TopNode {
+  protected transformTop(node: TopNode, _queryId?: QueryId): TopNode {
     return requireAllProps<TopNode>({
       kind: 'TopNode',
       expression: node.expression,
@@ -1095,58 +1258,78 @@ export class OperationNodeTransformer {
     })
   }
 
-  protected transformOutput(node: OutputNode): OutputNode {
+  protected transformOutput(node: OutputNode, queryId?: QueryId): OutputNode {
     return requireAllProps<OutputNode>({
       kind: 'OutputNode',
-      selections: this.transformNodeList(node.selections),
+      selections: this.transformNodeList(node.selections, queryId),
     })
   }
 
-  protected transformDataType(node: DataTypeNode): DataTypeNode {
+  protected transformDataType(
+    node: DataTypeNode,
+    _queryId?: QueryId,
+  ): DataTypeNode {
     // An Object.freezed leaf node. No need to clone.
     return node
   }
 
-  protected transformSelectAll(node: SelectAllNode): SelectAllNode {
+  protected transformSelectAll(
+    node: SelectAllNode,
+    _queryId?: QueryId,
+  ): SelectAllNode {
     // An Object.freezed leaf node. No need to clone.
     return node
   }
 
-  protected transformIdentifier(node: IdentifierNode): IdentifierNode {
+  protected transformIdentifier(
+    node: IdentifierNode,
+    _queryId?: QueryId,
+  ): IdentifierNode {
     // An Object.freezed leaf node. No need to clone.
     return node
   }
 
-  protected transformValue(node: ValueNode): ValueNode {
+  protected transformValue(node: ValueNode, _queryId?: QueryId): ValueNode {
     // An Object.freezed leaf node. No need to clone.
     return node
   }
 
   protected transformPrimitiveValueList(
     node: PrimitiveValueListNode,
+    _queryId?: QueryId,
   ): PrimitiveValueListNode {
     // An Object.freezed leaf node. No need to clone.
     return node
   }
 
-  protected transformOperator(node: OperatorNode): OperatorNode {
+  protected transformOperator(
+    node: OperatorNode,
+    _queryId?: QueryId,
+  ): OperatorNode {
     // An Object.freezed leaf node. No need to clone.
     return node
   }
 
   protected transformDefaultInsertValue(
     node: DefaultInsertValueNode,
+    _queryId?: QueryId,
   ): DefaultInsertValueNode {
     // An Object.freezed leaf node. No need to clone.
     return node
   }
 
-  protected transformOrAction(node: OrActionNode): OrActionNode {
+  protected transformOrAction(
+    node: OrActionNode,
+    _queryId?: QueryId,
+  ): OrActionNode {
     // An Object.freezed leaf node. No need to clone.
     return node
   }
 
-  protected transformCollate(node: CollateNode): CollateNode {
+  protected transformCollate(
+    node: CollateNode,
+    _queryId?: QueryId,
+  ): CollateNode {
     // An Object.freezed leaf node. No need to clone.
     return node
   }

--- a/src/plugin/camel-case/camel-case-plugin.ts
+++ b/src/plugin/camel-case/camel-case-plugin.ts
@@ -133,7 +133,7 @@ export class CamelCasePlugin implements KyselyPlugin {
   }
 
   transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
-    return this.#snakeCaseTransformer.transformNode(args.node)
+    return this.#snakeCaseTransformer.transformNode(args.node, args.queryId)
   }
 
   async transformResult(

--- a/src/plugin/camel-case/camel-case-transformer.ts
+++ b/src/plugin/camel-case/camel-case-transformer.ts
@@ -1,5 +1,6 @@
 import { IdentifierNode } from '../../operation-node/identifier-node.js'
 import { OperationNodeTransformer } from '../../operation-node/operation-node-transformer.js'
+import { QueryId } from '../../util/query-id.js'
 import { StringMapper } from './camel-case.js'
 
 export class SnakeCaseTransformer extends OperationNodeTransformer {
@@ -10,8 +11,11 @@ export class SnakeCaseTransformer extends OperationNodeTransformer {
     this.#snakeCase = snakeCase
   }
 
-  protected override transformIdentifier(node: IdentifierNode): IdentifierNode {
-    node = super.transformIdentifier(node)
+  protected override transformIdentifier(
+    node: IdentifierNode,
+    queryId: QueryId,
+  ): IdentifierNode {
+    node = super.transformIdentifier(node, queryId)
 
     return {
       ...node,

--- a/src/plugin/deduplicate-joins/deduplicate-joins-plugin.ts
+++ b/src/plugin/deduplicate-joins/deduplicate-joins-plugin.ts
@@ -17,7 +17,7 @@ export class DeduplicateJoinsPlugin implements KyselyPlugin {
   readonly #transformer = new DeduplicateJoinsTransformer()
 
   transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
-    return this.#transformer.transformNode(args.node)
+    return this.#transformer.transformNode(args.node, args.queryId)
   }
 
   transformResult(

--- a/src/plugin/deduplicate-joins/deduplicate-joins-transformer.ts
+++ b/src/plugin/deduplicate-joins/deduplicate-joins-transformer.ts
@@ -4,18 +4,28 @@ import { OperationNodeTransformer } from '../../operation-node/operation-node-tr
 import { SelectQueryNode } from '../../operation-node/select-query-node.js'
 import { UpdateQueryNode } from '../../operation-node/update-query-node.js'
 import { compare, freeze } from '../../util/object-utils.js'
+import { QueryId } from '../../util/query-id.js'
 
 export class DeduplicateJoinsTransformer extends OperationNodeTransformer {
-  protected transformSelectQuery(node: SelectQueryNode): SelectQueryNode {
-    return this.#transformQuery(super.transformSelectQuery(node))
+  protected transformSelectQuery(
+    node: SelectQueryNode,
+    queryId: QueryId,
+  ): SelectQueryNode {
+    return this.#transformQuery(super.transformSelectQuery(node, queryId))
   }
 
-  protected transformUpdateQuery(node: UpdateQueryNode): UpdateQueryNode {
-    return this.#transformQuery(super.transformUpdateQuery(node))
+  protected transformUpdateQuery(
+    node: UpdateQueryNode,
+    queryId: QueryId,
+  ): UpdateQueryNode {
+    return this.#transformQuery(super.transformUpdateQuery(node, queryId))
   }
 
-  protected transformDeleteQuery(node: DeleteQueryNode): DeleteQueryNode {
-    return this.#transformQuery(super.transformDeleteQuery(node))
+  protected transformDeleteQuery(
+    node: DeleteQueryNode,
+    queryId: QueryId,
+  ): DeleteQueryNode {
+    return this.#transformQuery(super.transformDeleteQuery(node, queryId))
   }
 
   #transformQuery<

--- a/src/plugin/handle-empty-in-lists/handle-empty-in-lists-plugin.ts
+++ b/src/plugin/handle-empty-in-lists/handle-empty-in-lists-plugin.ts
@@ -160,7 +160,7 @@ export class HandleEmptyInListsPlugin implements KyselyPlugin {
   }
 
   transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
-    return this.#transformer.transformNode(args.node)
+    return this.#transformer.transformNode(args.node, args.queryId)
   }
 
   async transformResult(

--- a/src/plugin/immediate-value/immediate-value-plugin.ts
+++ b/src/plugin/immediate-value/immediate-value-plugin.ts
@@ -20,7 +20,7 @@ export class ImmediateValuePlugin implements KyselyPlugin {
   readonly #transformer = new ImmediateValueTransformer()
 
   transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
-    return this.#transformer.transformNode(args.node)
+    return this.#transformer.transformNode(args.node, args.queryId)
   }
 
   transformResult(

--- a/src/plugin/immediate-value/immediate-value-transformer.ts
+++ b/src/plugin/immediate-value/immediate-value-transformer.ts
@@ -1,5 +1,6 @@
 import { OperationNodeTransformer } from '../../operation-node/operation-node-transformer.js'
 import { ValueNode } from '../../operation-node/value-node.js'
+import { QueryId } from '../../util/query-id.js'
 
 /**
  * Transforms all ValueNodes to immediate.
@@ -10,9 +11,9 @@ import { ValueNode } from '../../operation-node/value-node.js'
  * @internal
  */
 export class ImmediateValueTransformer extends OperationNodeTransformer {
-  override transformValue(node: ValueNode): ValueNode {
+  override transformValue(node: ValueNode, queryId: QueryId): ValueNode {
     return {
-      ...super.transformValue(node),
+      ...super.transformValue(node, queryId),
       immediate: true,
     }
   }

--- a/src/plugin/with-schema/with-schema-plugin.ts
+++ b/src/plugin/with-schema/with-schema-plugin.ts
@@ -16,7 +16,7 @@ export class WithSchemaPlugin implements KyselyPlugin {
   }
 
   transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
-    return this.#transformer.transformNode(args.node)
+    return this.#transformer.transformNode(args.node, args.queryId)
   }
 
   async transformResult(

--- a/src/query-builder/delete-query-builder.ts
+++ b/src/query-builder/delete-query-builder.ts
@@ -1074,12 +1074,7 @@ export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
       return result.rows as any
     }
 
-    return [
-      new DeleteResult(
-        // TODO: remove numUpdatedOrDeletedRows.
-        result.numAffectedRows ?? result.numUpdatedOrDeletedRows ?? BigInt(0),
-      ) as any,
-    ]
+    return [new DeleteResult(result.numAffectedRows ?? BigInt(0)) as any]
   }
 
   /**

--- a/src/query-builder/insert-query-builder.ts
+++ b/src/query-builder/insert-query-builder.ts
@@ -1310,8 +1310,7 @@ export class InsertQueryBuilder<DB, TB extends keyof DB, O>
     return [
       new InsertResult(
         result.insertId,
-        // TODO: remove numUpdatedOrDeletedRows.
-        result.numAffectedRows ?? result.numUpdatedOrDeletedRows,
+        result.numAffectedRows ?? BigInt(0),
       ) as any,
     ]
   }

--- a/src/query-builder/update-query-builder.ts
+++ b/src/query-builder/update-query-builder.ts
@@ -1165,9 +1165,7 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
 
     return [
       new UpdateResult(
-        // TODO: remove numUpdatedOrDeletedRows.
-        // TODO: https://github.com/kysely-org/kysely/pull/431#discussion_r1172330899
-        result.numAffectedRows ?? result.numUpdatedOrDeletedRows ?? BigInt(0),
+        result.numAffectedRows ?? BigInt(0),
         result.numChangedRows,
       ) as any,
     ]

--- a/src/query-compiler/compiled-query.ts
+++ b/src/query-compiler/compiled-query.ts
@@ -1,9 +1,11 @@
 import { RawNode } from '../operation-node/raw-node.js'
 import { freeze } from '../util/object-utils.js'
+import { createQueryId, QueryId } from '../util/query-id.js'
 import { RootOperationNode } from './query-compiler.js'
 
 export interface CompiledQuery<O = unknown> {
   readonly query: RootOperationNode
+  readonly queryId: QueryId
   readonly sql: string
   readonly parameters: ReadonlyArray<unknown>
 }
@@ -14,6 +16,7 @@ export const CompiledQuery = freeze({
       sql,
       query: RawNode.createWithSql(sql),
       parameters: freeze(parameters),
+      queryId: createQueryId(),
     })
   },
 })

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -115,6 +115,7 @@ import { RefreshMaterializedViewNode } from '../operation-node/refresh-materiali
 import { OrActionNode } from '../operation-node/or-action-node.js'
 import { logOnce } from '../util/log-once.js'
 import { CollateNode } from '../operation-node/collate-node.js'
+import { QueryId } from '../util/query-id.js'
 
 export class DefaultQueryCompiler
   extends OperationNodeVisitor
@@ -127,7 +128,7 @@ export class DefaultQueryCompiler
     return this.#parameters.length
   }
 
-  compileQuery(node: RootOperationNode): CompiledQuery {
+  compileQuery(node: RootOperationNode, queryId: QueryId): CompiledQuery {
     this.#sql = ''
     this.#parameters = []
     this.nodeStack.splice(0, this.nodeStack.length)
@@ -136,6 +137,7 @@ export class DefaultQueryCompiler
 
     return freeze({
       query: node,
+      queryId,
       sql: this.getSql(),
       parameters: [...this.#parameters],
     })

--- a/src/query-compiler/query-compiler.ts
+++ b/src/query-compiler/query-compiler.ts
@@ -13,6 +13,7 @@ import { MergeQueryNode } from '../operation-node/merge-query-node.js'
 import { QueryNode } from '../operation-node/query-node.js'
 import { RawNode } from '../operation-node/raw-node.js'
 import { RefreshMaterializedViewNode } from '../operation-node/refresh-materialized-view-node.js'
+import { QueryId } from '../util/query-id.js'
 import { CompiledQuery } from './compiled-query.js'
 
 export type RootOperationNode =
@@ -36,5 +37,5 @@ export type RootOperationNode =
  * a `QueryCompiler` compiles a query expressed as a tree of `OperationNodes` into SQL.
  */
 export interface QueryCompiler {
-  compileQuery(node: RootOperationNode): CompiledQuery
+  compileQuery(node: RootOperationNode, queryId: QueryId): CompiledQuery
 }

--- a/src/query-executor/default-query-executor.ts
+++ b/src/query-executor/default-query-executor.ts
@@ -8,6 +8,7 @@ import {
 import { KyselyPlugin } from '../plugin/kysely-plugin.js'
 import { QueryExecutorBase } from './query-executor-base.js'
 import { DialectAdapter } from '../dialect/dialect-adapter.js'
+import { QueryId } from '../util/query-id.js'
 
 export class DefaultQueryExecutor extends QueryExecutorBase {
   #compiler: QueryCompiler
@@ -31,8 +32,8 @@ export class DefaultQueryExecutor extends QueryExecutorBase {
     return this.#adapter
   }
 
-  compileQuery(node: RootOperationNode): CompiledQuery {
-    return this.#compiler.compileQuery(node)
+  compileQuery(node: RootOperationNode, queryId: QueryId): CompiledQuery {
+    return this.#compiler.compileQuery(node, queryId)
   }
 
   provideConnection<T>(

--- a/src/query-executor/query-executor-base.ts
+++ b/src/query-executor/query-executor-base.ts
@@ -11,6 +11,7 @@ import { QueryId } from '../util/query-id.js'
 import { DialectAdapter } from '../dialect/dialect-adapter.js'
 import { QueryExecutor } from './query-executor.js'
 import { provideControlledConnection } from '../util/provide-controlled-connection.js'
+import { logOnce } from '../util/log-once.js'
 
 const NO_PLUGINS: ReadonlyArray<KyselyPlugin> = freeze([])
 
@@ -65,6 +66,12 @@ export abstract class QueryExecutorBase implements QueryExecutor {
   ): Promise<QueryResult<R>> {
     return await this.provideConnection(async (connection) => {
       const result = await connection.executeQuery(compiledQuery)
+
+      if ('numUpdatedOrDeletedRows' in result) {
+        logOnce(
+          'kysely:warning: outdated driver/plugin detected! `QueryResult.numUpdatedOrDeletedRows` has been replaced with `QueryResult.numAffectedRows`.',
+        )
+      }
 
       return await this.#transformResult(result, queryId)
     })

--- a/src/query-executor/query-executor-base.ts
+++ b/src/query-executor/query-executor-base.ts
@@ -10,8 +10,6 @@ import { freeze } from '../util/object-utils.js'
 import { QueryId } from '../util/query-id.js'
 import { DialectAdapter } from '../dialect/dialect-adapter.js'
 import { QueryExecutor } from './query-executor.js'
-import { Deferred } from '../util/deferred.js'
-import { logOnce } from '../util/log-once.js'
 import { provideControlledConnection } from '../util/provide-controlled-connection.js'
 
 const NO_PLUGINS: ReadonlyArray<KyselyPlugin> = freeze([])
@@ -67,12 +65,8 @@ export abstract class QueryExecutorBase implements QueryExecutor {
   ): Promise<QueryResult<R>> {
     return await this.provideConnection(async (connection) => {
       const result = await connection.executeQuery(compiledQuery)
-      const transformedResult = await this.#transformResult(result, queryId)
 
-      // TODO: remove.
-      warnOfOutdatedDriverOrPlugins(result, transformedResult)
-
-      return transformedResult as any
+      return await this.#transformResult(result, queryId)
     })
   }
 
@@ -114,25 +108,4 @@ export abstract class QueryExecutorBase implements QueryExecutor {
 
     return result
   }
-}
-
-// TODO: remove.
-function warnOfOutdatedDriverOrPlugins(
-  result: QueryResult<unknown>,
-  transformedResult: QueryResult<unknown>,
-): void {
-  const { numAffectedRows } = result
-
-  if (
-    (numAffectedRows === undefined &&
-      result.numUpdatedOrDeletedRows === undefined) ||
-    (numAffectedRows !== undefined &&
-      transformedResult.numAffectedRows !== undefined)
-  ) {
-    return
-  }
-
-  logOnce(
-    'kysely:warning: outdated driver/plugin detected! QueryResult.numUpdatedOrDeletedRows is deprecated and will be removed in a future release.',
-  )
 }

--- a/src/schema/create-index-builder.ts
+++ b/src/schema/create-index-builder.ts
@@ -270,7 +270,10 @@ export class CreateIndexBuilder<C = never>
       ...this.#props,
       node: QueryNode.cloneWithWhere(
         this.#props.node,
-        transformer.transformNode(parseValueBinaryOperationOrExpression(args)),
+        transformer.transformNode(
+          parseValueBinaryOperationOrExpression(args),
+          this.#props.queryId,
+        ),
       ),
     })
   }

--- a/test/node/src/query-id.test.ts
+++ b/test/node/src/query-id.test.ts
@@ -1,0 +1,75 @@
+import { expect } from 'chai'
+import {
+  DatabaseConnection,
+  DummyDriver,
+  Kysely,
+  PostgresAdapter,
+  PostgresIntrospector,
+  PostgresQueryCompiler,
+  RootOperationNode,
+  QueryId,
+} from '../../..'
+import { Database } from './test-setup'
+
+describe('queryId', () => {
+  const visits = new Map()
+
+  const db = new Kysely<Database>({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () =>
+        new (class extends DummyDriver {
+          async acquireConnection(): Promise<DatabaseConnection> {
+            // @ts-ignore
+            return {
+              executeQuery: async ({ queryId }) => {
+                checkIn(queryId, 'connection.executeQuery')
+
+                return {
+                  rows: [],
+                }
+              },
+            }
+          }
+        })(),
+      createIntrospector: (db) => new PostgresIntrospector(db),
+      createQueryCompiler: () =>
+        new (class SomeCompiler extends PostgresQueryCompiler {
+          compileQuery(node: RootOperationNode, queryId: QueryId) {
+            checkIn(queryId, 'compiler.compileQuery')
+
+            return super.compileQuery(node, queryId)
+          }
+        })(),
+    },
+    plugins: [
+      {
+        transformQuery: (args) => {
+          checkIn(args.queryId, 'plugin.transformQuery')
+
+          return args.node
+        },
+        transformResult: async (args) => {
+          checkIn(args.queryId, 'plugin.transformResult')
+
+          return args.result
+        },
+      },
+    ],
+  })
+
+  it('should pass query id around, allowing async communication between compilers, plugins and connections', async () => {
+    await db.selectFrom('person').where('id', '=', 1).execute()
+
+    expect(Array.from(visits.values())[0]).to.deep.equal([
+      'plugin.transformQuery',
+      'compiler.compileQuery',
+      'connection.executeQuery',
+      'plugin.transformResult',
+    ])
+  })
+
+  function checkIn(queryId: QueryId, place: string): void {
+    visits.set(queryId, [...(visits.get(queryId) || []), place])
+  }
+})

--- a/test/node/src/raw-sql.test.ts
+++ b/test/node/src/raw-sql.test.ts
@@ -1,4 +1,9 @@
-import { sql, CompiledQuery, DefaultQueryCompiler } from '../../../'
+import {
+  sql,
+  CompiledQuery,
+  DefaultQueryCompiler,
+  createQueryId,
+} from '../../../'
 
 import {
   clearDatabase,
@@ -66,7 +71,7 @@ for (const dialect of DIALECTS) {
       let node = sql`before ${ctx.db
         .selectFrom('person')
         .selectAll()} after`.toOperationNode()
-      expect(compiler.compileQuery(node).sql).to.equal(
+      expect(compiler.compileQuery(node, createQueryId()).sql).to.equal(
         `before (select * from "person") after`,
       )
 
@@ -75,21 +80,21 @@ for (const dialect of DIALECTS) {
         last_name: 'Aniston',
         gender: 'female',
       })} after`.toOperationNode()
-      expect(compiler.compileQuery(node).sql).to.equal(
+      expect(compiler.compileQuery(node, createQueryId()).sql).to.equal(
         `before insert into "person" ("first_name", "last_name", "gender") values ($1, $2, $3) after`,
       )
 
       node = sql`before ${ctx.db
         .deleteFrom('person')
         .where('id', '=', 1)} after`.toOperationNode()
-      expect(compiler.compileQuery(node).sql).to.equal(
+      expect(compiler.compileQuery(node, createQueryId()).sql).to.equal(
         `before delete from "person" where "id" = $1 after`,
       )
 
       node = sql`before ${ctx.db
         .updateTable('person')
         .set('first_name', 'Jennifer')} after`.toOperationNode()
-      expect(compiler.compileQuery(node).sql).to.equal(
+      expect(compiler.compileQuery(node, createQueryId()).sql).to.equal(
         `before update "person" set "first_name" = $1 after`,
       )
     })

--- a/test/node/src/test-setup.ts
+++ b/test/node/src/test-setup.ts
@@ -35,6 +35,7 @@ import {
   InsertObject,
   MssqlDialect,
   SelectQueryBuilder,
+  QueryId,
 } from '../../../'
 import {
   OrderByDirection,
@@ -479,7 +480,7 @@ function createNoopTransformerPlugin(): KyselyPlugin {
 
   return {
     transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
-      return transformer.transformNode(args.node)
+      return transformer.transformNode(args.node, args.queryId)
     },
 
     async transformResult(


### PR DESCRIPTION
does what #173 tried to achieve, but in a simpler way as suggested by @koskimas.

- adds `queryId` to `CompileQuery` - now `DatabaseConnection` has access to it in `executeQuery` and `streamQuery` methods in a non-breaking way.
- adds `queryId` as a 2nd optional (for now) argument in all `transform` methods. Now plugins can enjoy even more flexibility - not just in root `transformQuery` and `transformResults` methods.
- exposes `createQueryId` to ease dialect/plugin implementation by 3rd parties.
- also removes `numUpdatedOrDeletedRows` usage as it has been deprecated for 2 years now.