### PR TITLE
docs(getting started): add clarification to Types section

### DIFF
--- a/site/docs/getting-started/_types.mdx
+++ b/site/docs/getting-started/_types.mdx
@@ -58,6 +58,6 @@ export type EditedPet = Updateable<PetTable>
 
 For production apps, it is recommended to automatically generate your <code>Database</code>
 interface by introspecting your production database or Prisma schemas. Generated types
-might differ in naming convention, internal order, etc. Find out more at ["Generating types"(https://kysely.dev/docs/generating-types).
+might differ in naming convention, internal order, etc. Find out more at ["Generating types"](https://kysely.dev/docs/generating-types).
 
 :::

--- a/site/docs/getting-started/_types.mdx
+++ b/site/docs/getting-started/_types.mdx
@@ -57,8 +57,7 @@ export type EditedPet = Updateable<PetTable>
 :::tip Codegen
 
 For production apps, it is recommended to automatically generate your <code>Database</code>
-interface by introspecting your production database or Prisma schemas. Find out more at
-["Generating types"](https://kysely.dev/docs/generating-types).
-Consider that automatic code generation could lead to different naming and structure of this file, for example the Database interface could be named DB and placed at the bottom.
+interface by introspecting your production database or Prisma schemas. Generated types
+might differ in naming convention, internal order, etc. Find out more at ["Generating types"(https://kysely.dev/docs/generating-types).
 
 :::

--- a/site/docs/getting-started/_types.mdx
+++ b/site/docs/getting-started/_types.mdx
@@ -59,5 +59,6 @@ export type EditedPet = Updateable<PetTable>
 For production apps, it is recommended to automatically generate your <code>Database</code>
 interface by introspecting your production database or Prisma schemas. Find out more at
 ["Generating types"](https://kysely.dev/docs/generating-types).
+Consider that automatic code generation could lead to different naming and structure of this file, for example the Database interface could be named DB and placed at the bottom.
 
 :::


### PR DESCRIPTION
Clarifying that automatic generation of the Database interface could lead to a different file of the one shown currently in the documentation, by warning readers of this could help saving some time if they find mismatches, this happened to me while using `prisma-kysely` package.