### PR TITLE
Update outdated alterColumn function call example

### DIFF
--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -201,8 +201,7 @@ export class SchemaModule {
    * ```ts
    * await db.schema
    *   .alterTable('person')
-   *   .alterColumn('first_name')
-   *   .setDataType('text')
+   *   .alterColumn('first_name', (ac) => ac.setDataType('text'))
    *   .execute()
    * ```
    */


### PR DESCRIPTION
This function call syntax was changed in the breaking change noted in https://github.com/kysely-org/kysely/releases/tag/0.23.0

Thanks!