### PR TITLE
Support boolean subqueries in addition to boolean expressions in filters

### DIFF
--- a/src/expression/expression-builder.ts
+++ b/src/expression/expression-builder.ts
@@ -59,6 +59,7 @@ import { CaseBuilder } from '../query-builder/case-builder.js'
 import { CaseNode } from '../operation-node/case-node.js'
 import { isReadonlyArray, isUndefined } from '../util/object-utils.js'
 import { JSONPathBuilder } from '../query-builder/json-path-builder.js'
+import { OperandExpression } from '../parser/expression-parser.js'
 
 export interface ExpressionBuilder<DB, TB extends keyof DB> {
   /**
@@ -611,7 +612,7 @@ export interface ExpressionBuilder<DB, TB extends keyof DB> {
    * ```
    */
   and(
-    exprs: ReadonlyArray<Expression<SqlBool>>
+    exprs: ReadonlyArray<OperandExpression<SqlBool>>
   ): ExpressionWrapper<DB, TB, SqlBool>
 
   and(exprs: Readonly<FilterObject<DB, TB>>): ExpressionWrapper<DB, TB, SqlBool>
@@ -673,7 +674,7 @@ export interface ExpressionBuilder<DB, TB extends keyof DB> {
    * ```
    */
   or(
-    exprs: ReadonlyArray<Expression<SqlBool>>
+    exprs: ReadonlyArray<OperandExpression<SqlBool>>
   ): ExpressionWrapper<DB, TB, SqlBool>
 
   or(exprs: Readonly<FilterObject<DB, TB>>): ExpressionWrapper<DB, TB, SqlBool>
@@ -869,7 +870,9 @@ export function createExpressionBuilder<DB, TB extends keyof DB>(
     },
 
     and(
-      exprs: ReadonlyArray<Expression<SqlBool>> | Readonly<FilterObject<DB, TB>>
+      exprs:
+        | ReadonlyArray<OperandExpression<SqlBool>>
+        | Readonly<FilterObject<DB, TB>>
     ): ExpressionWrapper<DB, TB, SqlBool> {
       if (isReadonlyArray(exprs)) {
         return new ExpressionWrapper(parseFilterList(exprs, 'and'))
@@ -879,7 +882,9 @@ export function createExpressionBuilder<DB, TB extends keyof DB>(
     },
 
     or(
-      exprs: ReadonlyArray<Expression<SqlBool>> | Readonly<FilterObject<DB, TB>>
+      exprs:
+        | ReadonlyArray<OperandExpression<SqlBool>>
+        | Readonly<FilterObject<DB, TB>>
     ): ExpressionWrapper<DB, TB, SqlBool> {
       if (isReadonlyArray(exprs)) {
         return new ExpressionWrapper(parseFilterList(exprs, 'or'))

--- a/src/expression/expression-wrapper.ts
+++ b/src/expression/expression-wrapper.ts
@@ -10,6 +10,7 @@ import {
   OperandValueExpressionOrList,
   parseValueBinaryOperationOrExpression,
 } from '../parser/binary-operation-parser.js'
+import { OperandExpression } from '../parser/expression-parser.js'
 import { ReferenceExpression } from '../parser/reference-parser.js'
 import { KyselyTypeError } from '../util/type-error.js'
 import { SqlBool } from '../util/type-utils.js'
@@ -131,7 +132,7 @@ export class ExpressionWrapper<DB, TB extends keyof DB, T>
     : KyselyTypeError<'or() method can only be called on boolean expressions'>
 
   or(
-    expression: Expression<SqlBool>
+    expression: OperandExpression<SqlBool>
   ): T extends SqlBool
     ? OrWrapper<DB, TB, SqlBool>
     : KyselyTypeError<'or() method can only be called on boolean expressions'>
@@ -211,7 +212,7 @@ export class ExpressionWrapper<DB, TB extends keyof DB, T>
     : KyselyTypeError<'and() method can only be called on boolean expressions'>
 
   and(
-    expression: Expression<SqlBool>
+    expression: OperandExpression<SqlBool>
   ): T extends SqlBool
     ? AndWrapper<DB, TB, SqlBool>
     : KyselyTypeError<'and() method can only be called on boolean expressions'>
@@ -328,7 +329,7 @@ export class OrWrapper<DB, TB extends keyof DB, T extends SqlBool>
     rhs: OperandValueExpressionOrList<DB, TB, RE>
   ): OrWrapper<DB, TB, T>
 
-  or(expression: Expression<SqlBool>): OrWrapper<DB, TB, T>
+  or(expression: OperandExpression<SqlBool>): OrWrapper<DB, TB, T>
 
   or(...args: any[]): any {
     return new OrWrapper(
@@ -411,7 +412,7 @@ export class AndWrapper<DB, TB extends keyof DB, T extends SqlBool>
     rhs: OperandValueExpressionOrList<DB, TB, RE>
   ): AndWrapper<DB, TB, T>
 
-  and(expression: Expression<SqlBool>): AndWrapper<DB, TB, T>
+  and(expression: OperandExpression<SqlBool>): AndWrapper<DB, TB, T>
 
   and(...args: any[]): any {
     return new AndWrapper(

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,3 +247,7 @@ export {
   FilterObject,
 } from './parser/binary-operation-parser.js'
 export { ExistsExpression } from './parser/unary-operation-parser.js'
+export {
+  OperandExpression,
+  ExpressionOrFactory,
+} from './parser/expression-parser.js'

--- a/src/parser/expression-parser.ts
+++ b/src/parser/expression-parser.ts
@@ -13,17 +13,22 @@ import {
 } from '../expression/expression-builder.js'
 import { SelectQueryBuilder } from '../query-builder/select-query-builder.js'
 import { isFunction } from '../util/object-utils.js'
-import { ShallowRecord } from '../util/type-utils.js'
 
-export type ExpressionOrFactory<DB, TB extends keyof DB, V> =
+/**
+ * Like `Expression<V>` but also accepts a select query with an output
+ * type extending `Record<string, V>`. This type is useful because SQL
+ * treats records with a single column as single values.
+ */
+export type OperandExpression<V> =
   // SQL treats a subquery with a single selection as a scalar. That's
   // why we need to explicitly allow `SelectQueryBuilder` here with a
-  // `ShallowRecord<string, V>` output type, even though `SelectQueryBuilder`
+  // `Record<string, V>` output type, even though `SelectQueryBuilder`
   // is also an `Expression`.
-  | SelectQueryBuilder<any, any, ShallowRecord<string, V>>
-  | SelectQueryBuilderFactory<DB, TB, ShallowRecord<string, V>>
-  | Expression<V>
-  | ExpressionFactory<DB, TB, V>
+  Expression<V> | SelectQueryBuilder<any, any, Record<string, V>>
+
+export type ExpressionOrFactory<DB, TB extends keyof DB, V> =
+  | OperandExpression<V>
+  | OperandExpressionFactory<DB, TB, V>
 
 export type AliasedExpressionOrFactory<DB, TB extends keyof DB> =
   | AliasedExpression<any, any>
@@ -33,9 +38,9 @@ export type ExpressionFactory<DB, TB extends keyof DB, V> = (
   eb: ExpressionBuilder<DB, TB>
 ) => Expression<V>
 
-type SelectQueryBuilderFactory<DB, TB extends keyof DB, V> = (
+type OperandExpressionFactory<DB, TB extends keyof DB, V> = (
   eb: ExpressionBuilder<DB, TB>
-) => SelectQueryBuilder<any, any, V>
+) => OperandExpression<V>
 
 type AliasedExpressionFactory<DB, TB extends keyof DB> = (
   eb: ExpressionBuilder<DB, TB>

--- a/src/query-builder/aggregate-function-builder.ts
+++ b/src/query-builder/aggregate-function-builder.ts
@@ -13,7 +13,8 @@ import {
   parseReferentialBinaryOperation,
   parseValueBinaryOperationOrExpression,
 } from '../parser/binary-operation-parser.js'
-import { WhereExpressionFactory } from './where-interface.js'
+import { SqlBool } from '../util/type-utils.js'
+import { ExpressionOrFactory } from '../parser/expression-parser.js'
 
 export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   implements Expression<O>
@@ -138,10 +139,8 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   ): AggregateFunctionBuilder<DB, TB, O>
 
   filterWhere(
-    factory: WhereExpressionFactory<DB, TB>
+    expression: ExpressionOrFactory<DB, TB, SqlBool>
   ): AggregateFunctionBuilder<DB, TB, O>
-
-  filterWhere(expression: Expression<any>): AggregateFunctionBuilder<DB, TB, O>
 
   filterWhere(...args: any[]): any {
     return new AggregateFunctionBuilder({

--- a/src/query-builder/delete-query-builder.ts
+++ b/src/query-builder/delete-query-builder.ts
@@ -28,6 +28,7 @@ import {
   ShallowRecord,
   SimplifyResult,
   SimplifySingleResult,
+  SqlBool,
 } from '../util/type-utils.js'
 import { preventAwait } from '../util/prevent-await.js'
 import { Compilable } from '../util/compilable.js'
@@ -35,7 +36,7 @@ import { QueryExecutor } from '../query-executor/query-executor.js'
 import { QueryId } from '../util/query-id.js'
 import { freeze } from '../util/object-utils.js'
 import { KyselyPlugin } from '../plugin/kysely-plugin.js'
-import { WhereExpressionFactory, WhereInterface } from './where-interface.js'
+import { WhereInterface } from './where-interface.js'
 import { ReturningInterface } from './returning-interface.js'
 import {
   isNoResultErrorConstructor,
@@ -60,6 +61,7 @@ import {
 } from '../parser/binary-operation-parser.js'
 import { KyselyTypeError } from '../util/type-error.js'
 import { Streamable } from '../util/streamable.js'
+import { ExpressionOrFactory } from '../parser/expression-parser.js'
 
 export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
   implements
@@ -82,9 +84,9 @@ export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
     rhs: OperandValueExpressionOrList<DB, TB, RE>
   ): DeleteQueryBuilder<DB, TB, O>
 
-  where(factory: WhereExpressionFactory<DB, TB>): DeleteQueryBuilder<DB, TB, O>
-
-  where(expression: Expression<any>): DeleteQueryBuilder<DB, TB, O>
+  where(
+    expression: ExpressionOrFactory<DB, TB, SqlBool>
+  ): DeleteQueryBuilder<DB, TB, O>
 
   where(...args: any[]): any {
     return new DeleteQueryBuilder({

--- a/src/query-builder/having-interface.ts
+++ b/src/query-builder/having-interface.ts
@@ -4,6 +4,7 @@ import {
   ComparisonOperatorExpression,
   OperandValueExpressionOrList,
 } from '../parser/binary-operation-parser.js'
+import { ExpressionOrFactory } from '../parser/expression-parser.js'
 import { ReferenceExpression } from '../parser/reference-parser.js'
 import { SqlBool } from '../util/type-utils.js'
 
@@ -18,9 +19,9 @@ export interface HavingInterface<DB, TB extends keyof DB> {
     rhs: OperandValueExpressionOrList<DB, TB, RE>
   ): HavingInterface<DB, TB>
 
-  having(factory: HavingExpressionFactory<DB, TB>): HavingInterface<DB, TB>
-
-  having(expression: Expression<any>): HavingInterface<DB, TB>
+  having(
+    expression: ExpressionOrFactory<DB, TB, SqlBool>
+  ): HavingInterface<DB, TB>
 
   /**
    * Just like {@link WhereInterface.whereRef | whereRef} but adds a `having` statement
@@ -32,7 +33,3 @@ export interface HavingInterface<DB, TB extends keyof DB> {
     rhs: ReferenceExpression<DB, TB>
   ): HavingInterface<DB, TB>
 }
-
-export type HavingExpressionFactory<DB, TB extends keyof DB> = (
-  eb: ExpressionBuilder<DB, TB>
-) => Expression<SqlBool>

--- a/src/query-builder/join-builder.ts
+++ b/src/query-builder/join-builder.ts
@@ -9,6 +9,7 @@ import {
   parseValueBinaryOperationOrExpression,
   parseReferentialBinaryOperation,
 } from '../parser/binary-operation-parser.js'
+import { ExpressionOrFactory } from '../parser/expression-parser.js'
 import { ReferenceExpression } from '../parser/reference-parser.js'
 import { freeze } from '../util/object-utils.js'
 import { preventAwait } from '../util/prevent-await.js'
@@ -35,8 +36,7 @@ export class JoinBuilder<DB, TB extends keyof DB>
     rhs: OperandValueExpressionOrList<DB, TB, RE>
   ): JoinBuilder<DB, TB>
 
-  on(factory: OnExpressionFactory<DB, TB>): JoinBuilder<DB, TB>
-  on(expression: Expression<any>): JoinBuilder<DB, TB>
+  on(expression: ExpressionOrFactory<DB, TB, SqlBool>): JoinBuilder<DB, TB>
 
   on(...args: any[]): JoinBuilder<DB, TB> {
     return new JoinBuilder({
@@ -102,7 +102,3 @@ preventAwait(
 export interface JoinBuilderProps {
   readonly joinNode: JoinNode
 }
-
-type OnExpressionFactory<DB, TB extends keyof DB> = (
-  eb: ExpressionBuilder<DB, TB>
-) => Expression<SqlBool>

--- a/src/query-builder/on-conflict-builder.ts
+++ b/src/query-builder/on-conflict-builder.ts
@@ -9,6 +9,7 @@ import {
   parseValueBinaryOperationOrExpression,
   parseReferentialBinaryOperation,
 } from '../parser/binary-operation-parser.js'
+import { ExpressionOrFactory } from '../parser/expression-parser.js'
 import { ReferenceExpression } from '../parser/reference-parser.js'
 import {
   UpdateExpression,
@@ -16,8 +17,8 @@ import {
 } from '../parser/update-set-parser.js'
 import { freeze } from '../util/object-utils.js'
 import { preventAwait } from '../util/prevent-await.js'
-import { AnyColumn } from '../util/type-utils.js'
-import { WhereExpressionFactory, WhereInterface } from './where-interface.js'
+import { AnyColumn, SqlBool } from '../util/type-utils.js'
+import { WhereInterface } from './where-interface.js'
 
 export class OnConflictBuilder<DB, TB extends keyof DB>
   implements WhereInterface<DB, TB>
@@ -111,8 +112,9 @@ export class OnConflictBuilder<DB, TB extends keyof DB>
     rhs: OperandValueExpressionOrList<DB, TB, RE>
   ): OnConflictBuilder<DB, TB>
 
-  where(factory: WhereExpressionFactory<DB, TB>): OnConflictBuilder<DB, TB>
-  where(expression: Expression<any>): OnConflictBuilder<DB, TB>
+  where(
+    expression: ExpressionOrFactory<DB, TB, SqlBool>
+  ): OnConflictBuilder<DB, TB>
 
   where(...args: any[]): OnConflictBuilder<DB, TB> {
     return new OnConflictBuilder({
@@ -300,10 +302,8 @@ export class OnConflictUpdateBuilder<DB, TB extends keyof DB>
   ): OnConflictUpdateBuilder<DB, TB>
 
   where(
-    factory: WhereExpressionFactory<DB, TB>
+    expression: ExpressionOrFactory<DB, TB, SqlBool>
   ): OnConflictUpdateBuilder<DB, TB>
-
-  where(expression: Expression<any>): OnConflictUpdateBuilder<DB, TB>
 
   where(...args: any[]): OnConflictUpdateBuilder<DB, TB> {
     return new OnConflictUpdateBuilder({

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -29,6 +29,7 @@ import {
   ShallowRecord,
   Simplify,
   SimplifySingleResult,
+  SqlBool,
 } from '../util/type-utils.js'
 import {
   OrderByDirectionExpression,
@@ -44,13 +45,13 @@ import { QueryId } from '../util/query-id.js'
 import { freeze } from '../util/object-utils.js'
 import { GroupByArg, parseGroupBy } from '../parser/group-by-parser.js'
 import { KyselyPlugin } from '../plugin/kysely-plugin.js'
-import { WhereExpressionFactory, WhereInterface } from './where-interface.js'
+import { WhereInterface } from './where-interface.js'
 import {
   isNoResultErrorConstructor,
   NoResultError,
   NoResultErrorConstructor,
 } from './no-result-error.js'
-import { HavingExpressionFactory, HavingInterface } from './having-interface.js'
+import { HavingInterface } from './having-interface.js'
 import { IdentifierNode } from '../operation-node/identifier-node.js'
 import { Explainable, ExplainFormat } from '../util/explainable.js'
 import {
@@ -67,6 +68,7 @@ import {
 import { KyselyTypeError } from '../util/type-error.js'
 import { Selectable } from '../util/column-type.js'
 import { Streamable } from '../util/streamable.js'
+import { ExpressionOrFactory } from '../parser/expression-parser.js'
 
 export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
   extends WhereInterface<DB, TB>,
@@ -81,9 +83,9 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
     rhs: OperandValueExpressionOrList<DB, TB, RE>
   ): SelectQueryBuilder<DB, TB, O>
 
-  where(factory: WhereExpressionFactory<DB, TB>): SelectQueryBuilder<DB, TB, O>
-
-  where(expression: Expression<any>): SelectQueryBuilder<DB, TB, O>
+  where(
+    expression: ExpressionOrFactory<DB, TB, SqlBool>
+  ): SelectQueryBuilder<DB, TB, O>
 
   whereRef(
     lhs: ReferenceExpression<DB, TB>,
@@ -98,10 +100,8 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
   ): SelectQueryBuilder<DB, TB, O>
 
   having(
-    factory: HavingExpressionFactory<DB, TB>
+    expression: ExpressionOrFactory<DB, TB, SqlBool>
   ): SelectQueryBuilder<DB, TB, O>
-
-  having(expression: Expression<any>): SelectQueryBuilder<DB, TB, O>
 
   havingRef(
     lhs: ReferenceExpression<DB, TB>,

--- a/src/query-builder/update-query-builder.ts
+++ b/src/query-builder/update-query-builder.ts
@@ -28,6 +28,7 @@ import {
   ShallowRecord,
   SimplifyResult,
   SimplifySingleResult,
+  SqlBool,
 } from '../util/type-utils.js'
 import { UpdateQueryNode } from '../operation-node/update-query-node.js'
 import {
@@ -43,7 +44,7 @@ import { QueryId } from '../util/query-id.js'
 import { freeze } from '../util/object-utils.js'
 import { UpdateResult } from './update-result.js'
 import { KyselyPlugin } from '../plugin/kysely-plugin.js'
-import { WhereExpressionFactory, WhereInterface } from './where-interface.js'
+import { WhereInterface } from './where-interface.js'
 import { ReturningInterface } from './returning-interface.js'
 import {
   isNoResultErrorConstructor,
@@ -61,6 +62,7 @@ import {
 } from '../parser/binary-operation-parser.js'
 import { KyselyTypeError } from '../util/type-error.js'
 import { Streamable } from '../util/streamable.js'
+import { ExpressionOrFactory } from '../parser/expression-parser.js'
 
 export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
   implements
@@ -84,10 +86,8 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
   ): UpdateQueryBuilder<DB, UT, TB, O>
 
   where(
-    factory: WhereExpressionFactory<DB, TB>
+    expression: ExpressionOrFactory<DB, TB, SqlBool>
   ): UpdateQueryBuilder<DB, UT, TB, O>
-
-  where(expression: Expression<any>): UpdateQueryBuilder<DB, UT, TB, O>
 
   where(...args: any[]): any {
     return new UpdateQueryBuilder({

--- a/src/query-builder/where-interface.ts
+++ b/src/query-builder/where-interface.ts
@@ -6,6 +6,7 @@ import {
 import { ReferenceExpression } from '../parser/reference-parser.js'
 import { SqlBool } from '../util/type-utils.js'
 import { ExpressionBuilder } from '../expression/expression-builder.js'
+import { ExpressionOrFactory } from '../parser/expression-parser.js'
 
 export interface WhereInterface<DB, TB extends keyof DB> {
   /**
@@ -313,9 +314,9 @@ export interface WhereInterface<DB, TB extends keyof DB> {
     rhs: OperandValueExpressionOrList<DB, TB, RE>
   ): WhereInterface<DB, TB>
 
-  where(factory: WhereExpressionFactory<DB, TB>): WhereInterface<DB, TB>
-
-  where(expression: Expression<any>): WhereInterface<DB, TB>
+  where(
+    expression: ExpressionOrFactory<DB, TB, SqlBool>
+  ): WhereInterface<DB, TB>
 
   /**
    * Adds a `where` clause where both sides of the operator are references
@@ -394,7 +395,3 @@ export interface WhereInterface<DB, TB extends keyof DB> {
    */
   clearWhere(): WhereInterface<DB, TB>
 }
-
-export type WhereExpressionFactory<DB, TB extends keyof DB> = (
-  eb: ExpressionBuilder<DB, TB>
-) => Expression<SqlBool>

--- a/src/schema/create-index-builder.ts
+++ b/src/schema/create-index-builder.ts
@@ -231,7 +231,7 @@ export class CreateIndexBuilder<C = never>
     ) => Expression<SqlBool>
   ): CreateIndexBuilder<C>
 
-  where(expression: Expression<any>): CreateIndexBuilder<C>
+  where(expression: Expression<SqlBool>): CreateIndexBuilder<C>
 
   where(...args: any[]): any {
     const transformer = new ImmediateValueTransformer()

--- a/test/node/src/raw-sql.test.ts
+++ b/test/node/src/raw-sql.test.ts
@@ -36,7 +36,7 @@ for (const dialect of DIALECTS) {
       const query = ctx.db
         .selectFrom('person')
         .selectAll()
-        .where(sql`first_name between ${'A'} and ${'B'}`)
+        .where(sql<boolean>`first_name between ${'A'} and ${'B'}`)
 
       testSql(query, dialect, {
         postgres: {
@@ -60,7 +60,9 @@ for (const dialect of DIALECTS) {
       const query = ctx.db
         .selectFrom('person')
         .selectAll()
-        .where(sql`first_name between ${sql.lit('A')} and ${sql.lit('B')}`)
+        .where(
+          sql<boolean>`first_name between ${sql.lit('A')} and ${sql.lit('B')}`
+        )
 
       testSql(query, dialect, {
         postgres: {
@@ -84,7 +86,7 @@ for (const dialect of DIALECTS) {
       const query = ctx.db
         .selectFrom('person')
         .selectAll()
-        .where(sql`${sql.id('first_name')} between ${'A'} and ${'B'}`)
+        .where(sql<boolean>`${sql.id('first_name')} between ${'A'} and ${'B'}`)
 
       testSql(query, dialect, {
         postgres: {
@@ -110,7 +112,7 @@ for (const dialect of DIALECTS) {
           .selectFrom('person')
           .selectAll()
           .where(
-            sql`${sql.id(
+            sql<boolean>`${sql.id(
               'public',
               'person',
               'first_name'
@@ -134,7 +136,7 @@ for (const dialect of DIALECTS) {
       const query = ctx.db
         .selectFrom('person')
         .selectAll()
-        .where(sql`${sql.ref('first_name')} between ${'A'} and ${'B'}`)
+        .where(sql<boolean>`${sql.ref('first_name')} between ${'A'} and ${'B'}`)
 
       testSql(query, dialect, {
         postgres: {
@@ -160,7 +162,7 @@ for (const dialect of DIALECTS) {
           .selectFrom('person')
           .selectAll()
           .where(
-            sql`${sql.ref(
+            sql<boolean>`${sql.ref(
               'public.person.first_name'
             )} between ${'A'} and ${'B'}`
           )
@@ -226,7 +228,7 @@ for (const dialect of DIALECTS) {
       const query = ctx.db
         .selectFrom('person')
         .selectAll()
-        .where(sql`first_name in (${sql.join(names)})`)
+        .where(sql<boolean>`first_name in (${sql.join(names)})`)
 
       testSql(query, dialect, {
         postgres: {
@@ -253,7 +255,9 @@ for (const dialect of DIALECTS) {
         const query = ctx.db
           .selectFrom('person')
           .selectAll()
-          .where(sql`first_name in (${sql.join(names, sql`::varchar,`)})`)
+          .where(
+            sql<boolean>`first_name in (${sql.join(names, sql`::varchar,`)})`
+          )
 
         testSql(query, dialect, {
           postgres: {

--- a/test/typings/test-d/where.test-d.ts
+++ b/test/typings/test-d/where.test-d.ts
@@ -81,6 +81,24 @@ function testWhere(db: Kysely<Database>) {
   db.selectFrom('person').where(sql`whatever`, '=', true)
   db.selectFrom('person').where(sql`whatever`, '=', '1')
 
+  // Boolean returning select query
+  db.selectFrom('person')
+    .selectAll()
+    .where(
+      db
+        .selectFrom('pet')
+        .select((eb) => eb('name', '=', 'Doggo').as('is_doggo'))
+    )
+
+  // Boolean returning select query using a callback
+  db.selectFrom('person')
+    .selectAll()
+    .where((eb) =>
+      eb
+        .selectFrom('pet')
+        .select((eb) => eb('name', '=', 'Doggo').as('is_doggo'))
+    )
+
   // List value
   db.selectFrom('person').where('gender', 'in', ['female', 'male'])
 
@@ -128,4 +146,20 @@ function testWhere(db: Kysely<Database>) {
 
   // Invalid type for column
   expectError(db.selectFrom('person').where(sql<string>`first_name`, '=', 1))
+
+  // Non-boolean returning select query
+  expectError(
+    db
+      .selectFrom('person')
+      .selectAll()
+      .where(db.selectFrom('pet').select('name'))
+  )
+
+  // Non-boolean returning select query using a callback
+  expectError(
+    db
+      .selectFrom('person')
+      .selectAll()
+      .where((eb) => eb.selectFrom('pet').select('name'))
+  )
 }


### PR DESCRIPTION
There were couple of issues in filter expressions this PR fixes:

1. Filters allowed all kinds of expressions, not just boolean expressions.
2. Filters didn't allow subqueries that select a boolean value.

This PR can be considered a breaking change since people will need to add explicit types for raw sql filters if they didn't have them already. On the other hand this PR fixes a typing bug, so it's open to interpretation.