### PR TITLE
Convert `SelectQueryBuilder` and `RawBuilder` to interfaces

### DIFF
--- a/scripts/generate-site-examples.js
+++ b/scripts/generate-site-examples.js
@@ -25,27 +25,27 @@ const CODE_LINE_REGEX = /\*(.*)/
 const moreExamplesByCategory = {
   select: {
     'select method':
-      'https://kysely-org.github.io/kysely/classes/SelectQueryBuilder.html#select',
+      'https://kysely-org.github.io/kysely/interfaces/SelectQueryBuilder.html#select',
     'selectAll method':
-      'https://kysely-org.github.io/kysely/classes/SelectQueryBuilder.html#selectAll',
+      'https://kysely-org.github.io/kysely/interfaces/SelectQueryBuilder.html#selectAll',
     'selectFrom method':
       'https://kysely-org.github.io/kysely/classes/Kysely.html#selectFrom',
   },
   where: {
     'where method':
-      'https://kysely-org.github.io/kysely/classes/SelectQueryBuilder.html#where',
+      'https://kysely-org.github.io/kysely/interfaces/SelectQueryBuilder.html#where',
     'whereRef method':
-      'https://kysely-org.github.io/kysely/classes/SelectQueryBuilder.html#whereRef',
+      'https://kysely-org.github.io/kysely/interfaces/SelectQueryBuilder.html#whereRef',
   },
   join: {
     'innerJoin method':
-      'https://kysely-org.github.io/kysely/classes/SelectQueryBuilder.html#innerJoin',
+      'https://kysely-org.github.io/kysely/interfaces/SelectQueryBuilder.html#innerJoin',
     'leftJoin method':
-      'https://kysely-org.github.io/kysely/classes/SelectQueryBuilder.html#leftJoin',
+      'https://kysely-org.github.io/kysely/interfaces/SelectQueryBuilder.html#leftJoin',
     'rightJoin method':
-      'https://kysely-org.github.io/kysely/classes/SelectQueryBuilder.html#rightJoin',
+      'https://kysely-org.github.io/kysely/interfaces/SelectQueryBuilder.html#rightJoin',
     'fullJoin method':
-      'https://kysely-org.github.io/kysely/classes/SelectQueryBuilder.html#fullJoin',
+      'https://kysely-org.github.io/kysely/interfaces/SelectQueryBuilder.html#fullJoin',
   },
   insert: {
     'values method':

--- a/src/expression/expression-builder.ts
+++ b/src/expression/expression-builder.ts
@@ -1,4 +1,7 @@
-import { SelectQueryBuilder } from '../query-builder/select-query-builder.js'
+import {
+  SelectQueryBuilder,
+  createSelectQueryBuilder,
+} from '../query-builder/select-query-builder.js'
 import { SelectQueryNode } from '../operation-node/select-query-node.js'
 import {
   parseTableExpressionOrList,
@@ -771,7 +774,7 @@ export function createExpressionBuilder<DB, TB extends keyof DB>(
     eb: undefined! as ExpressionBuilder<DB, TB>,
 
     selectFrom(table: TableExpressionOrList<DB, TB>): any {
-      return new SelectQueryBuilder({
+      return createSelectQueryBuilder({
         queryId: createQueryId(),
         executor: executor,
         queryNode: SelectQueryNode.create(parseTableExpressionOrList(table)),

--- a/src/parser/parse-utils.ts
+++ b/src/parser/parse-utils.ts
@@ -3,7 +3,10 @@ import { OverNode } from '../operation-node/over-node.js'
 import { SelectQueryNode } from '../operation-node/select-query-node.js'
 import { JoinBuilder } from '../query-builder/join-builder.js'
 import { OverBuilder } from '../query-builder/over-builder.js'
-import { SelectQueryBuilder } from '../query-builder/select-query-builder.js'
+import {
+  SelectQueryBuilder,
+  createSelectQueryBuilder as newSelectQueryBuilder,
+} from '../query-builder/select-query-builder.js'
 import { QueryCreator } from '../query-creator.js'
 import { NOOP_QUERY_EXECUTOR } from '../query-executor/noop-query-executor.js'
 import { createQueryId } from '../util/query-id.js'
@@ -14,7 +17,7 @@ import {
 } from './table-parser.js'
 
 export function createSelectQueryBuilder(): SelectQueryBuilder<any, any, any> {
-  return new SelectQueryBuilder({
+  return newSelectQueryBuilder({
     queryId: createQueryId(),
     executor: NOOP_QUERY_EXECUTOR,
     queryNode: SelectQueryNode.create(parseTableExpressionOrList([])),

--- a/src/query-builder/delete-query-builder.ts
+++ b/src/query-builder/delete-query-builder.ts
@@ -83,6 +83,7 @@ export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
   ): DeleteQueryBuilder<DB, TB, O>
 
   where(factory: WhereExpressionFactory<DB, TB>): DeleteQueryBuilder<DB, TB, O>
+
   where(expression: Expression<any>): DeleteQueryBuilder<DB, TB, O>
 
   where(...args: any[]): any {

--- a/src/query-builder/having-interface.ts
+++ b/src/query-builder/having-interface.ts
@@ -19,6 +19,7 @@ export interface HavingInterface<DB, TB extends keyof DB> {
   ): HavingInterface<DB, TB>
 
   having(factory: HavingExpressionFactory<DB, TB>): HavingInterface<DB, TB>
+
   having(expression: Expression<any>): HavingInterface<DB, TB>
 
   /**

--- a/src/query-builder/where-interface.ts
+++ b/src/query-builder/where-interface.ts
@@ -314,6 +314,7 @@ export interface WhereInterface<DB, TB extends keyof DB> {
   ): WhereInterface<DB, TB>
 
   where(factory: WhereExpressionFactory<DB, TB>): WhereInterface<DB, TB>
+
   where(expression: Expression<any>): WhereInterface<DB, TB>
 
   /**

--- a/src/query-creator.ts
+++ b/src/query-creator.ts
@@ -1,4 +1,7 @@
-import { SelectQueryBuilder } from './query-builder/select-query-builder.js'
+import {
+  SelectQueryBuilder,
+  createSelectQueryBuilder,
+} from './query-builder/select-query-builder.js'
 import { InsertQueryBuilder } from './query-builder/insert-query-builder.js'
 import { DeleteQueryBuilder } from './query-builder/delete-query-builder.js'
 import { UpdateQueryBuilder } from './query-builder/update-query-builder.js'
@@ -176,7 +179,7 @@ export class QueryCreator<DB> {
   ): SelectQueryBuilder<From<DB, TE>, FromTables<DB, never, TE>, {}>
 
   selectFrom(from: TableExpressionOrList<any, any>): any {
-    return new SelectQueryBuilder({
+    return createSelectQueryBuilder({
       queryId: createQueryId(),
       executor: this.#props.executor,
       queryNode: SelectQueryNode.create(

--- a/src/raw-builder/raw-builder.ts
+++ b/src/raw-builder/raw-builder.ts
@@ -4,7 +4,7 @@ import { RawNode } from '../operation-node/raw-node.js'
 import { CompiledQuery } from '../query-compiler/compiled-query.js'
 import { preventAwait } from '../util/prevent-await.js'
 import { QueryExecutor } from '../query-executor/query-executor.js'
-import { freeze, isFunction, isObject } from '../util/object-utils.js'
+import { freeze } from '../util/object-utils.js'
 import { KyselyPlugin } from '../plugin/kysely-plugin.js'
 import { NOOP_QUERY_EXECUTOR } from '../query-executor/noop-query-executor.js'
 import { QueryExecutorProvider } from '../query-executor/query-executor-provider.js'
@@ -19,17 +19,11 @@ import { isOperationNodeSource } from '../operation-node/operation-node-source.j
  * You shouldn't need to create `RawBuilder` instances directly. Instead you should
  * use the {@link sql} template tag.
  */
-export class RawBuilder<O> implements Expression<O> {
-  readonly #props: RawBuilderProps
-
-  constructor(props: RawBuilderProps) {
-    this.#props = freeze(props)
-  }
-
-  /** @private */
-  get expressionType(): O | undefined {
-    return undefined
-  }
+export interface RawBuilder<O> extends Expression<O> {
+  /**
+   * @private Without this SelectQueryBuilder extends RawBuilder and things break.
+   */
+  get isRawBuilder(): true
 
   /**
    * Returns an aliased version of the SQL expression.
@@ -86,9 +80,6 @@ export class RawBuilder<O> implements Expression<O> {
    */
   as<A extends string>(alias: A): AliasedRawBuilder<O, A>
   as<A extends string>(alias: Expression<any>): AliasedRawBuilder<O, A>
-  as(alias: string | Expression<unknown>): AliasedRawBuilder<O, string> {
-    return new AliasedRawBuilder(this, alias)
-  }
 
   /**
    * Change the output type of the raw expression.
@@ -96,22 +87,64 @@ export class RawBuilder<O> implements Expression<O> {
    * This method call doesn't change the SQL in any way. This methods simply
    * returns a copy of this `RawBuilder` with a new output type.
    */
-  $castTo<T>(): RawBuilder<T> {
-    return new RawBuilder({ ...this.#props })
-  }
-
-  /**
-   * @deprecated Use `$castTo` instead.
-   */
-  castTo<T>(): RawBuilder<T> {
-    return this.$castTo<T>()
-  }
+  $castTo<T>(): RawBuilder<T>
 
   /**
    * Adds a plugin for this SQL snippet.
    */
+  withPlugin(plugin: KyselyPlugin): RawBuilder<O>
+
+  /**
+   * Compiles the builder to a `CompiledQuery`.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * const { sql } = sql`select * from ${sql.table('person')}`.compile(db)
+   * console.log(sql)
+   * ```
+   */
+  compile(executorProvider: QueryExecutorProvider): CompiledQuery<O>
+
+  /**
+   * Executes the raw query.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * const result = await sql`select * from ${sql.table('person')}`.execute(db)
+   * ```
+   */
+  execute(executorProvider: QueryExecutorProvider): Promise<QueryResult<O>>
+
+  toOperationNode(): RawNode
+}
+
+class RawBuilderImpl<O> implements RawBuilder<O> {
+  readonly #props: RawBuilderProps
+
+  constructor(props: RawBuilderProps) {
+    this.#props = freeze(props)
+  }
+
+  get expressionType(): O | undefined {
+    return undefined
+  }
+
+  get isRawBuilder(): true {
+    return true
+  }
+
+  as(alias: string | Expression<unknown>): AliasedRawBuilder<O, string> {
+    return new AliasedRawBuilderImpl(this, alias)
+  }
+
+  $castTo<T>(): RawBuilder<T> {
+    return new RawBuilderImpl({ ...this.#props })
+  }
+
   withPlugin(plugin: KyselyPlugin): RawBuilder<O> {
-    return new RawBuilder({
+    return new RawBuilderImpl({
       ...this.#props,
       plugins:
         this.#props.plugins !== undefined
@@ -162,27 +195,31 @@ export class RawBuilder<O> implements Expression<O> {
   }
 }
 
-export function isRawBuilder(obj: unknown): obj is RawBuilder<unknown> {
-  return (
-    isObject(obj) &&
-    isFunction(obj.as) &&
-    isFunction(obj.$castTo) &&
-    isFunction(obj.withPlugin) &&
-    isFunction(obj.toOperationNode) &&
-    isFunction(obj.execute)
-  )
+export interface RawBuilderProps {
+  readonly queryId: QueryId
+  readonly rawNode: RawNode
+  readonly plugins?: ReadonlyArray<KyselyPlugin>
+}
+
+export function createRawBuilder<O>(props: RawBuilderProps): RawBuilder<O> {
+  return new RawBuilderImpl(props)
 }
 
 preventAwait(
-  RawBuilder,
+  RawBuilderImpl,
   "don't await RawBuilder instances directly. To execute the query you need to call `execute`"
 )
 
 /**
  * {@link RawBuilder} with an alias. The result of calling {@link RawBuilder.as}.
  */
-export class AliasedRawBuilder<O = unknown, A extends string = never>
-  implements AliasedExpression<O, A>
+export interface AliasedRawBuilder<O = unknown, A extends string = never>
+  extends AliasedExpression<O, A> {
+  get rawBuilder(): RawBuilder<O>
+}
+
+class AliasedRawBuilderImpl<O = unknown, A extends string = never>
+  implements AliasedRawBuilder<O, A>
 {
   readonly #rawBuilder: RawBuilder<O>
   readonly #alias: A | Expression<unknown>
@@ -192,14 +229,16 @@ export class AliasedRawBuilder<O = unknown, A extends string = never>
     this.#alias = alias
   }
 
-  /** @private */
   get expression(): Expression<O> {
     return this.#rawBuilder
   }
 
-  /** @private */
   get alias(): A | Expression<unknown> {
     return this.#alias
+  }
+
+  get rawBuilder(): RawBuilder<O> {
+    return this.#rawBuilder
   }
 
   toOperationNode(): AliasNode {
@@ -212,8 +251,7 @@ export class AliasedRawBuilder<O = unknown, A extends string = never>
   }
 }
 
-export interface RawBuilderProps {
-  readonly queryId: QueryId
-  readonly rawNode: RawNode
-  readonly plugins?: ReadonlyArray<KyselyPlugin>
-}
+preventAwait(
+  AliasedRawBuilderImpl,
+  "don't await AliasedRawBuilder instances directly. AliasedRawBuilder should never be executed directly since it's always a part of another query."
+)

--- a/src/raw-builder/sql.ts
+++ b/src/raw-builder/sql.ts
@@ -6,7 +6,7 @@ import { parseStringReference } from '../parser/reference-parser.js'
 import { parseTable } from '../parser/table-parser.js'
 import { parseValueExpression } from '../parser/value-parser.js'
 import { createQueryId } from '../util/query-id.js'
-import { RawBuilder } from './raw-builder.js'
+import { RawBuilder, createRawBuilder } from './raw-builder.js'
 
 export interface Sql {
   /**
@@ -374,7 +374,7 @@ export const sql: Sql = Object.assign(
     sqlFragments: TemplateStringsArray,
     ...parameters: unknown[]
   ): RawBuilder<T> => {
-    return new RawBuilder({
+    return createRawBuilder({
       queryId: createQueryId(),
       rawNode: RawNode.create(
         sqlFragments,
@@ -384,14 +384,14 @@ export const sql: Sql = Object.assign(
   },
   {
     ref<R = unknown>(columnReference: string): RawBuilder<R> {
-      return new RawBuilder({
+      return createRawBuilder({
         queryId: createQueryId(),
         rawNode: RawNode.createWithChild(parseStringReference(columnReference)),
       })
     },
 
     val<V>(value: V): RawBuilder<V> {
-      return new RawBuilder({
+      return createRawBuilder({
         queryId: createQueryId(),
         rawNode: RawNode.createWithChild(parseValueExpression(value)),
       })
@@ -402,7 +402,7 @@ export const sql: Sql = Object.assign(
     },
 
     table(tableReference: string): RawBuilder<unknown> {
-      return new RawBuilder({
+      return createRawBuilder({
         queryId: createQueryId(),
         rawNode: RawNode.createWithChild(parseTable(tableReference)),
       })
@@ -414,14 +414,14 @@ export const sql: Sql = Object.assign(
       fragments[0] = ''
       fragments[fragments.length - 1] = ''
 
-      return new RawBuilder({
+      return createRawBuilder({
         queryId: createQueryId(),
         rawNode: RawNode.create(fragments, ids.map(IdentifierNode.create)),
       })
     },
 
     lit<V>(value: V): RawBuilder<V> {
-      return new RawBuilder({
+      return createRawBuilder({
         queryId: createQueryId(),
         rawNode: RawNode.createWithChild(ValueNode.createImmediate(value)),
       })
@@ -432,7 +432,7 @@ export const sql: Sql = Object.assign(
     },
 
     raw<R = unknown>(sql: string): RawBuilder<R> {
-      return new RawBuilder({
+      return createRawBuilder({
         queryId: createQueryId(),
         rawNode: RawNode.createWithSql(sql),
       })
@@ -453,7 +453,7 @@ export const sql: Sql = Object.assign(
         }
       }
 
-      return new RawBuilder({
+      return createRawBuilder({
         queryId: createQueryId(),
         rawNode: RawNode.createWithChildren(nodes),
       })


### PR DESCRIPTION
My guess is that these two classes are most used ones (in addition to Kysely) in customer code. By turning them to interfaces we get rid of some of the type mismatches when there are multiple versions of Kysely.