### PR TITLE
optional `constraintName` in CreateTableBuilder/AlterTableBuilder methods

### DIFF
--- a/src/schema/alter-table-builder.ts
+++ b/src/schema/alter-table-builder.ts
@@ -155,10 +155,16 @@ export class AlterTableBuilder implements ColumnAlteringInterface {
   /**
    * See {@link CreateTableBuilder.addUniqueConstraint}
    */
+  addUniqueConstraint(columns: string[]): AlterTableExecutor
   addUniqueConstraint(
     constraintName: string,
     columns: string[]
+  ): AlterTableExecutor
+  addUniqueConstraint(
+    ...args: [string[]] | [string, string[]]
   ): AlterTableExecutor {
+    const constraintName = args.length === 1 ? undefined : args[0]
+    const columns = args.length === 1 ? args[0] : args[1]
     return new AlterTableExecutor({
       ...this.#props,
       node: AlterTableNode.cloneWithTableProps(this.#props.node, {
@@ -173,9 +179,17 @@ export class AlterTableBuilder implements ColumnAlteringInterface {
    * See {@link CreateTableBuilder.addCheckConstraint}
    */
   addCheckConstraint(
+    checkExpression: Expression<any>
+  ): AlterTableExecutor
+  addCheckConstraint(
     constraintName: string,
     checkExpression: Expression<any>
+  ): AlterTableExecutor
+  addCheckConstraint(
+    ...args: [string, Expression<any>] | [Expression<any>]
   ): AlterTableExecutor {
+    const constraintName = args.length === 1 ? undefined : args[0]
+    const checkExpression = args.length === 1 ? args[0] : args[1]
     return new AlterTableExecutor({
       ...this.#props,
       node: AlterTableNode.cloneWithTableProps(this.#props.node, {
@@ -201,7 +215,19 @@ export class AlterTableBuilder implements ColumnAlteringInterface {
     columns: string[],
     targetTable: string,
     targetColumns: string[]
+  ): AlterTableAddForeignKeyConstraintBuilder
+  addForeignKeyConstraint(
+    columns: string[],
+    targetTable: string,
+    targetColumns: string[]
+  ): AlterTableAddForeignKeyConstraintBuilder
+  addForeignKeyConstraint(
+    ...args: [string, string[], string, string[]] | [string[], string, string[]]
   ): AlterTableAddForeignKeyConstraintBuilder {
+    const constraintName = args.length === 4 ? args[0] : undefined
+    const columns = args.length === 4 ? args[1] : args[0]
+    const targetTable = args.length === 4 ? args[2] : args[1]
+    const targetColumns = args.length === 4 ? args[3] : args[2]
     return new AlterTableAddForeignKeyConstraintBuilder({
       ...this.#props,
       constraintBuilder: new ForeignKeyConstraintBuilder(

--- a/src/schema/create-table-builder.ts
+++ b/src/schema/create-table-builder.ts
@@ -161,10 +161,16 @@ export class CreateTableBuilder<TB extends string, C extends string = never>
    * addPrimaryKeyConstraint('primary_key', ['first_name', 'last_name'])
    * ```
    */
+  addPrimaryKeyConstraint(columns: C[]): CreateTableBuilder<TB, C>
   addPrimaryKeyConstraint(
     constraintName: string,
     columns: C[]
+  ): CreateTableBuilder<TB, C>
+  addPrimaryKeyConstraint(
+    ...args: [C[]] | [string, C[]]
   ): CreateTableBuilder<TB, C> {
+    const constraintName = args.length === 1 ? undefined : args[0]
+    const columns = args.length === 1 ? args[0] : args[1]
     return new CreateTableBuilder({
       ...this.#props,
       node: CreateTableNode.cloneWithConstraint(
@@ -186,10 +192,16 @@ export class CreateTableBuilder<TB extends string, C extends string = never>
    * addUniqueConstraint('first_name_last_name_unique', ['first_name', 'last_name'])
    * ```
    */
+  addUniqueConstraint(columns: C[]): CreateTableBuilder<TB, C>
   addUniqueConstraint(
     constraintName: string,
     columns: C[]
+  ): CreateTableBuilder<TB, C>
+  addUniqueConstraint(
+    ...args: [C[]] | [string, C[]]
   ): CreateTableBuilder<TB, C> {
+    const constraintName = args.length === 1 ? undefined : args[0]
+    const columns = args.length === 1 ? args[0] : args[1]
     return new CreateTableBuilder({
       ...this.#props,
       node: CreateTableNode.cloneWithConstraint(
@@ -214,9 +226,17 @@ export class CreateTableBuilder<TB extends string, C extends string = never>
    * ```
    */
   addCheckConstraint(
+    checkExpression: Expression<any>
+  ): CreateTableBuilder<TB, C>
+  addCheckConstraint(
     constraintName: string,
     checkExpression: Expression<any>
+  ): CreateTableBuilder<TB, C>
+  addCheckConstraint(
+    ...args: [Expression<any>] | [string, Expression<any>]
   ): CreateTableBuilder<TB, C> {
+    const constraintName = args.length === 1 ? undefined : args[0]
+    const checkExpression = args.length === 1 ? args[0] : args[1]
     return new CreateTableBuilder({
       ...this.#props,
       node: CreateTableNode.cloneWithConstraint(
@@ -263,8 +283,22 @@ export class CreateTableBuilder<TB extends string, C extends string = never>
     columns: C[],
     targetTable: string,
     targetColumns: string[],
-    build: ForeignKeyConstraintBuilderCallback = noop
-  ): CreateTableBuilder<TB, C> {
+    build?: ForeignKeyConstraintBuilderCallback
+  ): CreateTableBuilder<TB, C>
+  addForeignKeyConstraint(
+    columns: C[],
+    targetTable: string,
+    targetColumns: string[],
+    build?: ForeignKeyConstraintBuilderCallback
+  ): CreateTableBuilder<TB, C>
+  addForeignKeyConstraint(...args: any[]): CreateTableBuilder<TB, C> {
+    const constraintName = typeof args[0] === 'string' ? args[0] : undefined
+    const columns: C[] = typeof args[0] === 'string' ? args[1] : args[0]
+    const targetTable: string = typeof args[0] === 'string' ? args[2] : args[1]
+    const targetColumns: string[] =
+      typeof args[0] === 'string' ? args[3] : args[2]
+    const build: ForeignKeyConstraintBuilderCallback =
+      (typeof args[0] === 'string' ? args[4] : args[3]) ?? noop
     const builder = build(
       new ForeignKeyConstraintBuilder(
         ForeignKeyConstraintNode.create(

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -330,18 +330,19 @@ for (const dialect of DIALECTS) {
           .addColumn('c', 'varchar(255)')
           .addUniqueConstraint('a_b_unique', ['a', 'b'])
           .addUniqueConstraint('b_c_unique', ['b', 'c'])
+          .addUniqueConstraint(['a', 'c'])
 
         testSql(builder, dialect, {
           postgres: {
-            sql: 'create table "test" ("a" varchar(255), "b" varchar(255), "c" varchar(255), constraint "a_b_unique" unique ("a", "b"), constraint "b_c_unique" unique ("b", "c"))',
+            sql: 'create table "test" ("a" varchar(255), "b" varchar(255), "c" varchar(255), constraint "a_b_unique" unique ("a", "b"), constraint "b_c_unique" unique ("b", "c"), unique ("a", "c"))',
             parameters: [],
           },
           mysql: {
-            sql: 'create table `test` (`a` varchar(255), `b` varchar(255), `c` varchar(255), constraint `a_b_unique` unique (`a`, `b`), constraint `b_c_unique` unique (`b`, `c`))',
+            sql: 'create table `test` (`a` varchar(255), `b` varchar(255), `c` varchar(255), constraint `a_b_unique` unique (`a`, `b`), constraint `b_c_unique` unique (`b`, `c`), unique (`a`, `c`))',
             parameters: [],
           },
           sqlite: {
-            sql: 'create table "test" ("a" varchar(255), "b" varchar(255), "c" varchar(255), constraint "a_b_unique" unique ("a", "b"), constraint "b_c_unique" unique ("b", "c"))',
+            sql: 'create table "test" ("a" varchar(255), "b" varchar(255), "c" varchar(255), constraint "a_b_unique" unique ("a", "b"), constraint "b_c_unique" unique ("b", "c"), unique ("a", "c"))',
             parameters: [],
           },
         })
@@ -357,18 +358,19 @@ for (const dialect of DIALECTS) {
           .addColumn('c', 'integer')
           .addCheckConstraint('check_a', sql`a > 1`)
           .addCheckConstraint('check_b', sql`b < c`)
+          .addCheckConstraint(sql`a < c`)
 
         testSql(builder, dialect, {
           postgres: {
-            sql: 'create table "test" ("a" integer, "b" integer, "c" integer, constraint "check_a" check (a > 1), constraint "check_b" check (b < c))',
+            sql: 'create table "test" ("a" integer, "b" integer, "c" integer, constraint "check_a" check (a > 1), constraint "check_b" check (b < c), check (a < c))',
             parameters: [],
           },
           mysql: {
-            sql: 'create table `test` (`a` integer, `b` integer, `c` integer, constraint `check_a` check (a > 1), constraint `check_b` check (b < c))',
+            sql: 'create table `test` (`a` integer, `b` integer, `c` integer, constraint `check_a` check (a > 1), constraint `check_b` check (b < c), check (a < c))',
             parameters: [],
           },
           sqlite: {
-            sql: 'create table "test" ("a" integer, "b" integer, "c" integer, constraint "check_a" check (a > 1), constraint "check_b" check (b < c))',
+            sql: 'create table "test" ("a" integer, "b" integer, "c" integer, constraint "check_a" check (a > 1), constraint "check_b" check (b < c), check (a < c))',
             parameters: [],
           },
         })
@@ -417,18 +419,19 @@ for (const dialect of DIALECTS) {
             'c',
             'd',
           ])
+          .addForeignKeyConstraint(['a', 'b'], 'test2', ['c', 'd'])
 
         testSql(builder, dialect, {
           postgres: {
-            sql: 'create table "test" ("a" integer, "b" integer, constraint "foreign_key" foreign key ("a", "b") references "test2" ("c", "d"))',
+            sql: 'create table "test" ("a" integer, "b" integer, constraint "foreign_key" foreign key ("a", "b") references "test2" ("c", "d"), foreign key ("a", "b") references "test2" ("c", "d"))',
             parameters: [],
           },
           mysql: {
-            sql: 'create table `test` (`a` integer, `b` integer, constraint `foreign_key` foreign key (`a`, `b`) references `test2` (`c`, `d`))',
+            sql: 'create table `test` (`a` integer, `b` integer, constraint `foreign_key` foreign key (`a`, `b`) references `test2` (`c`, `d`), foreign key (`a`, `b`) references `test2` (`c`, `d`))',
             parameters: [],
           },
           sqlite: {
-            sql: 'create table "test" ("a" integer, "b" integer, constraint "foreign_key" foreign key ("a", "b") references "test2" ("c", "d"))',
+            sql: 'create table "test" ("a" integer, "b" integer, constraint "foreign_key" foreign key ("a", "b") references "test2" ("c", "d"), foreign key ("a", "b") references "test2" ("c", "d"))',
             parameters: [],
           },
         })
@@ -455,10 +458,11 @@ for (const dialect of DIALECTS) {
               'public.test2',
               ['c', 'd']
             )
+            .addForeignKeyConstraint(['a', 'b'], 'public.test2', ['c', 'd'])
 
           testSql(builder, dialect, {
             postgres: {
-              sql: 'create table "test" ("a" integer, "b" integer, constraint "foreign_key" foreign key ("a", "b") references "public"."test2" ("c", "d"))',
+              sql: 'create table "test" ("a" integer, "b" integer, constraint "foreign_key" foreign key ("a", "b") references "public"."test2" ("c", "d"), foreign key ("a", "b") references "public"."test2" ("c", "d"))',
               parameters: [],
             },
             mysql: NOT_SUPPORTED,
@@ -488,18 +492,24 @@ for (const dialect of DIALECTS) {
             ['c', 'd'],
             (cb) => cb.onUpdate('cascade')
           )
+          .addForeignKeyConstraint(
+            ['a', 'b'],
+            'test2',
+            ['c', 'd'],
+            (cb) => cb.onUpdate('cascade')
+          )
 
         testSql(builder, dialect, {
           postgres: {
-            sql: 'create table "test" ("a" integer, "b" integer, constraint "foreign_key" foreign key ("a", "b") references "test2" ("c", "d") on update cascade)',
+            sql: 'create table "test" ("a" integer, "b" integer, constraint "foreign_key" foreign key ("a", "b") references "test2" ("c", "d") on update cascade, foreign key ("a", "b") references "test2" ("c", "d") on update cascade)',
             parameters: [],
           },
           mysql: {
-            sql: 'create table `test` (`a` integer, `b` integer, constraint `foreign_key` foreign key (`a`, `b`) references `test2` (`c`, `d`) on update cascade)',
+            sql: 'create table `test` (`a` integer, `b` integer, constraint `foreign_key` foreign key (`a`, `b`) references `test2` (`c`, `d`) on update cascade, foreign key (`a`, `b`) references `test2` (`c`, `d`) on update cascade)',
             parameters: [],
           },
           sqlite: {
-            sql: 'create table "test" ("a" integer, "b" integer, constraint "foreign_key" foreign key ("a", "b") references "test2" ("c", "d") on update cascade)',
+            sql: 'create table "test" ("a" integer, "b" integer, constraint "foreign_key" foreign key ("a", "b") references "test2" ("c", "d") on update cascade, foreign key ("a", "b") references "test2" ("c", "d") on update cascade)',
             parameters: [],
           },
         })
@@ -2302,6 +2312,40 @@ for (const dialect of DIALECTS) {
               },
               sqlite: {
                 sql: 'alter table "test" add constraint "some_constraint" foreign key ("integer_col", "varchar_col") references "test2" ("a", "b")',
+                parameters: [],
+              },
+            })
+
+            await builder.execute()
+          })
+
+          it('should add an unnamed foreign key constraint', async () => {
+            await ctx.db.schema
+              .createTable('test2')
+              .addColumn('a', 'integer')
+              .addColumn('b', 'varchar(255)')
+              .addUniqueConstraint('unique_a_b', ['a', 'b'])
+              .execute()
+
+            const builder = ctx.db.schema
+              .alterTable('test')
+              .addForeignKeyConstraint(
+                ['integer_col', 'varchar_col'],
+                'test2',
+                ['a', 'b']
+              )
+
+            testSql(builder, dialect, {
+              postgres: {
+                sql: 'alter table "test" add foreign key ("integer_col", "varchar_col") references "test2" ("a", "b")',
+                parameters: [],
+              },
+              mysql: {
+                sql: 'alter table `test` add foreign key (`integer_col`, `varchar_col`) references `test2` (`a`, `b`)',
+                parameters: [],
+              },
+              sqlite: {
+                sql: 'alter table "test" add foreign key ("integer_col", "varchar_col") references "test2" ("a", "b")',
                 parameters: [],
               },
             })


### PR DESCRIPTION
It is anyway optional in `*ConstraintNode` constructors, so I'd not need to pass an ambiguous empty string in case I want Postgres to automatically name a constraint for me:

```sql
create table "tbl" (
  "id" bigint not null,
  unique ("id")
)
```