### PR TITLE
make `SchemaModule` optional and injectable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,8 @@ import {
   Kysely,
   Migrator,
   PostgresDialect,
-  FileMigrationProvider
+  FileMigrationProvider,
+  SchemaModule,
 } from 'kysely'
 
 async function migrateToLatest() {
@@ -438,6 +439,7 @@ async function migrateToLatest() {
         database: 'kysely_test',
       })
     }),
+    SchemaModule,
   })
 
   const migrator = new Migrator({

--- a/site/docs/migrations.mdx
+++ b/site/docs/migrations.mdx
@@ -94,6 +94,7 @@ import {
   Migrator,
   PostgresDialect,
   FileMigrationProvider,
+  SchemaModule,
 } from 'kysely'
 
 async function migrateToLatest() {
@@ -104,6 +105,7 @@ async function migrateToLatest() {
         database: 'kysely_test',
       }),
     }),
+    SchemaModule,
   })
 
   const migrator = new Migrator({

--- a/test/node/src/camel-case.test.ts
+++ b/test/node/src/camel-case.test.ts
@@ -1,4 +1,11 @@
-import { CamelCasePlugin, Generated, Kysely, RawBuilder, sql } from '../../../'
+import {
+  CamelCasePlugin,
+  Generated,
+  Kysely,
+  RawBuilder,
+  SchemaModule,
+  sql,
+} from '../../../'
 
 import {
   DIALECTS,
@@ -34,6 +41,7 @@ for (const dialect of DIALECTS) {
       camelDb = new Kysely<CamelDatabase>({
         ...ctx.config,
         plugins: [new CamelCasePlugin()],
+        SchemaModule,
       })
 
       await camelDb.schema.dropTable('camelPerson').ifExists().execute()

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -1,4 +1,4 @@
-import { ColumnMetadata, sql } from '../../../'
+import { ColumnMetadata, Kysely, sql } from '../../../'
 
 import {
   DIALECTS,
@@ -9,6 +9,7 @@ import {
   NOT_SUPPORTED,
   TestContext,
   testSql,
+  DB_CONFIGS,
 } from './test-setup.js'
 
 for (const dialect of DIALECTS) {
@@ -27,6 +28,12 @@ for (const dialect of DIALECTS) {
 
     after(async () => {
       await destroyTest(ctx)
+    })
+
+    it('should throw an error when module is not provided in the config', () => {
+      expect(() => {
+        new Kysely({ ...DB_CONFIGS[dialect] }).schema
+      }).to.throw()
     })
 
     describe('create table', () => {
@@ -101,7 +108,7 @@ for (const dialect of DIALECTS) {
                 '"u" timestamp(6) default current_timestamp not null,',
                 '"v" timestamptz(6),',
                 '"w" char(4),',
-                '"x" char)'
+                '"x" char)',
               ],
               parameters: [],
             },
@@ -201,7 +208,7 @@ for (const dialect of DIALECTS) {
                 '`r` datetime(6),',
                 '`s` timestamp(6) default current_timestamp(6) not null,',
                 '`t` char(4),',
-                '`u` char)'
+                '`u` char)',
               ],
               parameters: [],
             },
@@ -1128,7 +1135,7 @@ for (const dialect of DIALECTS) {
 
         await builder.execute()
       })
-      
+
       if (dialect !== 'mysql') {
         it('should create a partial index', async () => {
           const builder = ctx.db.schema

--- a/test/node/src/test-setup.ts
+++ b/test/node/src/test-setup.ts
@@ -127,7 +127,7 @@ export const DIALECT_CONFIGS = {
   },
 }
 
-const DB_CONFIGS: PerDialect<KyselyConfig> = {
+export const DB_CONFIGS: PerDialect<KyselyConfig> = {
   postgres: {
     dialect: new PostgresDialect({
       pool: async () => new Pool(DIALECT_CONFIGS.postgres),
@@ -162,6 +162,7 @@ export async function initTest(
   const db = await connect({
     ...config,
     log,
+    SchemaModule,
   })
 
   await createDatabase(db, dialect)


### PR DESCRIPTION
This PR makes `SchemaModule` optional and injectable when instantiating Kysely. 
If not injected and consumer tries accessing it, a runtime error is thrown.

99% of the time, DDL queries are executed in migrations.

A considerable chunk of our consumers use Kysely in serverless/edge/browser environments. 99% of the time only DML queries are being executed there. In such environments bundle sizes affect cold starts / load times. The bigger the bundle, the worse our consumers' user experience.

Builder pattern is great for DX, but is bad for tree-shaking. By making `SchemaModule` injectable and optionally supported, we help decrease our consumers bundle sizes and help them ship better user experiences.

Things considered but not done:

- export `SchemaModule` & builders from `kysely/schema` instead of `kysely`. Unlike helpers, `SchemaModule` belongs in "main" Kysely.
- make `db.schema` return type `never` if no `SchemaModule` was passed @ config. Compilation performance hit that's not worth it.

Todo:

- [ ] check bundle size without `SchemaModule` usage.