### PR TITLE
Fix playground iframe of site.

### DIFF
--- a/site/src/components/Playground.tsx
+++ b/site/src/components/Playground.tsx
@@ -20,6 +20,7 @@ export function Playground({
         borderRadius: 8,
         background: gray.gray12,
       }}
+      allow="clipboard-write"
       src={`https://wirekang.github.io/kysely-playground/?${params.toString()}`}
     />
   )

--- a/site/src/components/Playground.tsx
+++ b/site/src/components/Playground.tsx
@@ -3,7 +3,7 @@ import { gray } from '@radix-ui/colors'
 
 export function Playground({
   ts,
-  kyselyVersion = '0.23.3',
+  kyselyVersion = '0.23.5',
   dialect = 'postgres',
 }: PlaygroundProps) {
   const params = new URLSearchParams()
@@ -27,7 +27,7 @@ export function Playground({
 }
 
 interface PlaygroundProps {
-  kyselyVersion?: '0.23.3'
+  kyselyVersion?: '0.23.5'
   dialect?: 'postgres'
   ts: string
 }


### PR DESCRIPTION
## Minor changes
Pass `allow="clipboard-write" to playground iframe to solve the permission error:
![image](https://user-images.githubusercontent.com/43294688/227838990-88faaa57-a486-47de-a845-e8d12a2aa936.png)


Default kysely version: 0.23.3 -> 0.23.5