### PR TITLE
Workaround obscure RDS Data Api Bug

### DIFF
--- a/src/dialect/postgres/postgres-introspector.ts
+++ b/src/dialect/postgres/postgres-introspector.ts
@@ -70,7 +70,10 @@ export class PostgresIntrospector implements DatabaseIntrospector {
           .as('auto_incrementing'),
       ])
       // r == normal table
-      .where(qb => qb.where('c.relkind', '=', 'r').orWhere('c.relkind', '=', 'v'))
+      .where(({ cmpr, or }) => or([
+        cmpr('c.relkind', '=', 'r'),
+        cmpr('c.relkind', '=', 'v'),
+      ])
       .where('ns.nspname', '!~', '^pg_')
       .where('ns.nspname', '!=', 'information_schema')
       // No system columns

--- a/src/dialect/postgres/postgres-introspector.ts
+++ b/src/dialect/postgres/postgres-introspector.ts
@@ -73,7 +73,7 @@ export class PostgresIntrospector implements DatabaseIntrospector {
       .where(({ cmpr, or }) => or([
         cmpr('c.relkind', '=', 'r'),
         cmpr('c.relkind', '=', 'v'),
-      ])
+      ]))
       .where('ns.nspname', '!~', '^pg_')
       .where('ns.nspname', '!=', 'information_schema')
       // No system columns

--- a/src/dialect/postgres/postgres-introspector.ts
+++ b/src/dialect/postgres/postgres-introspector.ts
@@ -70,7 +70,7 @@ export class PostgresIntrospector implements DatabaseIntrospector {
           .as('auto_incrementing'),
       ])
       // r == normal table
-      .where('c.relkind', 'in', ['r', 'v'])
+      .where(qb => qb.where('c.relkind', '=', 'r').orWhere('c.relkind', '=', 'v'))
       .where('ns.nspname', '!~', '^pg_')
       .where('ns.nspname', '!=', 'information_schema')
       // No system columns


### PR DESCRIPTION
So I know this isn't ideal because it's making changes in kysely core for a 3rd party adapter - however it is also the simplest fix

There's some bug in the RDS api that does not like `in` statements used with char fields - it's interpreting the in values as strings instead of chars and failing

Switching it to an orWhere statement fixes the problem

Wanted to throw this up here in case you were willing to accept this change - otherwise we'll have to copy the whole PostgresIntrospector into kysely-data-api to make this one change