### PR TITLE
feat: support `char` datatype

### DIFF
--- a/src/operation-node/data-type-node.ts
+++ b/src/operation-node/data-type-node.ts
@@ -4,6 +4,7 @@ import { OperationNode } from './operation-node.js'
 export type ColumnDataType =
   | 'varchar'
   | `varchar(${number})`
+  | `char(${number})`
   | 'text'
   | 'integer'
   | 'int2'

--- a/src/operation-node/data-type-node.ts
+++ b/src/operation-node/data-type-node.ts
@@ -4,6 +4,7 @@ import { OperationNode } from './operation-node.js'
 export type ColumnDataType =
   | 'varchar'
   | `varchar(${number})`
+  | 'char'
   | `char(${number})`
   | 'text'
   | 'integer'

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -71,6 +71,7 @@ for (const dialect of DIALECTS) {
               col.notNull().defaultTo(sql`current_timestamp`)
             )
             .addColumn('v', 'timestamptz(6)')
+            .addColumn('w', 'char(4)')
 
           testSql(builder, dialect, {
             postgres: {
@@ -97,7 +98,8 @@ for (const dialect of DIALECTS) {
                 '"s" double precision generated always as (f + g) stored not null,',
                 '"t" time(6),',
                 '"u" timestamp(6) default current_timestamp not null,',
-                '"v" timestamptz(6))',
+                '"v" timestamptz(6),',
+                '"w" char(4))',
               ],
               parameters: [],
             },
@@ -170,6 +172,7 @@ for (const dialect of DIALECTS) {
             .addColumn('s', 'timestamp(6)', (col) =>
               col.notNull().defaultTo(sql`current_timestamp(6)`)
             )
+            .addColumn('t', 'char(4)')
 
           testSql(builder, dialect, {
             mysql: {
@@ -193,7 +196,8 @@ for (const dialect of DIALECTS) {
                 '`p` double precision generated always as (e + f) stored not null,',
                 '`q` time(6),',
                 '`r` datetime(6),',
-                '`s` timestamp(6) default current_timestamp(6) not null)',
+                '`s` timestamp(6) default current_timestamp(6) not null,',
+                '`t` char(4))',
               ],
               parameters: [],
             },

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -72,6 +72,7 @@ for (const dialect of DIALECTS) {
             )
             .addColumn('v', 'timestamptz(6)')
             .addColumn('w', 'char(4)')
+            .addColumn('x', 'char')
 
           testSql(builder, dialect, {
             postgres: {
@@ -99,7 +100,8 @@ for (const dialect of DIALECTS) {
                 '"t" time(6),',
                 '"u" timestamp(6) default current_timestamp not null,',
                 '"v" timestamptz(6),',
-                '"w" char(4))',
+                '"w" char(4),',
+                '"x" char)'
               ],
               parameters: [],
             },
@@ -173,6 +175,7 @@ for (const dialect of DIALECTS) {
               col.notNull().defaultTo(sql`current_timestamp(6)`)
             )
             .addColumn('t', 'char(4)')
+            .addColumn('u', 'char')
 
           testSql(builder, dialect, {
             mysql: {
@@ -197,7 +200,8 @@ for (const dialect of DIALECTS) {
                 '`q` time(6),',
                 '`r` datetime(6),',
                 '`s` timestamp(6) default current_timestamp(6) not null,',
-                '`t` char(4))',
+                '`t` char(4),',
+                '`u` char)'
               ],
               parameters: [],
             },


### PR DESCRIPTION
closes #339 

### CONTEXT
This PR adds support for `char` datatype for -
- mysql
- postgresql

### Implementation
To achieve that we've added the `char` type to `ColumnDataType` type. This will allow consumers to use type `char`.
- Existing test have been updated to test the functionality.