### PR TITLE
fix: fix vercel auto deployments

### DIFF
--- a/site/docs/playground.mdx
+++ b/site/docs/playground.mdx
@@ -8,7 +8,7 @@ sidebar_position: 3
 
 import { Playground, exampleFindById } from '../src/components/Playground'
 
-<Playground ts={exampleFindById} />
+<Playground code={exampleFindById} />
 
 ## Codesandbox
 

--- a/site/src/components/Playground.tsx
+++ b/site/src/components/Playground.tsx
@@ -3,10 +3,11 @@ import { gray } from "@radix-ui/colors"
 
 export function Playground({
   code,
-  setupCode,
+  setupCode = exampleSetup,
   kyselyVersion,
   dialect = "postgres",
 }: PlaygroundProps) {
+  console.log("code", code)
   const params = new URLSearchParams()
   params.set("p", "j")
   params.set("i", JSON.stringify({
@@ -37,7 +38,7 @@ interface PlaygroundProps {
   kyselyVersion?: string
   dialect?: "postgres"
   code: string
-  setupCode: string,
+  setupCode?: string,
 }
 
 export const exampleSetup = `


### PR DESCRIPTION
Auto deployments were broken due to SSR crashing in the docs/playground page. Concretely, the setupCode was not being passed.