### PR TITLE
feat: add algolia search

### DIFF
--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -68,6 +68,15 @@ const config = {
         disableSwitch: true,
         respectPrefersColorScheme: false,
       },
+
+      algolia: {
+        appId: 'MDKJWTIJFR',
+        // Public API key, safe to expose. See https://docusaurus.io/docs/search#using-algolia-docsearch
+        apiKey: 'ebee59ab1b71803be5983f6dbfeea352',
+        indexName: 'kysely',
+        contextualSearch: true,
+      },
+
       docs: {
         sidebar: { hideable: true, autoCollapseCategories: true },
       },


### PR DESCRIPTION
Adds algolia search using the recommended docusaurus defaults. See https://docusaurus.io/docs/search#using-algolia-docsearch for more information.