### PR TITLE
fix `onConflict` compilation errors since TS 5.1.6.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "sinon": "^15.1.0",
         "tsd": "^0.28.1",
         "typedoc": "^0.24.8",
-        "typescript": "5.1.3"
+        "typescript": "^5.1.6"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3653,9 +3653,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,6 @@
     "sinon": "^15.1.0",
     "tsd": "^0.28.1",
     "typedoc": "^0.24.8",
-    "typescript": "5.1.3"
+    "typescript": "^5.1.6"
   }
 }

--- a/src/query-builder/insert-query-builder.ts
+++ b/src/query-builder/insert-query-builder.ts
@@ -45,7 +45,9 @@ import { ColumnNode } from '../operation-node/column-node.js'
 import { ReturningInterface } from './returning-interface.js'
 import {
   OnConflictBuilder,
+  OnConflictDatabase,
   OnConflictDoNothingBuilder,
+  OnConflictTables,
   OnConflictUpdateBuilder,
 } from './on-conflict-builder.js'
 import { OnConflictNode } from '../operation-node/on-conflict-node.js'
@@ -487,7 +489,12 @@ export class InsertQueryBuilder<DB, TB extends keyof DB, O>
   onConflict(
     callback: (
       builder: OnConflictBuilder<DB, TB>
-    ) => OnConflictDoNothingBuilder<DB, TB> | OnConflictUpdateBuilder<DB, TB>
+    ) =>
+      | OnConflictUpdateBuilder<
+          OnConflictDatabase<DB, TB>,
+          OnConflictTables<TB>
+        >
+      | OnConflictDoNothingBuilder
   ): InsertQueryBuilder<DB, TB, O> {
     return new InsertQueryBuilder({
       ...this.#props,

--- a/src/query-builder/insert-query-builder.ts
+++ b/src/query-builder/insert-query-builder.ts
@@ -494,7 +494,7 @@ export class InsertQueryBuilder<DB, TB extends keyof DB, O>
           OnConflictDatabase<DB, TB>,
           OnConflictTables<TB>
         >
-      | OnConflictDoNothingBuilder
+      | OnConflictDoNothingBuilder<DB, TB>
   ): InsertQueryBuilder<DB, TB, O> {
     return new InsertQueryBuilder({
       ...this.#props,

--- a/src/query-builder/on-conflict-builder.ts
+++ b/src/query-builder/on-conflict-builder.ts
@@ -289,7 +289,7 @@ export class OnConflictBuilder<DB, TB extends keyof DB>
    * on conflict ("pic") do nothing
    * ```
    */
-  doNothing(): OnConflictDoNothingBuilder {
+  doNothing(): OnConflictDoNothingBuilder<DB, TB> {
     return new OnConflictDoNothingBuilder({
       ...this.#props,
       onConflictNode: OnConflictNode.cloneWith(this.#props.onConflictNode, {
@@ -374,7 +374,9 @@ export type OnConflictDatabase<DB, TB extends keyof DB> = {
 
 export type OnConflictTables<TB> = TB | 'excluded'
 
-export class OnConflictDoNothingBuilder implements OperationNodeSource {
+export class OnConflictDoNothingBuilder<DB, TB extends keyof DB>
+  implements OperationNodeSource
+{
   readonly #props: OnConflictBuilderProps
 
   constructor(props: OnConflictBuilderProps) {

--- a/src/query-builder/on-conflict-builder.ts
+++ b/src/query-builder/on-conflict-builder.ts
@@ -289,7 +289,7 @@ export class OnConflictBuilder<DB, TB extends keyof DB>
    * on conflict ("pic") do nothing
    * ```
    */
-  doNothing(): OnConflictDoNothingBuilder<DB, TB> {
+  doNothing(): OnConflictDoNothingBuilder {
     return new OnConflictDoNothingBuilder({
       ...this.#props,
       onConflictNode: OnConflictNode.cloneWith(this.#props.onConflictNode, {
@@ -374,9 +374,7 @@ export type OnConflictDatabase<DB, TB extends keyof DB> = {
 
 export type OnConflictTables<TB> = TB | 'excluded'
 
-export class OnConflictDoNothingBuilder<DB, TB extends keyof DB>
-  implements OperationNodeSource
-{
+export class OnConflictDoNothingBuilder implements OperationNodeSource {
   readonly #props: OnConflictBuilderProps
 
   constructor(props: OnConflictBuilderProps) {


### PR DESCRIPTION
closes #567.

Seems like a bug in both TypeScript (up to 5.1.3) and in our codebase. We provided an expected return type that can never be matched by call site, and TypeScript never yelled.

And looks like they fixed it in 5.1.6?? 🤷 

`.doUpdateSet` return type:

```ts
OnConflictUpdateBuilder<OnConflictDatabase<DB, TB>, OnConflictTables<TB>>
```
vs.

`.onConflict`'s `callback` argument's return type:

```ts
OnConflictDoNothingBuilder<DB, TB> | OnConflictUpdateBuilder<DB, TB>
```