### PR TITLE
Support materialized CTEs using CTE builder

### DIFF
--- a/src/operation-node/common-table-expression-node.ts
+++ b/src/operation-node/common-table-expression-node.ts
@@ -2,9 +2,15 @@ import { freeze } from '../util/object-utils.js'
 import { CommonTableExpressionNameNode } from './common-table-expression-name-node.js'
 import { OperationNode } from './operation-node.js'
 
+type CommonTableExpressionNodeProps = Pick<
+  CommonTableExpressionNode,
+  'materialized'
+>
+
 export interface CommonTableExpressionNode extends OperationNode {
   readonly kind: 'CommonTableExpressionNode'
   readonly name: CommonTableExpressionNameNode
+  readonly materialized?: boolean
   readonly expression: OperationNode
 }
 
@@ -24,6 +30,16 @@ export const CommonTableExpressionNode = freeze({
       kind: 'CommonTableExpressionNode',
       name,
       expression,
+    })
+  },
+
+  cloneWith(
+    node: CommonTableExpressionNode,
+    props: CommonTableExpressionNodeProps
+  ): CommonTableExpressionNode {
+    return freeze({
+      ...node,
+      ...props,
     })
   },
 })

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -642,6 +642,7 @@ export class OperationNodeTransformer {
     return requireAllProps<CommonTableExpressionNode>({
       kind: 'CommonTableExpressionNode',
       name: this.transformNode(node.name),
+      materialized: node.materialized,
       expression: this.transformNode(node.expression),
     })
   }

--- a/src/parser/join-parser.ts
+++ b/src/parser/join-parser.ts
@@ -43,8 +43,7 @@ function parseCallbackJoin(
   from: TableExpression<any, any>,
   callback: JoinCallbackExpression<any, any, any>
 ): JoinNode {
-  const joinBuilder = callback(createJoinBuilder(joinType, from))
-  return joinBuilder.toOperationNode()
+  return callback(createJoinBuilder(joinType, from)).toOperationNode()
 }
 
 function parseSingleOnJoin(

--- a/src/query-builder/cte-builder.ts
+++ b/src/query-builder/cte-builder.ts
@@ -1,0 +1,48 @@
+import { OperationNodeSource } from '../operation-node/operation-node-source.js'
+import { CommonTableExpressionNode } from '../operation-node/common-table-expression-node.js'
+import { preventAwait } from '../util/prevent-await.js'
+import { freeze } from '../util/object-utils.js'
+
+export class CTEBuilder<N extends string> implements OperationNodeSource {
+  readonly #props: CTEBuilderProps
+
+  constructor(props: CTEBuilderProps) {
+    this.#props = freeze(props)
+  }
+
+  asMaterialized(): CTEBuilder<N> {
+    return new CTEBuilder({
+      ...this.#props,
+      node: CommonTableExpressionNode.cloneWith(this.#props.node, {
+        materialized: true,
+      }),
+    })
+  }
+
+  asNotMaterialized(): CTEBuilder<N> {
+    return new CTEBuilder({
+      ...this.#props,
+      node: CommonTableExpressionNode.cloneWith(this.#props.node, {
+        materialized: false,
+      }),
+    })
+  }
+
+  toOperationNode(): CommonTableExpressionNode {
+    return this.#props.node
+  }
+}
+
+preventAwait(
+  CTEBuilder,
+  "don't await CTEBuilder instances. They are never executed directly and are always just a part of a query."
+)
+
+interface CTEBuilderProps {
+  readonly node: CommonTableExpressionNode
+}
+
+export type CTEBuilderCallback<N extends string> = (
+  // N2 is needed for proper inference. Don't remove it.
+  cte: <N2 extends string>(name: N2) => CTEBuilder<N2>
+) => CTEBuilder<N>

--- a/src/query-builder/cte-builder.ts
+++ b/src/query-builder/cte-builder.ts
@@ -10,6 +10,9 @@ export class CTEBuilder<N extends string> implements OperationNodeSource {
     this.#props = freeze(props)
   }
 
+  /**
+   * Makes the common table expression materialized.
+   */
   materialized(): CTEBuilder<N> {
     return new CTEBuilder({
       ...this.#props,
@@ -19,6 +22,9 @@ export class CTEBuilder<N extends string> implements OperationNodeSource {
     })
   }
 
+  /**
+   * Makes the common table expression not materialized.
+   */
   notMaterialized(): CTEBuilder<N> {
     return new CTEBuilder({
       ...this.#props,

--- a/src/query-builder/cte-builder.ts
+++ b/src/query-builder/cte-builder.ts
@@ -10,7 +10,7 @@ export class CTEBuilder<N extends string> implements OperationNodeSource {
     this.#props = freeze(props)
   }
 
-  asMaterialized(): CTEBuilder<N> {
+  materialized(): CTEBuilder<N> {
     return new CTEBuilder({
       ...this.#props,
       node: CommonTableExpressionNode.cloneWith(this.#props.node, {
@@ -19,7 +19,7 @@ export class CTEBuilder<N extends string> implements OperationNodeSource {
     })
   }
 
-  asNotMaterialized(): CTEBuilder<N> {
+  notMaterialized(): CTEBuilder<N> {
     return new CTEBuilder({
       ...this.#props,
       node: CommonTableExpressionNode.cloneWith(this.#props.node, {

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -938,6 +938,15 @@ export class DefaultQueryCompiler
   ): void {
     this.visitNode(node.name)
     this.append(' as ')
+
+    if (isBoolean(node.materialized)) {
+      if (node.materialized) {
+        this.append('materialized ')
+      } else {
+        this.append('not materialized ')
+      }
+    }
+
     this.visitNode(node.expression)
   }
 

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -940,11 +940,11 @@ export class DefaultQueryCompiler
     this.append(' as ')
 
     if (isBoolean(node.materialized)) {
-      if (node.materialized) {
-        this.append('materialized ')
-      } else {
-        this.append('not materialized ')
+      if (!node.materialized) {
+        this.append('not ')
       }
+      
+      this.append('materialized ')
     }
 
     this.visitNode(node.expression)

--- a/src/query-creator.ts
+++ b/src/query-creator.ts
@@ -454,6 +454,23 @@ export class QueryCreator<DB> {
    *   .selectAll()
    *   .execute()
    * ```
+   *
+   * The first argument can also be a callback. The callback is passed
+   * a `CTEBuilder` instance that can be used to configure the CTE:
+   *
+   * ```ts
+   * await db
+   *   .with(
+   *     (cte) => cte('jennifers').materialized(),
+   *     (db) => db
+   *       .selectFrom('person')
+   *       .where('first_name', '=', 'Jennifer')
+   *       .select(['id', 'age'])
+   *   )
+   *   .selectFrom('jennifers')
+   *   .selectAll()
+   *   .execute()
+   * ```
    */
   with<N extends string, E extends CommonTableExpression<DB, N>>(
     nameOrBuilder: N | CTEBuilderCallback<N>,
@@ -471,6 +488,11 @@ export class QueryCreator<DB> {
 
   /**
    * Creates a recursive `with` query (Common Table Expression).
+   *
+   * Note that recursiveness is a property of the whole `with` statement.
+   * You cannot have recursive and non-recursive CTEs in a same `with` statement.
+   * Therefore the recursiveness is determined by the **first** `with` or
+   * `withRecusive` call you make.
    *
    * See the {@link with} method for examples and more documentation.
    */

--- a/src/query-creator.ts
+++ b/src/query-creator.ts
@@ -23,9 +23,9 @@ import {
 import { QueryExecutor } from './query-executor/query-executor.js'
 import {
   CommonTableExpression,
-  parseCommonTableExpression,
   QueryCreatorWithCommonTableExpression,
   RecursiveCommonTableExpression,
+  parseCommonTableExpression,
 } from './parser/with-parser.js'
 import { WithNode } from './operation-node/with-node.js'
 import { createQueryId } from './util/query-id.js'
@@ -35,6 +35,7 @@ import { InsertResult } from './query-builder/insert-result.js'
 import { DeleteResult } from './query-builder/delete-result.js'
 import { UpdateResult } from './query-builder/update-result.js'
 import { KyselyPlugin } from './plugin/kysely-plugin.js'
+import { CTEBuilderCallback } from './query-builder/cte-builder.js'
 
 export class QueryCreator<DB> {
   readonly #props: QueryCreatorProps
@@ -455,10 +456,10 @@ export class QueryCreator<DB> {
    * ```
    */
   with<N extends string, E extends CommonTableExpression<DB, N>>(
-    name: N,
+    nameOrBuilder: N | CTEBuilderCallback<N>,
     expression: E
   ): QueryCreatorWithCommonTableExpression<DB, N, E> {
-    const cte = parseCommonTableExpression(name, expression)
+    const cte = parseCommonTableExpression(nameOrBuilder, expression)
 
     return new QueryCreator({
       ...this.#props,
@@ -476,8 +477,11 @@ export class QueryCreator<DB> {
   withRecursive<
     N extends string,
     E extends RecursiveCommonTableExpression<DB, N>
-  >(name: N, expression: E): QueryCreatorWithCommonTableExpression<DB, N, E> {
-    const cte = parseCommonTableExpression(name, expression)
+  >(
+    nameOrBuilder: N | CTEBuilderCallback<N>,
+    expression: E
+  ): QueryCreatorWithCommonTableExpression<DB, N, E> {
+    const cte = parseCommonTableExpression(nameOrBuilder, expression)
 
     return new QueryCreator({
       ...this.#props,

--- a/test/node/src/with.test.ts
+++ b/test/node/src/with.test.ts
@@ -182,7 +182,7 @@ for (const dialect of DIALECTS) {
       it('should create a CTE with `as materialized`', async () => {
         const query = ctx.db
           .with(
-            (cte) => cte('person_name').asMaterialized(),
+            (cte) => cte('person_name').materialized(),
             (qb) => qb.selectFrom('person').select('first_name')
           )
           .selectFrom('person_name')
@@ -209,7 +209,7 @@ for (const dialect of DIALECTS) {
       it('should create a CTE with `as not materialized`', async () => {
         const query = ctx.db
           .with(
-            (cte) => cte('person_name').asNotMaterialized(),
+            (cte) => cte('person_name').notMaterialized(),
             (qb) => qb.selectFrom('person').select('first_name')
           )
           .selectFrom('person_name')

--- a/test/node/src/with.test.ts
+++ b/test/node/src/with.test.ts
@@ -178,6 +178,60 @@ for (const dialect of DIALECTS) {
           ])
         })
       })
+
+      it('should create a CTE with `as materialized`', async () => {
+        const query = ctx.db
+          .with(
+            (cte) => cte('person_name').asMaterialized(),
+            (qb) => qb.selectFrom('person').select('first_name')
+          )
+          .selectFrom('person_name')
+          .select('person_name.first_name')
+          .orderBy('first_name')
+
+        testSql(query, dialect, {
+          postgres: {
+            sql: 'with "person_name" as materialized (select "first_name" from "person") select "person_name"."first_name" from "person_name" order by "first_name"',
+            parameters: [],
+          },
+          mysql: NOT_SUPPORTED,
+          sqlite: NOT_SUPPORTED,
+        })
+
+        const result = await query.execute()
+        expect(result).to.eql([
+          { first_name: 'Arnold' },
+          { first_name: 'Jennifer' },
+          { first_name: 'Sylvester' },
+        ])
+      })
+
+      it('should create a CTE with `as not materialized`', async () => {
+        const query = ctx.db
+          .with(
+            (cte) => cte('person_name').asNotMaterialized(),
+            (qb) => qb.selectFrom('person').select('first_name')
+          )
+          .selectFrom('person_name')
+          .select('person_name.first_name')
+          .orderBy('first_name')
+
+        testSql(query, dialect, {
+          postgres: {
+            sql: 'with "person_name" as not materialized (select "first_name" from "person") select "person_name"."first_name" from "person_name" order by "first_name"',
+            parameters: [],
+          },
+          mysql: NOT_SUPPORTED,
+          sqlite: NOT_SUPPORTED,
+        })
+
+        const result = await query.execute()
+        expect(result).to.eql([
+          { first_name: 'Arnold' },
+          { first_name: 'Jennifer' },
+          { first_name: 'Sylvester' },
+        ])
+      })
     }
 
     if (dialect !== 'mysql') {

--- a/test/typings/test-d/with.test-d.ts
+++ b/test/typings/test-d/with.test-d.ts
@@ -67,7 +67,7 @@ async function testWith(db: Kysely<Database>) {
   // Using CTE builder.
   const r4 = await db
     .with(
-      (cte) => cte('jennifers').asMaterialized(),
+      (cte) => cte('jennifers').materialized(),
       (db) =>
         db
           .selectFrom('person')
@@ -102,7 +102,7 @@ async function testWith(db: Kysely<Database>) {
   expectError(
     db
       .with(
-        (cte) => cte('jennifers').asMaterialized(),
+        (cte) => cte('jennifers').materialized(),
         (db) =>
           db
             .selectFrom('person')

--- a/test/typings/test-d/with.test-d.ts
+++ b/test/typings/test-d/with.test-d.ts
@@ -64,6 +64,27 @@ async function testWith(db: Kysely<Database>) {
     }[]
   >(r3)
 
+  // Using CTE builder.
+  const r4 = await db
+    .with(
+      (cte) => cte('jennifers').asMaterialized(),
+      (db) =>
+        db
+          .selectFrom('person')
+          .where('first_name', '=', 'Jennifer')
+          .select(['first_name', 'last_name as ln', 'gender'])
+    )
+    .selectFrom('jennifers')
+    .select(['first_name', 'ln'])
+    .execute()
+
+  expectType<
+    {
+      first_name: string
+      ln: string | null
+    }[]
+  >(r4)
+
   // Different columns in expression and CTE name.
   expectError(
     db
@@ -75,6 +96,22 @@ async function testWith(db: Kysely<Database>) {
       )
       .selectFrom('jennifers')
       .select(['first_name', 'last_name'])
+  )
+
+  // Unknown CTE name when using the CTE builder.
+  expectError(
+    db
+      .with(
+        (cte) => cte('jennifers').asMaterialized(),
+        (db) =>
+          db
+            .selectFrom('person')
+            .where('first_name', '=', 'Jennifer')
+            .select(['first_name', 'last_name as ln', 'gender'])
+      )
+      .selectFrom('lollifers')
+      .select(['first_name', 'ln'])
+      .execute()
   )
 }
 


### PR DESCRIPTION
The first argument of `with` can now be a callback that's given a CTE builder. The CTE builder can be used to create the common table expression statement.

```ts
db.with(
    (cte) => cte('jennifers').materialized(),
    (db) =>
      db
        .selectFrom('person')
        .where('first_name', '=', 'Jennifer')
        .select(['first_name', 'last_name as ln', 'gender'])
  )
  .selectFrom('jennifers')
  .select(['first_name', 'ln'])
  .execute()
```

The syntax feels natural and this way `as materialized` is "in the correct place" between the name and the query. But we're introducing a new way to do things here and I'm not sure if this a good precedent for future development, or just something completely disjoint from all other builders.

Putting the CTE builder last, after the query, also feels bad since it's in the wrong place. But that would be more in line with the other builders. 🤷

Closes #246