### PR TITLE
when traversing `Record<string, T>`, infer output type as `Nullable<T>`.

### DIFF
--- a/src/query-builder/json-path-builder.ts
+++ b/src/query-builder/json-path-builder.ts
@@ -151,6 +151,9 @@ export class JSONPathBuilder<S, O = S> {
       ? null | NonNullable<NonNullable<O>[K]>
       : null extends O
       ? null | NonNullable<NonNullable<O>[K]>
+      : // when the object has non-specific keys, e.g. Record<string, T>, should infer `T | null`!
+      string extends keyof NonNullable<O>
+      ? null | NonNullable<NonNullable<O>[K]>
       : NonNullable<O>[K]
   >(key: K): TraversedJSONPathBuilder<S, O2> {
     return this.#createBuilderWithPathLeg('Member', key)

--- a/test/typings/shared.d.ts
+++ b/test/typings/shared.d.ts
@@ -69,4 +69,6 @@ export interface PersonMetadata {
     }[]
   >
   schedule: JSONColumnType<{ name: string; time: string }[][][]>
+  record: JSONColumnType<Record<string, string>>
+  array: JSONColumnType<Array<string>>
 }

--- a/test/typings/test-d/json-traversal.test-d.ts
+++ b/test/typings/test-d/json-traversal.test-d.ts
@@ -71,6 +71,20 @@ async function testJSONTraversal(db: Kysely<Database>) {
 
   expectType<{ nickname: string | null }>(r8)
 
+  const [r9] = await db
+    .selectFrom('person_metadata')
+    .select((eb) => eb.ref('record', '->').key('i_dunno_man').as('whatever'))
+    .execute()
+
+  expectType<{ whatever: string | null }>(r9)
+
+  const [r10] = await db
+    .selectFrom('person_metadata')
+    .select((eb) => eb.ref('array', '->').at(0).as('whenever'))
+    .execute()
+
+  expectType<{ whenever: string | null }>(r10)
+
   // missing operator
 
   expectError(


### PR DESCRIPTION
Hey 👋 

We haven't handled dictionaries with wide `string` keys (`Record<string, T>`) in phase 1 (#440).
The type-safe way should be to infer `Nullable<T>` here, since there's no indication `key('blabla')` exists in the JSON object.

This PR handles this, and adds some typings tests.