### PR TITLE
fix: fixed ES Module loading with abolute path fails on windows

### DIFF
--- a/src/migration/file-migration-provider.ts
+++ b/src/migration/file-migration-provider.ts
@@ -37,6 +37,7 @@ export class FileMigrationProvider implements MigrationProvider {
       ) {
         const migration = await import(
           /* webpackIgnore: true */ this.#props.path.join(
+            "file://",
             this.#props.migrationFolder,
             fileName
           )


### PR DESCRIPTION
Fixed error on windows


Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file and data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
    at new NodeError (node:internal/errors:399:5)
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/resolve:1059:11)
    at defaultResolve (node:internal/modules/esm/resolve:1135:3)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at defer (C:\Projetos\cubos\api-typescript-sdkgen-kysely\node_modules\.pnpm\ts-node@10.9.1_@swc+core@1.3.49_@types+node@18.15.11_typescript@4.9.5\node_modules\ts-node\src\esm.ts:159:23)
    at entrypointFallback (C:\Projetos\cubos\api-typescript-sdkgen-kysely\node_modules\.pnpm\ts-node@10.9.1_@swc+core@1.3.49_@types+node@18.15.11_typescript@4.9.5\node_modules\ts-node\src\esm.ts:168:34)
    at C:\Projetos\cubos\api-typescript-sdkgen-kysely\node_modules\.pnpm\ts-node@10.9.1_@swc+core@1.3.49_@types+node@18.15.11_typescript@4.9.5\node_modules\ts-node\src\esm.ts:202:16
    at addShortCircuitFlag (C:\Projetos\cubos\api-typescript-sdkgen-kysely\node_modules\.pnpm\ts-node@10.9.1_@swc+core@1.3.49_@types+node@18.15.11_typescript@4.9.5\node_modules\ts-node\src\esm.ts:409:21)
    at resolve (C:\Projetos\cubos\api-typescript-sdkgen-kysely\node_modules\.pnpm\ts-node@10.9.1_@swc+core@1.3.49_@types+node@18.15.11_typescript@4.9.5\node_modules\ts-node\src\esm.ts:197:12)
    at nextResolve (node:internal/modules/esm/loader:163:28)