### PR TITLE
fix `fn.max`/`fn.min` not usable as `fn(...)` arguments.

### DIFF
--- a/src/query-builder/function-module.ts
+++ b/src/query-builder/function-module.ts
@@ -13,7 +13,7 @@ import {
   parseReferenceExpressionOrList,
 } from '../parser/reference-parser.js'
 import { parseSelectAll } from '../parser/select-parser.js'
-import { Equals, IsNever } from '../util/type-utils.js'
+import { Equals, IsAny } from '../util/type-utils.js'
 import { AggregateFunctionBuilder } from './aggregate-function-builder.js'
 
 /**
@@ -462,7 +462,7 @@ export interface FunctionModule<DB, TB extends keyof DB> {
    * ```
    */
   max<
-    O extends number | string | bigint | null = never,
+    O extends number | string | bigint | null = any,
     C extends StringReference<DB, TB> = StringReference<DB, TB>
   >(
     column: OutputBoundStringReference<DB, TB, C, O>
@@ -523,7 +523,7 @@ export interface FunctionModule<DB, TB extends keyof DB> {
    * ```
    */
   min<
-    O extends number | string | bigint | null = never,
+    O extends number | string | bigint | null = any,
     C extends StringReference<DB, TB> = StringReference<DB, TB>
   >(
     column: OutputBoundStringReference<DB, TB, C, O>
@@ -710,7 +710,7 @@ type OutputBoundStringReference<
   TB extends keyof DB,
   C extends StringReference<DB, TB>,
   O
-> = IsNever<O> extends true
+> = IsAny<O> extends true
   ? C // output not provided, unbound
   : Equals<
       ExtractTypeFromReferenceExpression<DB, TB, C> | null,
@@ -728,5 +728,5 @@ type StringReferenceBoundAggregateFunctionBuilder<
   DB,
   TB,
   | ExtractTypeFromReferenceExpression<DB, TB, C>
-  | (null extends O ? null : never) // output is nullable, but column type might not be nullable.
+  | (IsAny<O> extends true ? never : null extends O ? null : never) // output is nullable, but column type might not be nullable.
 >

--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -174,6 +174,11 @@ export type MergePartial<T1, T2> = T1 & Partial<Omit<T2, keyof T1>>
 export type IsNever<T> = [T] extends [never] ? true : false
 
 /**
+ * Evaluates to `true` if `T` is `any`.
+ */
+export type IsAny<T> = 0 extends T & 1 ? true : false
+
+/**
  * Evaluates to `true` if the types `T` and `U` are equal.
  */
 export type Equals<T, U> = (<G>() => G extends T ? 1 : 2) extends <

--- a/test/typings/test-d/aggregate-function.test-d.ts
+++ b/test/typings/test-d/aggregate-function.test-d.ts
@@ -972,9 +972,55 @@ async function testSelectAsCustomFunctionArgument(db: Kysely<Database>) {
     .select(({ fn }) => [
       fn('round', [fn.avg('age')]).as('avg_age'),
       fn('round', [fn.count('age')]).as('total_people'),
+      fn('round', [fn.countAll()]).as('total_all_people'),
       fn('round', [fn.max('age')]).as('max_age'),
       fn('round', [fn.min('age')]).as('min_age'),
       fn('round', [fn.sum('age')]).as('total_age'),
     ])
     .executeTakeFirstOrThrow()
+
+  expectError(
+    await db
+      .selectFrom('person')
+      .select(({ fn }) => [
+        fn('round', [fn.avg('NO_SUCH_COLUMN')]).as('avg_age'),
+      ])
+      .executeTakeFirstOrThrow()
+  )
+
+  expectError(
+    await db
+      .selectFrom('person')
+      .select(({ fn }) => [
+        fn('round', [fn.count('NO_SUCH_COLUMN')]).as('avg_age'),
+      ])
+      .executeTakeFirstOrThrow()
+  )
+
+  expectError(
+    await db
+      .selectFrom('person')
+      .select(({ fn }) => [
+        fn('round', [fn.max('NO_SUCH_COLUMN')]).as('avg_age'),
+      ])
+      .executeTakeFirstOrThrow()
+  )
+
+  expectError(
+    await db
+      .selectFrom('person')
+      .select(({ fn }) => [
+        fn('round', [fn.min('NO_SUCH_COLUMN')]).as('avg_age'),
+      ])
+      .executeTakeFirstOrThrow()
+  )
+
+  expectError(
+    await db
+      .selectFrom('person')
+      .select(({ fn }) => [
+        fn('round', [fn.sum('NO_SUCH_COLUMN')]).as('avg_age'),
+      ])
+      .executeTakeFirstOrThrow()
+  )
 }

--- a/test/typings/test-d/aggregate-function.test-d.ts
+++ b/test/typings/test-d/aggregate-function.test-d.ts
@@ -965,3 +965,16 @@ async function testSelectWithOverAndOrderByUnexpectedColumns(
       .executeTakeFirst()
   )
 }
+
+async function testSelectAsCustomFunctionArgument(db: Kysely<Database>) {
+  await db
+    .selectFrom('person')
+    .select(({ fn }) => [
+      fn('round', [fn.avg('age')]).as('avg_age'),
+      fn('round', [fn.count('age')]).as('total_people'),
+      fn('round', [fn.max('age')]).as('max_age'),
+      fn('round', [fn.min('age')]).as('min_age'),
+      fn('round', [fn.sum('age')]).as('total_age'),
+    ])
+    .executeTakeFirstOrThrow()
+}


### PR DESCRIPTION
Spotted by ddanielcruzz on discord.

```ts
 fn("round", [fn.min("ld.price_btc"), sql.lit(5)]).as("floor_price"), // TS does complain ❌
 fn("round", [fn.sum("s.volume"), sql.lit(2)]).as("volume"), // TS does not complain ✅
 fn("round", [fn.avg("s.avg_price"), sql.lit(5)]).as("avg_price"),// TS does not complain✅
```

When `.min`/`.max` are used as `fn(...)` arguments, their `O` generic defaults to `any` instead of `never` and doesn't allow to use `StringReference` as `.min`/`.max` argument.

The fix replaces `never` with `any` as the "consumer didn't explictly pick an `O` type" default `O` value and everything is fine again.