### PR TITLE
feature: Make logger support async calls

### DIFF
--- a/src/driver/runtime-driver.ts
+++ b/src/driver/runtime-driver.ts
@@ -105,20 +105,20 @@ export class RuntimeDriver implements Driver {
       try {
         return await executeQuery.call(connection, compiledQuery)
       } catch (error) {
-        this.#logError(error, compiledQuery, startTime)
+        await this.#logError(error, compiledQuery, startTime)
         throw error
       } finally {
-        this.#logQuery(compiledQuery, startTime)
+        await this.#logQuery(compiledQuery, startTime)
       }
     }
   }
 
-  #logError(
+  async #logError(
     error: unknown,
     compiledQuery: CompiledQuery,
     startTime: number
-  ): void {
-    this.#log.error(() => ({
+  ): Promise<void> {
+    await this.#log.error(() => ({
       level: 'error',
       error,
       query: compiledQuery,
@@ -126,8 +126,11 @@ export class RuntimeDriver implements Driver {
     }))
   }
 
-  #logQuery(compiledQuery: CompiledQuery, startTime: number): void {
-    this.#log.query(() => ({
+  async #logQuery(
+    compiledQuery: CompiledQuery,
+    startTime: number
+  ): Promise<void> {
+    await this.#log.query(() => ({
       level: 'query',
       query: compiledQuery,
       queryDurationMillis: this.#calculateDurationMillis(startTime),

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -20,7 +20,7 @@ export interface ErrorLogEvent {
 }
 
 export type LogEvent = QueryLogEvent | ErrorLogEvent
-export type Logger = (event: LogEvent) => void
+export type Logger = (event: LogEvent) => void | Promise<void>
 export type LogConfig = ReadonlyArray<LogLevel> | Logger
 
 export class Log {
@@ -49,15 +49,15 @@ export class Log {
     return this.#levels[level]
   }
 
-  query(getEvent: () => QueryLogEvent) {
+  async query(getEvent: () => QueryLogEvent) {
     if (this.#levels.query) {
-      this.#logger(getEvent())
+      await this.#logger(getEvent())
     }
   }
 
-  error(getEvent: () => ErrorLogEvent) {
+  async error(getEvent: () => ErrorLogEvent) {
     if (this.#levels.error) {
-      this.#logger(getEvent())
+      await this.#logger(getEvent())
     }
   }
 }


### PR DESCRIPTION
We use kysely on AWS lambdas (serverless) with `context.callbackWaitsForEmptyEventLoop = false` option. This helps us keep DB connection pool opened in background when lambda gets reused by AWS.

We want to log specific errors and immediately inform us over Slack if something unexpected happens with a specific query/error. We can setup a pipeline via Cloudwatch/lambda triggers however the use-case can also work for us if `log` function inside `Kysely` class can be `awaited` by Kysely internally.

The reason we cannot use `.then()` inside the logger function for making async network requests is because we run with `callbackWaitsForEmptyEventLoop = false` option where AWS freezes lambda the moment the callback is complete (which will happen unless kysely internally `awaits` the logger to return)

Please let me know if this needs any clarification 