### PR TITLE
add node20 to workflows, drop node14, bump better-sqlite3 to v8.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         deno-version: [1.19.x]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
         deno-version: [1.19.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/pg": "^8.6.5",
         "@types/pg-cursor": "^2.7.0",
         "@types/sinon": "^10.0.13",
-        "better-sqlite3": "^7.5.3",
+        "better-sqlite3": "^8.4.0",
         "chai": "^4.3.6",
         "chai-as-promised": "^7.1.1",
         "chai-subset": "^1.6.0",
@@ -489,9 +489,9 @@
       ]
     },
     "node_modules/better-sqlite3": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-7.6.2.tgz",
-      "integrity": "sha512-S5zIU1Hink2AH4xPsN0W43T1/AJ5jrPh7Oy07ocuW/AKYYY02GWzz9NH0nbSMn/gw6fDZ5jZ1QsHt1BXAwJ6Lg==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.4.0.tgz",
+      "integrity": "sha512-NmsNW1CQvqMszu/CFAJ3pLct6NEFlNfuGM6vw72KHkjOD1UDnL96XNN1BMQc1hiHo8vE2GbOWQYIpZ+YM5wrZw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3962,9 +3962,9 @@
       "dev": true
     },
     "better-sqlite3": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-7.6.2.tgz",
-      "integrity": "sha512-S5zIU1Hink2AH4xPsN0W43T1/AJ5jrPh7Oy07ocuW/AKYYY02GWzz9NH0nbSMn/gw6fDZ5jZ1QsHt1BXAwJ6Lg==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.4.0.tgz",
+      "integrity": "sha512-NmsNW1CQvqMszu/CFAJ3pLct6NEFlNfuGM6vw72KHkjOD1UDnL96XNN1BMQc1hiHo8vE2GbOWQYIpZ+YM5wrZw==",
       "dev": true,
       "requires": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@types/pg": "^8.6.5",
     "@types/pg-cursor": "^2.7.0",
     "@types/sinon": "^10.0.13",
-    "better-sqlite3": "^7.5.3",
+    "better-sqlite3": "^8.4.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
     "chai-subset": "^1.6.0",


### PR DESCRIPTION
Node.js LTS is v18, current is v20. v14 was April 30, 2023.

Let's ditch node 14 from our required tests in CI. Replace it with node 20.

This PR also bumps `better-sqlite3` to latest v8 to get node20 compatible binaries.

postrequisites:

- add `run-tests (20.x, 1.19.x)` to required PR checks.
- remove `run-tests (14.x, 1.19.x)` from required PR checks.