### PR TITLE
small mistake in Getting Started/Types

### DIFF
--- a/site/docs/getting-started/_types.mdx
+++ b/site/docs/getting-started/_types.mdx
@@ -6,7 +6,7 @@ values.
 **Let's define our first database interface:**
 
 ```ts title="src/types.ts"
-import { ColumnType, Generated, Insertable, Selectable, Updatable } from 'kysely'
+import { ColumnType, Generated, Insertable, Selectable, Updateable } from 'kysely'
 
 export interface Database {
   person: PersonTable


### PR DESCRIPTION
the code example in getting started/types part imports Updatable (which doesn't exist) instead of Updateable