### PR TITLE
fix: disallow AlterColumn method chaining

### DIFF
--- a/src/operation-node/alter-column-node.ts
+++ b/src/operation-node/alter-column-node.ts
@@ -1,8 +1,6 @@
 import { OperationNode } from './operation-node.js'
 import { freeze } from '../util/object-utils.js'
 import { ColumnNode } from './column-node.js'
-import { DataTypeNode } from './data-type-node.js'
-import { ValueNode } from './value-node.js'
 import { RawNode } from './raw-node.js'
 
 export type AlterColumnNodeProps = Omit<AlterColumnNode, 'kind' | 'column'>
@@ -26,20 +24,11 @@ export const AlterColumnNode = freeze({
     return node.kind === 'AlterColumnNode'
   },
 
-  create(column: string): AlterColumnNode {
+  create<T extends keyof AlterColumnNode>(column: string, prop: T, value: Required<AlterColumnNode>[T]): AlterColumnNode {
     return freeze({
       kind: 'AlterColumnNode',
       column: ColumnNode.create(column),
-    })
-  },
-
-  cloneWith(
-    node: AlterColumnNode,
-    props: AlterColumnNodeProps
-  ): AlterColumnNode {
-    return freeze({
-      ...node,
-      ...props,
+      [prop]: value
     })
   },
 })

--- a/src/operation-node/alter-column-node.ts
+++ b/src/operation-node/alter-column-node.ts
@@ -24,7 +24,7 @@ export const AlterColumnNode = freeze({
     return node.kind === 'AlterColumnNode'
   },
 
-  create<T extends keyof AlterColumnNode>(column: string, prop: T, value: Required<AlterColumnNode>[T]): AlterColumnNode {
+  create<T extends keyof AlterColumnNodeProps>(column: string, prop: T, value: Required<AlterColumnNodeProps>[T]): AlterColumnNode {
     return freeze({
       kind: 'AlterColumnNode',
       column: ColumnNode.create(column),

--- a/src/schema/alter-column-builder.ts
+++ b/src/schema/alter-column-builder.ts
@@ -10,39 +10,39 @@ import {
 } from '../parser/default-value-parser.js'
 
 export class AlterColumnBuilder {
-  protected column: string
+  readonly #column: string
 
   constructor(column: string) {
-    this.column = column
+    this.#column = column
   }
 
   setDataType(dataType: DataTypeExpression): AlteredColumnBuilder {
     return new AlteredColumnBuilder(
-      AlterColumnNode.create(this.column, 'dataType', parseDataTypeExpression(dataType))
+      AlterColumnNode.create(this.#column, 'dataType', parseDataTypeExpression(dataType))
     )
   }
 
   setDefault(value: DefaultValueExpression): AlteredColumnBuilder {
     return new AlteredColumnBuilder(
-      AlterColumnNode.create(this.column, 'setDefault', parseDefaultValueExpression(value))
+      AlterColumnNode.create(this.#column, 'setDefault', parseDefaultValueExpression(value))
     )
   }
 
   dropDefault(): AlteredColumnBuilder {
     return new AlteredColumnBuilder(
-      AlterColumnNode.create(this.column, 'dropDefault', true)
+      AlterColumnNode.create(this.#column, 'dropDefault', true)
     )
   }
 
   setNotNull(): AlteredColumnBuilder {
     return new AlteredColumnBuilder(
-      AlterColumnNode.create(this.column, 'setNotNull', true)
+      AlterColumnNode.create(this.#column, 'setNotNull', true)
     )
   }
 
   dropNotNull(): AlteredColumnBuilder {
     return new AlteredColumnBuilder(
-      AlterColumnNode.create(this.column, 'dropNotNull', true)
+      AlterColumnNode.create(this.#column, 'dropNotNull', true)
     )
   }
 
@@ -56,9 +56,7 @@ export class AlterColumnBuilder {
 }
 
 /**
- * Allows us to force consumers to do something, anything, when altering a column,
- * and also disallows chaining more methods on AlterColumnBuilder, because
- * SQL syntax for chaining ALTER COLUMN operations would be not WYSIWYG
+ * Allows us to force consumers to do exactly one alteration to a column.
  *
  * Basically, deny the following:
  *
@@ -74,14 +72,14 @@ export class AlterColumnBuilder {
  */
 export class AlteredColumnBuilder implements OperationNodeSource
 {
-  protected readonly alterColumnNode: AlterColumnNode
+  readonly #alterColumnNode: AlterColumnNode
 
   constructor(alterColumnNode: AlterColumnNode) {
-    this.alterColumnNode = alterColumnNode
+    this.#alterColumnNode = alterColumnNode
   }
 
   toOperationNode(): AlterColumnNode {
-    return this.alterColumnNode
+    return this.#alterColumnNode
   }
 }
 

--- a/src/schema/alter-column-builder.ts
+++ b/src/schema/alter-column-builder.ts
@@ -10,49 +10,39 @@ import {
 } from '../parser/default-value-parser.js'
 
 export class AlterColumnBuilder {
-  protected readonly alterColumnNode: AlterColumnNode
+  protected column: string
 
-  constructor(alterColumnNode: AlterColumnNode) {
-    this.alterColumnNode = alterColumnNode
+  constructor(column: string) {
+    this.column = column
   }
 
   setDataType(dataType: DataTypeExpression): AlteredColumnBuilder {
     return new AlteredColumnBuilder(
-      AlterColumnNode.cloneWith(this.alterColumnNode, {
-        dataType: parseDataTypeExpression(dataType),
-      })
+      AlterColumnNode.create(this.column, 'dataType', parseDataTypeExpression(dataType))
     )
   }
 
   setDefault(value: DefaultValueExpression): AlteredColumnBuilder {
     return new AlteredColumnBuilder(
-      AlterColumnNode.cloneWith(this.alterColumnNode, {
-        setDefault: parseDefaultValueExpression(value),
-      })
+      AlterColumnNode.create(this.column, 'setDefault', parseDefaultValueExpression(value))
     )
   }
 
   dropDefault(): AlteredColumnBuilder {
     return new AlteredColumnBuilder(
-      AlterColumnNode.cloneWith(this.alterColumnNode, {
-        dropDefault: true,
-      })
+      AlterColumnNode.create(this.column, 'dropDefault', true)
     )
   }
 
   setNotNull(): AlteredColumnBuilder {
     return new AlteredColumnBuilder(
-      AlterColumnNode.cloneWith(this.alterColumnNode, {
-        setNotNull: true,
-      })
+      AlterColumnNode.create(this.column, 'setNotNull', true)
     )
   }
 
   dropNotNull(): AlteredColumnBuilder {
     return new AlteredColumnBuilder(
-      AlterColumnNode.cloneWith(this.alterColumnNode, {
-        dropNotNull: true,
-      })
+      AlterColumnNode.create(this.column, 'dropNotNull', true)
     )
   }
 
@@ -66,20 +56,30 @@ export class AlterColumnBuilder {
 }
 
 /**
- * Allows us to force consumers to do something, anything, when altering a column.
+ * Allows us to force consumers to do something, anything, when altering a column,
+ * and also disallows chaining more methods on AlterColumnBuilder, because
+ * SQL syntax for chaining ALTER COLUMN operations would be not WYSIWYG
  *
  * Basically, deny the following:
  *
  * ```ts
  * db.schema.alterTable('person').alterColumn('age', (ac) => ac)
  * ```
+ * 
+ * ```ts
+ * db.schema.alterTable('person').alterColumn('age', (ac) => ac.dropNotNull().setNotNull())
+ * ```
  *
  * Which would now throw a compilation error, instead of a runtime error.
  */
-export class AlteredColumnBuilder
-  extends AlterColumnBuilder
-  implements OperationNodeSource
+export class AlteredColumnBuilder implements OperationNodeSource
 {
+  protected readonly alterColumnNode: AlterColumnNode
+
+  constructor(alterColumnNode: AlterColumnNode) {
+    this.alterColumnNode = alterColumnNode
+  }
+
   toOperationNode(): AlterColumnNode {
     return this.alterColumnNode
   }

--- a/src/schema/alter-table-builder.ts
+++ b/src/schema/alter-table-builder.ts
@@ -71,7 +71,7 @@ export class AlterTableBuilder implements ColumnAlteringInterface {
     alteration: AlterColumnBuilderCallback
   ): AlterTableColumnAlteringBuilder {
     const builder = alteration(
-      new AlterColumnBuilder(AlterColumnNode.create(column))
+      new AlterColumnBuilder(column)
     )
 
     return new AlterTableColumnAlteringBuilder({
@@ -292,7 +292,7 @@ export class AlterTableColumnAlteringBuilder
     alteration: AlterColumnBuilderCallback
   ): AlterTableColumnAlteringBuilder {
     const builder = alteration(
-      new AlterColumnBuilder(AlterColumnNode.create(column))
+      new AlterColumnBuilder(column)
     )
 
     return new AlterTableColumnAlteringBuilder({


### PR DESCRIPTION
Fixes: #467

It was slightly tricky, but I decided that "unwinding" looks the best in terms of clarity of what is happening.

This effectively produces query:

```
ALTER TABLE "x" ALTER COLUMN "y" SET DEFAULT true, ALTER COLUMN "z" DROP NOT NULL, [...]
```

as in Postgres docs. MySQL has exact syntax for chaining ALTER COLUMN, but supports only `drop default` and `set default` operations, so probably nobody will chain those two together, plus alter column usage for MySQL is not properly handled in whole Kysely anyway. I tested MySQL case manually.

---

EDIT: now it just disallows chaining
