### PR TITLE
Consistently used sqlite_master for compatibility with older SQLite versions

### DIFF
--- a/src/dialect/sqlite/sqlite-introspector.ts
+++ b/src/dialect/sqlite/sqlite-introspector.ts
@@ -28,7 +28,7 @@ export class SqliteIntrospector implements DatabaseIntrospector {
     options: DatabaseMetadataOptions = { withInternalKyselyTables: false }
   ): Promise<TableMetadata[]> {
     let query = this.#db
-      .selectFrom('sqlite_schema')
+      .selectFrom('sqlite_master')
       .where('type', 'in', ['table', 'view'])
       .where('name', 'not like', 'sqlite_%')
       .select('name')


### PR DESCRIPTION
There is a mismatch in the schema name being used in the inspector, in one query sqlite_schema is used, then directly after sqlite_master is used.  They renamed sqlite_master to sqlite_schema, but both exist at this point and will for the foreseeable future.  

In 3.33.0 created an alias for sqlite_master, sqlite_schema.

See:

https://sqlite.org/forum/forumpost/d90adfbb0a

Thanks!