### PR TITLE
Chore(docs): Missing comma in dynamic.ts

### DIFF
--- a/src/dynamic/dynamic.ts
+++ b/src/dynamic/dynamic.ts
@@ -70,7 +70,7 @@ export class DynamicModule {
    *
    * const [person] = await db.selectFrom('person')
    *   .select([
-   *     ref<PossibleColumns>(columnFromUserInput)
+   *     ref<PossibleColumns>(columnFromUserInput), 
    *     'id'
    *   ])
    *   .execute()


### PR DESCRIPTION
There appears to be a missing comma in the array of selects passed in as part of the dynamic example code.

This adds it in! 👍