### PR TITLE
feat: increase fault tolerance to deep types error

### DIFF
--- a/src/dialect/mysql/mysql-dialect-config.ts
+++ b/src/dialect/mysql/mysql-dialect-config.ts
@@ -1,4 +1,5 @@
 import { DatabaseConnection } from '../../driver/database-connection.js'
+import { ShallowRecord } from '../../util/type-utils.js'
 
 /**
  * Config for the MySQL dialect.
@@ -63,4 +64,4 @@ export interface MysqlOkPacket {
   insertId: number
 }
 
-export type MysqlQueryResult = MysqlOkPacket | Record<string, unknown>[]
+export type MysqlQueryResult = MysqlOkPacket | ShallowRecord<string, unknown>[]

--- a/src/parser/expression-parser.ts
+++ b/src/parser/expression-parser.ts
@@ -13,14 +13,15 @@ import {
 } from '../expression/expression-builder.js'
 import { SelectQueryBuilder } from '../query-builder/select-query-builder.js'
 import { isFunction } from '../util/object-utils.js'
+import { ShallowRecord } from '../util/type-utils.js'
 
 export type ExpressionOrFactory<DB, TB extends keyof DB, V> =
   // SQL treats a subquery with a single selection as a scalar. That's
   // why we need to explicitly allow `SelectQueryBuilder` here with a
-  // `Record<string, V>` output type, even though `SelectQueryBuilder`
+  // `ShallowRecord<string, V>` output type, even though `SelectQueryBuilder`
   // is also an `Expression`.
-  | SelectQueryBuilder<any, any, Record<string, V>>
-  | SelectQueryBuilderFactory<DB, TB, Record<string, V>>
+  | SelectQueryBuilder<any, any, ShallowRecord<string, V>>
+  | SelectQueryBuilderFactory<DB, TB, ShallowRecord<string, V>>
   | Expression<V>
   | ExpressionFactory<DB, TB, V>
 

--- a/src/parser/select-parser.ts
+++ b/src/parser/select-parser.ts
@@ -6,6 +6,7 @@ import {
   AnyAliasedColumnWithTable,
   AnyColumn,
   AnyColumnWithTable,
+  DrainOuterGeneric,
   ExtractColumnType,
 } from '../util/type-utils.js'
 import { parseAliasedStringReference } from './reference-parser.js'
@@ -42,11 +43,11 @@ export type SelectArg<
   | ReadonlyArray<SE>
   | ((eb: ExpressionBuilder<DB, TB>) => ReadonlyArray<SE>)
 
-export type Selection<DB, TB extends keyof DB, SE> = {
+export type Selection<DB, TB extends keyof DB, SE> = DrainOuterGeneric<{
   [A in ExtractAliasFromSelectExpression<SE>]: SelectType<
     ExtractTypeFromSelectExpression<DB, TB, SE, A>
   >
-}
+}>
 
 type ExtractAliasFromSelectExpression<SE> = SE extends string
   ? ExtractAliasFromStringSelectExpression<SE>
@@ -151,11 +152,13 @@ type ExtractTypeFromStringSelectExpression<
     : never
   : never
 
-export type AllSelection<DB, TB extends keyof DB> = Selectable<{
-  [C in AnyColumn<DB, TB>]: {
-    [T in TB]: C extends keyof DB[T] ? DB[T][C] : never
-  }[TB]
-}>
+export type AllSelection<DB, TB extends keyof DB> = DrainOuterGeneric<
+  Selectable<{
+    [C in AnyColumn<DB, TB>]: {
+      [T in TB]: C extends keyof DB[T] ? DB[T][C] : never
+    }[TB]
+  }>
+>
 
 export function parseSelectArg(
   selection: SelectArg<any, any, SelectExpression<any, any>>

--- a/src/parser/table-parser.ts
+++ b/src/parser/table-parser.ts
@@ -8,6 +8,7 @@ import {
 import { IdentifierNode } from '../operation-node/identifier-node.js'
 import { OperationNode } from '../operation-node/operation-node.js'
 import { AliasedExpression } from '../expression/expression.js'
+import { DrainOuterGeneric, ShallowRecord } from '../util/type-utils.js'
 
 export type TableExpression<DB, TB extends keyof DB> =
   | AnyAliasedTable<DB>
@@ -29,7 +30,7 @@ export type TableReferenceOrList<DB> =
   | TableReference<DB>
   | ReadonlyArray<TableReference<DB>>
 
-export type From<DB, TE> = {
+export type From<DB, TE> = DrainOuterGeneric<{
   [C in
     | keyof DB
     | ExtractAliasFromTableExpression<
@@ -40,11 +41,11 @@ export type From<DB, TE> = {
     : C extends keyof DB
     ? DB[C]
     : never
-}
+}>
 
-export type FromTables<DB, TB extends keyof DB, TE> =
-  | TB
-  | ExtractAliasFromTableExpression<DB, TE>
+export type FromTables<DB, TB extends keyof DB, TE> = DrainOuterGeneric<
+  TB | ExtractAliasFromTableExpression<DB, TE>
+>
 
 export type ExtractTableAlias<DB, TE> = TE extends `${string} as ${infer TA}`
   ? TA
@@ -57,7 +58,7 @@ export type PickTableWithAlias<
   T extends AnyAliasedTable<DB>
 > = T extends `${infer TB} as ${infer A}`
   ? TB extends keyof DB
-    ? Record<A, DB[TB]>
+    ? ShallowRecord<A, DB[TB]>
     : never
   : never
 

--- a/src/parser/with-parser.ts
+++ b/src/parser/with-parser.ts
@@ -6,6 +6,7 @@ import { CommonTableExpressionNameNode } from '../operation-node/common-table-ex
 import { QueryCreator } from '../query-creator.js'
 import { createQueryCreator } from './parse-utils.js'
 import { Expression } from '../expression/expression.js'
+import { DrainOuterGeneric, ShallowRecord } from '../util/type-utils.js'
 
 export type CommonTableExpression<DB, CN extends string> = (
   creator: QueryCreator<DB>
@@ -15,7 +16,7 @@ export type RecursiveCommonTableExpression<DB, CN extends string> = (
   creator: QueryCreator<
     DB &
       // Recursive CTE can select from itself.
-      Record<
+      ShallowRecord<
         ExtractTableFromCommonTableExpressionName<CN>,
         ExtractRowFromCommonTableExpressionName<CN>
       >
@@ -26,12 +27,14 @@ export type QueryCreatorWithCommonTableExpression<
   DB,
   CN extends string,
   CTE
-> = QueryCreator<
-  DB &
-    Record<
-      ExtractTableFromCommonTableExpressionName<CN>,
-      ExtractRowFromCommonTableExpression<CTE>
-    >
+> = DrainOuterGeneric<
+  QueryCreator<
+    DB &
+      ShallowRecord<
+        ExtractTableFromCommonTableExpressionName<CN>,
+        ExtractRowFromCommonTableExpression<CTE>
+      >
+  >
 >
 
 type CommonTableExpressionOutput<DB, CN extends string> =
@@ -83,7 +86,7 @@ type ExtractTableFromCommonTableExpressionName<CN extends string> =
 type ExtractRowFromCommonTableExpressionName<CN extends string> =
   CN extends `${string}(${infer CL})`
     ? { [C in ExtractColumnNamesFromColumnList<CL>]: any }
-    : Record<string, any>
+    : ShallowRecord<string, any>
 
 /**
  * Parses a string like 'id, first_name' into a type 'id' | 'first_name'

--- a/src/query-builder/delete-query-builder.ts
+++ b/src/query-builder/delete-query-builder.ts
@@ -22,9 +22,11 @@ import { ReturningAllRow, ReturningRow } from '../parser/returning-parser.js'
 import { ReferenceExpression } from '../parser/reference-parser.js'
 import { QueryNode } from '../operation-node/query-node.js'
 import {
+  DrainOuterGeneric,
   MergePartial,
   NarrowPartial,
   Nullable,
+  ShallowRecord,
   SimplifyResult,
   SimplifySingleResult,
 } from '../util/type-utils.js'
@@ -1070,11 +1072,11 @@ type InnerJoinedBuilder<
 > = A extends keyof DB
   ? DeleteQueryBuilder<InnerJoinedDB<DB, A, R>, TB | A, O>
   : // Much faster non-recursive solution for the simple case.
-    DeleteQueryBuilder<DB & Record<A, R>, TB | A, O>
+    DeleteQueryBuilder<DB & ShallowRecord<A, R>, TB | A, O>
 
-type InnerJoinedDB<DB, A extends string, R> = {
+type InnerJoinedDB<DB, A extends string, R> = DrainOuterGeneric<{
   [C in keyof DB | A]: C extends A ? R : C extends keyof DB ? DB[C] : never
-}
+}>
 
 export type DeleteQueryBuilderWithLeftJoin<
   DB,
@@ -1102,15 +1104,15 @@ type LeftJoinedBuilder<
 > = A extends keyof DB
   ? DeleteQueryBuilder<LeftJoinedDB<DB, A, R>, TB | A, O>
   : // Much faster non-recursive solution for the simple case.
-    DeleteQueryBuilder<DB & Record<A, Nullable<R>>, TB | A, O>
+    DeleteQueryBuilder<DB & ShallowRecord<A, Nullable<R>>, TB | A, O>
 
-type LeftJoinedDB<DB, A extends keyof any, R> = {
+type LeftJoinedDB<DB, A extends keyof any, R> = DrainOuterGeneric<{
   [C in keyof DB | A]: C extends A
     ? Nullable<R>
     : C extends keyof DB
     ? DB[C]
     : never
-}
+}>
 
 export type DeleteQueryBuilderWithRightJoin<
   DB,
@@ -1137,7 +1139,12 @@ type RightJoinedBuilder<
   R
 > = DeleteQueryBuilder<RightJoinedDB<DB, TB, A, R>, TB | A, O>
 
-type RightJoinedDB<DB, TB extends keyof DB, A extends keyof any, R> = {
+type RightJoinedDB<
+  DB,
+  TB extends keyof DB,
+  A extends keyof any,
+  R
+> = DrainOuterGeneric<{
   [C in keyof DB | A]: C extends A
     ? R
     : C extends TB
@@ -1145,7 +1152,7 @@ type RightJoinedDB<DB, TB extends keyof DB, A extends keyof any, R> = {
     : C extends keyof DB
     ? DB[C]
     : never
-}
+}>
 
 export type DeleteQueryBuilderWithFullJoin<
   DB,
@@ -1172,7 +1179,12 @@ type OuterJoinedBuilder<
   R
 > = DeleteQueryBuilder<OuterJoinedBuilderDB<DB, TB, A, R>, TB | A, O>
 
-type OuterJoinedBuilderDB<DB, TB extends keyof DB, A extends keyof any, R> = {
+type OuterJoinedBuilderDB<
+  DB,
+  TB extends keyof DB,
+  A extends keyof any,
+  R
+> = DrainOuterGeneric<{
   [C in keyof DB | A]: C extends A
     ? Nullable<R>
     : C extends TB
@@ -1180,4 +1192,4 @@ type OuterJoinedBuilderDB<DB, TB extends keyof DB, A extends keyof any, R> = {
     : C extends keyof DB
     ? DB[C]
     : never
-}
+}>

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -23,9 +23,11 @@ import {
 import { SelectQueryNode } from '../operation-node/select-query-node.js'
 import { QueryNode } from '../operation-node/query-node.js'
 import {
+  DrainOuterGeneric,
   MergePartial,
   NarrowPartial,
   Nullable,
+  ShallowRecord,
   Simplify,
   SimplifySingleResult,
 } from '../util/type-utils.js'
@@ -2050,11 +2052,11 @@ type InnerJoinedBuilder<
 > = A extends keyof DB
   ? SelectQueryBuilder<InnerJoinedDB<DB, A, R>, TB | A, O>
   : // Much faster non-recursive solution for the simple case.
-    SelectQueryBuilder<DB & Record<A, R>, TB | A, O>
+    SelectQueryBuilder<DB & ShallowRecord<A, R>, TB | A, O>
 
-type InnerJoinedDB<DB, A extends string, R> = {
+type InnerJoinedDB<DB, A extends string, R> = DrainOuterGeneric<{
   [C in keyof DB | A]: C extends A ? R : C extends keyof DB ? DB[C] : never
-}
+}>
 
 export type SelectQueryBuilderWithLeftJoin<
   DB,
@@ -2082,15 +2084,15 @@ type LeftJoinedBuilder<
 > = A extends keyof DB
   ? SelectQueryBuilder<LeftJoinedDB<DB, A, R>, TB | A, O>
   : // Much faster non-recursive solution for the simple case.
-    SelectQueryBuilder<DB & Record<A, Nullable<R>>, TB | A, O>
+    SelectQueryBuilder<DB & ShallowRecord<A, Nullable<R>>, TB | A, O>
 
-type LeftJoinedDB<DB, A extends keyof any, R> = {
+type LeftJoinedDB<DB, A extends keyof any, R> = DrainOuterGeneric<{
   [C in keyof DB | A]: C extends A
     ? Nullable<R>
     : C extends keyof DB
     ? DB[C]
     : never
-}
+}>
 
 export type SelectQueryBuilderWithRightJoin<
   DB,
@@ -2117,7 +2119,12 @@ type RightJoinedBuilder<
   R
 > = SelectQueryBuilder<RightJoinedDB<DB, TB, A, R>, TB | A, O>
 
-type RightJoinedDB<DB, TB extends keyof DB, A extends keyof any, R> = {
+type RightJoinedDB<
+  DB,
+  TB extends keyof DB,
+  A extends keyof any,
+  R
+> = DrainOuterGeneric<{
   [C in keyof DB | A]: C extends A
     ? R
     : C extends TB
@@ -2125,7 +2132,7 @@ type RightJoinedDB<DB, TB extends keyof DB, A extends keyof any, R> = {
     : C extends keyof DB
     ? DB[C]
     : never
-}
+}>
 
 export type SelectQueryBuilderWithFullJoin<
   DB,
@@ -2152,7 +2159,12 @@ type OuterJoinedBuilder<
   R
 > = SelectQueryBuilder<OuterJoinedBuilderDB<DB, TB, A, R>, TB | A, O>
 
-type OuterJoinedBuilderDB<DB, TB extends keyof DB, A extends keyof any, R> = {
+type OuterJoinedBuilderDB<
+  DB,
+  TB extends keyof DB,
+  A extends keyof any,
+  R
+> = DrainOuterGeneric<{
   [C in keyof DB | A]: C extends A
     ? Nullable<R>
     : C extends TB
@@ -2160,4 +2172,4 @@ type OuterJoinedBuilderDB<DB, TB extends keyof DB, A extends keyof any, R> = {
     : C extends keyof DB
     ? DB[C]
     : never
-}
+}>

--- a/src/schema/create-index-builder.ts
+++ b/src/schema/create-index-builder.ts
@@ -23,7 +23,7 @@ import {
 } from '../parser/binary-operation-parser.js'
 import { QueryNode } from '../operation-node/query-node.js'
 import { ExpressionBuilder } from '../expression/expression-builder.js'
-import { SqlBool } from '../util/type-utils.js'
+import { ShallowRecord, SqlBool } from '../util/type-utils.js'
 import { ImmediateValueTransformer } from '../plugin/immediate-value/immediate-value-transformer.js'
 
 export class CreateIndexBuilder<C = never>
@@ -224,7 +224,10 @@ export class CreateIndexBuilder<C = never>
 
   where(
     factory: (
-      qb: ExpressionBuilder<Record<string, Record<C & string, any>>, string>
+      qb: ExpressionBuilder<
+        ShallowRecord<string, ShallowRecord<C & string, any>>,
+        string
+      >
     ) => Expression<SqlBool>
   ): CreateIndexBuilder<C>
 

--- a/src/util/column-type.ts
+++ b/src/util/column-type.ts
@@ -1,4 +1,4 @@
-import { DrainOuterGeneric } from './type-utils'
+import { DrainOuterGeneric } from './type-utils.js'
 
 /**
  * This type can be used to specify a different type for

--- a/src/util/column-type.ts
+++ b/src/util/column-type.ts
@@ -1,3 +1,5 @@
+import { DrainOuterGeneric } from './type-utils'
+
 /**
  * This type can be used to specify a different type for
  * select, insert and update operations.
@@ -107,9 +109,11 @@ export type NonNullableInsertKeys<R> = {
 /**
  * Keys of `R` whose `SelectType` values are not `never`
  */
-type NonNeverSelectKeys<R> = {
-  [K in keyof R]: IfNotNever<SelectType<R[K]>, K>
-}[keyof R]
+type NonNeverSelectKeys<R> = DrainOuterGeneric<
+  {
+    [K in keyof R]: IfNotNever<SelectType<R[K]>, K>
+  }[keyof R]
+>
 
 /**
  * Keys of `R` whose `UpdateType` values are not `never`
@@ -139,9 +143,9 @@ export type UpdateKeys<R> = {
  * // }
  * ```
  */
-export type Selectable<R> = {
+export type Selectable<R> = DrainOuterGeneric<{
   [K in NonNeverSelectKeys<R>]: SelectType<R[K]>
-}
+}>
 
 /**
  * Given a table interface, extracts the insert type from all

--- a/src/util/object-utils.ts
+++ b/src/util/object-utils.ts
@@ -1,4 +1,4 @@
-import { ShallowRecord } from './type-utils'
+import { ShallowRecord } from './type-utils.js'
 
 export function isEmpty(obj: ArrayLike<unknown> | string | object): boolean {
   if (Array.isArray(obj) || isString(obj) || isBuffer(obj)) {

--- a/src/util/object-utils.ts
+++ b/src/util/object-utils.ts
@@ -1,3 +1,5 @@
+import { ShallowRecord } from './type-utils'
+
 export function isEmpty(obj: ArrayLike<unknown> | string | object): boolean {
   if (Array.isArray(obj) || isString(obj) || isBuffer(obj)) {
     return obj.length === 0
@@ -46,7 +48,7 @@ export function isFunction(obj: unknown): obj is Function {
   return typeof obj === 'function'
 }
 
-export function isObject(obj: unknown): obj is Record<string, unknown> {
+export function isObject(obj: unknown): obj is ShallowRecord<string, unknown> {
   return typeof obj === 'object' && obj !== null
 }
 

--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -35,10 +35,12 @@ import { KyselyTypeError } from './type-error.js'
  * // Columns == 'id' | 'name' | 'species'
  * ```
  */
-export type AnyColumn<DB, TB extends keyof DB> = {
-  [T in TB]: keyof DB[T]
-}[TB] &
-  string
+export type AnyColumn<DB, TB extends keyof DB> = DrainOuterGeneric<
+  {
+    [T in TB]: keyof DB[T]
+  }[TB] &
+    string
+>
 
 /**
  * Extracts a column type.
@@ -134,7 +136,7 @@ export type SimplifyResult<O> = O extends InsertResult
   ? O
   : Simplify<O>
 
-export type Simplify<T> = { [K in keyof T]: T[K] } & {}
+export type Simplify<T> = DrainOuterGeneric<{ [K in keyof T]: T[K] } & {}>
 
 /**
  * Represents a database row whose column names and their types are unknown.
@@ -166,7 +168,9 @@ export type Nullable<T> = { [P in keyof T]: T[P] | null }
  *
  * // { name: string, age: number, species?: 'cat' | 'dog' }
  */
-export type MergePartial<T1, T2> = T1 & Partial<Omit<T2, keyof T1>>
+export type MergePartial<T1, T2> = DrainOuterGeneric<
+  T1 & Partial<Omit<T2, keyof T1>>
+>
 
 /**
  * Evaluates to `true` if `T` is `never`.
@@ -187,12 +191,45 @@ export type Equals<T, U> = (<G>() => G extends T ? 1 : 2) extends <
   ? true
   : false
 
-export type NarrowPartial<S, T> = {
+export type NarrowPartial<S, T> = DrainOuterGeneric<{
   [K in keyof S & string]: K extends keyof T
     ? T[K] extends S[K]
       ? T[K]
       : KyselyTypeError<`$narrowType() call failed: passed type does not exist in '${K}'s type union`>
     : S[K]
-}
+}>
 
 export type SqlBool = boolean | 0 | 1
+
+/**
+ * Utility to reduce depth of TypeScript's internal type instantiation stack.
+ *
+ * Example:
+ *
+ * ```ts
+ * type A<T> = { item: T }
+ *
+ * type Test<T> = A<
+ *   A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<T>>>>>>>>>>>>>>>>>>>>>>>>
+ * >
+ *
+ * type Error = Test<number> // Type instantiation is excessively deep and possibly infinite.ts (2589)
+ * ```
+ *
+ * To fix this, we can use `DrainOuterGeneric`:
+ *
+ * ```ts
+ * type A<T> = DrainOuterGeneric<{ item: T }>
+ *
+ * type Test<T> = A<
+ *  A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<T>>>>>>>>>>>>>>>>>>>>>>>>
+ * >
+ *
+ * type Ok = Test<number> // Ok
+ * ```
+ */
+export type DrainOuterGeneric<T> = [T] extends [unknown] ? T : never
+
+export type ShallowRecord<K extends keyof any, T> = DrainOuterGeneric<{
+  [P in K]: T
+}>

--- a/test/typings/test-d/with.test-d.ts
+++ b/test/typings/test-d/with.test-d.ts
@@ -80,36 +80,11 @@ async function testWith(db: Kysely<Database>) {
 
 async function testManyWith(db: Kysely<Database>) {
   const res = await db
-    .with('w1', (eb) =>
-      eb
-        .selectFrom('person')
-        .select('first_name as fn1')
-        .$assertType<{ fn1: string }>()
-    )
-    .with('w2', (eb) =>
-      eb
-        .selectFrom('person')
-        .select('first_name as fn2')
-        .$assertType<{ fn2: string }>()
-    )
-    .with('w3', (eb) =>
-      eb
-        .selectFrom('person')
-        .select('first_name as fn3')
-        .$assertType<{ fn3: string }>()
-    )
-    .with('w4', (eb) =>
-      eb
-        .selectFrom('person')
-        .select('first_name as fn4')
-        .$assertType<{ fn4: string }>()
-    )
-    .with('w5', (eb) =>
-      eb
-        .selectFrom('person')
-        .select('first_name as fn5')
-        .$assertType<{ fn5: string }>()
-    )
+    .with('w1', (eb) => eb.selectFrom('person').select('first_name as fn1'))
+    .with('w2', (eb) => eb.selectFrom('person').select('first_name as fn2'))
+    .with('w3', (eb) => eb.selectFrom('person').select('first_name as fn3'))
+    .with('w4', (eb) => eb.selectFrom('person').select('first_name as fn4'))
+    .with('w5', (eb) => eb.selectFrom('person').select('first_name as fn5'))
     .with('w6', (eb) => eb.selectFrom('person').select('first_name as fn6'))
     .with('w7', (qb) => qb.selectFrom('person').select('first_name as fn7'))
     .with('w8', (qb) => qb.selectFrom('person').select('first_name as fn8'))
@@ -131,6 +106,10 @@ async function testManyWith(db: Kysely<Database>) {
     ])
     .selectAll()
     .executeTakeFirstOrThrow()
+
+  type IsAny<T> = 0 extends 1 & T ? true : false
+  type ResIsAny = IsAny<typeof res>
+  expectType<ResIsAny>(false)
 
   expectType<{
     fn1: string

--- a/test/typings/test-d/with.test-d.ts
+++ b/test/typings/test-d/with.test-d.ts
@@ -107,10 +107,6 @@ async function testManyWith(db: Kysely<Database>) {
     .selectAll()
     .executeTakeFirstOrThrow()
 
-  type IsAny<T> = 0 extends 1 & T ? true : false
-  type ResIsAny = IsAny<typeof res>
-  expectType<ResIsAny>(false)
-
   expectType<{
     fn1: string
     fn2: string


### PR DESCRIPTION
Closes #481

Background: TS treats differently simple type alias with generic parameters and type alias which uses conditional type inside. In particular using a conditional type instead of a simple generic doesn't create a new level of nesting. This feature allows us to create deep types without encountering "Type instantiation is excessively deep and possibly infinite" error.

In this PR I added `DrainOuterGeneric` type which transforms original type to conditional, and therefore removes outer generic type wrapper and reduces instantiation depth. Next I replaced every Record with ShallowRecord (the same type but without wrapper). But the key change was to wrap in `DrainOuterGeneric` every "simple" generic type alias located in the return type of query builders methods.

With this relatively small changes we're now able to safely remove every $assertType calls in `test/typings/test-d/with.test-d.ts`.

Also as a side effect it improves performance of type checking by 13%.

Running `npm run test:typings` before changes.
<img width="431" alt="Screenshot 2023-05-12 at 00 29 34" src="https://github.com/kysely-org/kysely/assets/16702275/6951f59d-2fb8-4b1d-a979-c73128c73a84">

Running `npm run test:typings` after changes.
<img width="431" alt="Screenshot 2023-05-12 at 00 32 53" src="https://github.com/kysely-org/kysely/assets/16702275/4324ee5c-713b-4fda-8c86-66b6fd7e1350">
