### PR TITLE
docs: update playground url

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ type UpdateablePerson = Updateable<PersonTable>
 
 # Playground
 
-[@wirekang](https://github.com/wirekang) has created a [playground for Kysely](https://wirekang.github.io/kysely-playground/?p=f&i=-NLp3n_P5fyeQKMQda8n). You can use to quickly test stuff out and for creating code examples for your issues, PRs and discord messages.
+[@wirekang](https://github.com/wirekang) has created a [playground for Kysely](https://kyse.link). You can use to quickly test stuff out and for creating code examples for your issues, PRs and discord messages.
 
 # Generating types
 

--- a/site/src/components/Playground.tsx
+++ b/site/src/components/Playground.tsx
@@ -29,7 +29,7 @@ export function Playground({
         background: gray.gray12,
       }}
       allow="clipboard-write"
-      src={`https://wirekang.github.io/kysely-playground/?${params.toString()}`}
+      src={`https://kyse.link/?${params.toString()}`}
     />
   )
 }


### PR DESCRIPTION
1. Update url on README.md
[Old](https://wirekang.github.io/kysely-playground/?p=f&i=-NLp3n_P5fyeQKMQda8n) -> [New](https://kyse.link)

2. Fix clipboard permission error
Since `wirekang.github.io/kysely-playground` redirects to `kyse.link`, `allow="clipboard-write"` won't work anymore with `src="https://wirekang.github.io/...".


#### More context about `kyse.link`

1. I bought the domain to make url as short as possible.  
2. I bought it from AWS Route53. It's **5** $/year and I have fixed income.
3. There are no subdomains or other purposes, now or later.
