### PR TITLE
Sqlite migration example

### DIFF
--- a/site/docs/getting-started/Instantiation.tsx
+++ b/site/docs/getting-started/Instantiation.tsx
@@ -47,9 +47,9 @@ const dialect = new MysqlDialect({
   sqlite: (packageManager) =>
     isDialectSupported('sqlite', packageManager)
       ? `import * as SQLite from '${DRIVER_NPM_PACKAGE_NAMES.sqlite}'
-import { Kysely, SQLiteDialect } from 'kysely'
+import { Kysely, SqliteDialect } from 'kysely'
 
-const dialect = new SQLiteDialect({
+const dialect = new SqliteDialect({
   database: new SQLite(':memory:'),
 })`
       : `/* Kysely doesn't support SQLite + ${
@@ -67,7 +67,7 @@ const dialectClassNames: Record<
   postgresql: () => 'PostgresDialect',
   mysql: () => 'MysqlDialect',
   sqlite: (packageManager) =>
-    isDialectSupported('sqlite', packageManager) ? 'SQLiteDialect' : null,
+    isDialectSupported('sqlite', packageManager) ? 'SqliteDialect' : null,
 }
 
 export function Instantiation(

--- a/site/docs/migrations.mdx
+++ b/site/docs/migrations.mdx
@@ -72,6 +72,46 @@ export async function down(db: Kysely<any>): Promise<void> {
 }
 ```
 
+## SQLite migration example
+
+```ts
+import { Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .createTable('person')
+    .addColumn('id', 'integer', (col) => col.primaryKey())
+    .addColumn('first_name', 'text', (col) => col.notNull())
+    .addColumn('last_name', 'text')
+    .addColumn('gender', 'text', (col) => col.notNull())
+    .addColumn('created_at', 'text', (col) =>
+      col.defaultTo(sql`CURRENT_TIMESTAMP`).notNull()
+    )
+    .execute()
+
+  await db.schema
+    .createTable('pet')
+    .addColumn('id', 'integer', (col) => col.primaryKey())
+    .addColumn('name', 'text', (col) => col.notNull().unique())
+    .addColumn('owner_id', 'integer', (col) =>
+      col.references('person.id').onDelete('cascade').notNull()
+    )
+    .addColumn('species', 'text', (col) => col.notNull())
+    .execute()
+
+  await db.schema
+    .createIndex('pet_owner_id_index')
+    .on('pet')
+    .column('owner_id')
+    .execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.dropTable('pet').execute()
+  await db.schema.dropTable('person').execute()
+}
+```
+
 ## Running migrations
 
 You can then use


### PR DESCRIPTION
Migration example using SQLite data types.  Parts of the PostgreSQL example are not valid SQLite syntax, such as `serial` and `now()`.

I also used the plain SQLite [data types](https://www.sqlite.org/datatype3.html), instead of their type affinity.  If you would like to use affinity types, use this snippet instead:

```ts
import { Kysely, sql } from "kysely";

export async function up(db: Kysely<any>): Promise<void> {
  await db.schema
    .createTable("person")
    .addColumn("id", "integer", (col) => col.primaryKey())
    .addColumn("first_name", "varchar", (col) => col.notNull())
    .addColumn("last_name", "varchar")
    .addColumn("gender", "varchar(50)", (col) => col.notNull())
    .addColumn("created_at", "timestamp", (col) =>
      col.defaultTo(sql`CURRENT_TIMESTAMP`).notNull()
    )
    .execute();

  await db.schema
    .createTable("pet")
    .addColumn("id", "integer", (col) => col.primaryKey())
    .addColumn("name", "varchar", (col) => col.notNull().unique())
    .addColumn("owner_id", "integer", (col) =>
      col.references("person.id").onDelete("cascade").notNull()
    )
    .addColumn("species", "varchar", (col) => col.notNull())
    .execute();

  await db.schema
    .createIndex("pet_owner_id_index")
    .on("pet")
    .column("owner_id")
    .execute();
}

export async function down(db: Kysely<any>): Promise<void> {
  await db.schema.dropTable("pet").execute();
  await db.schema.dropTable("person").execute();
}
```