### PR TITLE
add `agg` method @ `FunctionModule` to allow `AggregateFunctionBuilder` usage outside of built-ins.

### DIFF
--- a/src/operation-node/aggregate-function-node.ts
+++ b/src/operation-node/aggregate-function-node.ts
@@ -1,17 +1,12 @@
 import { freeze } from '../util/object-utils.js'
 import { OperationNode } from './operation-node.js'
 import { OverNode } from './over-node.js'
-import { SelectAllNode } from './select-all-node.js'
-import { SelectionNode } from './selection-node.js'
-import { SimpleReferenceExpressionNode } from './simple-reference-expression-node.js'
 import { WhereNode } from './where-node.js'
-
-type AggregateFunction = 'avg' | 'count' | 'max' | 'min' | 'sum'
 
 export interface AggregateFunctionNode extends OperationNode {
   readonly kind: 'AggregateFunctionNode'
-  readonly func: AggregateFunction
-  readonly aggregated: SimpleReferenceExpressionNode | SelectionNode
+  readonly func: string
+  readonly aggregated: readonly OperationNode[]
   readonly distinct?: boolean
   readonly filter?: WhereNode
   readonly over?: OverNode
@@ -26,8 +21,8 @@ export const AggregateFunctionNode = freeze({
   },
 
   create(
-    aggregateFunction: AggregateFunction,
-    aggregated: SimpleReferenceExpressionNode | SelectionNode
+    aggregateFunction: string,
+    aggregated: readonly OperationNode[] = []
   ): AggregateFunctionNode {
     return freeze({
       kind: 'AggregateFunctionNode',

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -834,7 +834,7 @@ export class OperationNodeTransformer {
   ): AggregateFunctionNode {
     return requireAllProps({
       kind: 'AggregateFunctionNode',
-      aggregated: this.transformNode(node.aggregated),
+      aggregated: this.transformNodeList(node.aggregated),
       distinct: node.distinct,
       filter: this.transformNode(node.filter),
       func: node.func,

--- a/src/query-builder/function-module.ts
+++ b/src/query-builder/function-module.ts
@@ -52,6 +52,8 @@ export interface FunctionModule<DB, TB extends keyof DB> {
   /**
    * Creates a function call.
    *
+   * To create an aggregate function call, use {@link FunctionModule.agg}.
+   *
    * ### Examples
    *
    * ```ts
@@ -81,6 +83,34 @@ export interface FunctionModule<DB, TB extends keyof DB> {
     args: ReadonlyArray<ReferenceExpression<DB, TB>>
   ): ExpressionWrapper<T>
 
+  /**
+   * Creates an aggregate function call.
+   *
+   * This is a specialized version of the `fn` method, that returns an {@link AggregateFunctionBuilder}
+   * instance. A builder that allows you to chain additional methods such as `distinct`,
+   * `filterWhere` and `over`.
+   *
+   * See {@link avg}, {@link count}, {@link countAll}, {@link max}, {@link min}, {@link sum}
+   * shortcuts of common aggregate functions.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * db.selectFrom('person')
+   *   .select(({ fn }) => [
+   *     fn.agg('rank').over().as('rank'),
+   *     fn.agg('group_concat', ['first_name']).distinct().as('first_names')
+   *   ])
+   * ```
+   *
+   * The generated SQL (MySQL):
+   *
+   * ```sql
+   * select rank() over() as "rank",
+   *   group_concat(distinct "first_name") as "first_names"
+   * from "person"
+   * ```
+   */
   agg<O>(
     name: string,
     args?: ReadonlyArray<ReferenceExpression<DB, TB>>

--- a/src/query-builder/function-module.ts
+++ b/src/query-builder/function-module.ts
@@ -1,5 +1,6 @@
 import { DynamicReferenceBuilder } from '../dynamic/dynamic-reference-builder.js'
 import { ExpressionWrapper } from '../expression/expression-wrapper.js'
+import { Expression } from '../expression/expression.js'
 import { AggregateFunctionNode } from '../operation-node/aggregate-function-node.js'
 import { FunctionNode } from '../operation-node/function-node.js'
 import { CoalesceReferenceExpressionList } from '../parser/coalesce-parser.js'
@@ -79,6 +80,11 @@ export interface FunctionModule<DB, TB extends keyof DB> {
     name: string,
     args: ReadonlyArray<ReferenceExpression<DB, TB>>
   ): ExpressionWrapper<T>
+
+  agg<O>(
+    name: string,
+    args?: ReadonlyArray<ReferenceExpression<DB, TB>>
+  ): AggregateFunctionBuilder<DB, TB, O>
 
   /**
    * Calls the `avg` function for the column given as the argument.
@@ -586,6 +592,18 @@ export function createFunctionModule<DB, TB extends keyof DB>(): FunctionModule<
   }
 
   return Object.assign(fn, {
+    agg<O>(
+      name: string,
+      args?: ReadonlyArray<ReferenceExpression<DB, TB>>
+    ): AggregateFunctionBuilder<DB, TB, O> {
+      return new AggregateFunctionBuilder({
+        aggregateFunctionNode: AggregateFunctionNode.create(
+          name,
+          args ? parseReferenceExpressionOrList(args) : undefined
+        ),
+      })
+    },
+
     avg<
       O extends number | string | null = number | string,
       C extends SimpleReferenceExpression<DB, TB> = SimpleReferenceExpression<

--- a/src/query-builder/function-module.ts
+++ b/src/query-builder/function-module.ts
@@ -98,8 +98,8 @@ export interface FunctionModule<DB, TB extends keyof DB> {
    * ```ts
    * db.selectFrom('person')
    *   .select(({ fn }) => [
-   *     fn.agg('rank').over().as('rank'),
-   *     fn.agg('group_concat', ['first_name']).distinct().as('first_names')
+   *     fn.agg<number>('rank').over().as('rank'),
+   *     fn.agg<string>('group_concat', ['first_name']).distinct().as('first_names')
    *   ])
    * ```
    *

--- a/src/query-builder/function-module.ts
+++ b/src/query-builder/function-module.ts
@@ -591,18 +591,20 @@ export function createFunctionModule<DB, TB extends keyof DB>(): FunctionModule<
     )
   }
 
+  const agg = <O>(
+    name: string,
+    args?: ReadonlyArray<ReferenceExpression<DB, TB>>
+  ): AggregateFunctionBuilder<DB, TB, O> => {
+    return new AggregateFunctionBuilder({
+      aggregateFunctionNode: AggregateFunctionNode.create(
+        name,
+        args ? parseReferenceExpressionOrList(args) : undefined
+      ),
+    })
+  }
+
   return Object.assign(fn, {
-    agg<O>(
-      name: string,
-      args?: ReadonlyArray<ReferenceExpression<DB, TB>>
-    ): AggregateFunctionBuilder<DB, TB, O> {
-      return new AggregateFunctionBuilder({
-        aggregateFunctionNode: AggregateFunctionNode.create(
-          name,
-          args ? parseReferenceExpressionOrList(args) : undefined
-        ),
-      })
-    },
+    agg,
 
     avg<
       O extends number | string | null = number | string,
@@ -611,12 +613,7 @@ export function createFunctionModule<DB, TB extends keyof DB>(): FunctionModule<
         TB
       >
     >(column: C): AggregateFunctionBuilder<DB, TB, O> {
-      return new AggregateFunctionBuilder({
-        aggregateFunctionNode: AggregateFunctionNode.create(
-          'avg',
-          parseSimpleReferenceExpression(column)
-        ),
-      })
+      return agg('avg', [column])
     },
 
     coalesce<
@@ -636,19 +633,14 @@ export function createFunctionModule<DB, TB extends keyof DB>(): FunctionModule<
         TB
       >
     >(column: C): AggregateFunctionBuilder<DB, TB, O> {
-      return new AggregateFunctionBuilder({
-        aggregateFunctionNode: AggregateFunctionNode.create(
-          'count',
-          parseSimpleReferenceExpression(column)
-        ),
-      })
+      return agg('count', [column])
     },
 
     countAll(table?: string): any {
       return new AggregateFunctionBuilder({
         aggregateFunctionNode: AggregateFunctionNode.create(
           'count',
-          parseSelectAll(table)[0]
+          parseSelectAll(table)
         ),
       })
     },
@@ -659,12 +651,7 @@ export function createFunctionModule<DB, TB extends keyof DB>(): FunctionModule<
         TB
       >
     >(column: C): any {
-      return new AggregateFunctionBuilder({
-        aggregateFunctionNode: AggregateFunctionNode.create(
-          'max',
-          parseSimpleReferenceExpression(column)
-        ),
-      })
+      return agg('max', [column])
     },
 
     min<
@@ -673,12 +660,7 @@ export function createFunctionModule<DB, TB extends keyof DB>(): FunctionModule<
         TB
       >
     >(column: C): any {
-      return new AggregateFunctionBuilder({
-        aggregateFunctionNode: AggregateFunctionNode.create(
-          'min',
-          parseSimpleReferenceExpression(column)
-        ),
-      })
+      return agg('min', [column])
     },
 
     sum<
@@ -688,12 +670,7 @@ export function createFunctionModule<DB, TB extends keyof DB>(): FunctionModule<
         TB
       >
     >(column: C): AggregateFunctionBuilder<DB, TB, O> {
-      return new AggregateFunctionBuilder({
-        aggregateFunctionNode: AggregateFunctionNode.create(
-          'sum',
-          parseSimpleReferenceExpression(column)
-        ),
-      })
+      return agg('sum', [column])
     },
   })
 }

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -1215,7 +1215,7 @@ export class DefaultQueryCompiler
       this.append('distinct ')
     }
 
-    this.visitNode(node.aggregated)
+    this.compileList(node.aggregated)
     this.append(')')
 
     if (node.filter) {


### PR DESCRIPTION
as discussed in #397.

This PR adds the ability to use `AggregateFunctionBuilder`'s methods without a built-in aggregate function method (e.g. sum), using `eg.fn.agg(name, [args])` which is inspired by `eb.fn(name, [args])`.

```ts
db.selectFrom('person')
  .select(({ fn }) => [
    fn.agg<number>('rank').over().as('rank'),
    fn.agg<string>('group_concat', ['first_name']).distinct().as('first_names')
  ])
```

breaking changes:

- internal: aggregate function node structure.