### PR TITLE
Change driver destroy method to closeConnection

### DIFF
--- a/example/src/app.ts
+++ b/example/src/app.ts
@@ -65,7 +65,7 @@ export class App {
       })
     })
 
-    await this.#db?.destroy()
+    await this.#db?.closeConnection()
   }
 
   private readonly errorHandler = async (

--- a/example/src/migrate-to-latest.ts
+++ b/example/src/migrate-to-latest.ts
@@ -42,7 +42,7 @@ async function migrateToLatest() {
     process.exit(1)
   }
 
-  await db.destroy()
+  await db.closeConnection()
 }
 
 migrateToLatest()

--- a/example/test/test-context.ts
+++ b/example/test/test-context.ts
@@ -38,7 +38,7 @@ export class TestContext {
     const { database } = testConfig.database
     await sql`drop database if exists ${sql.id(database!)}`.execute(adminDb)
     await sql`create database ${sql.id(database!)}`.execute(adminDb)
-    await adminDb.destroy()
+    await adminDb.closeConnection()
 
     // Now connect to the test databse and run the migrations
     const db = new Kysely<any>({
@@ -57,7 +57,7 @@ export class TestContext {
     })
 
     await migrator.migrateToLatest()
-    await db.destroy()
+    await db.closeConnection()
   }
 
   after = async (): Promise<void> => {

--- a/site/docs/getting-started/Instantiation.tsx
+++ b/site/docs/getting-started/Instantiation.tsx
@@ -127,8 +127,8 @@ export const db = new Kysely<Database>({
       </Admonition>
       <Admonition type="info" title="kill it with fire">
         When needed, you can dispose of the Kysely instance, release resources
-        and close all connections by invoking the <code>db.destroy()</code>{' '}
-        function.
+        and close all connections by invoking the{' '}
+        <code>db.closeConnection()</code> function.
       </Admonition>
     </>
   )

--- a/site/docs/migrations.mdx
+++ b/site/docs/migrations.mdx
@@ -172,7 +172,7 @@ async function migrateToLatest() {
     process.exit(1)
   }
 
-  await db.destroy()
+  await db.closeConnection()
 }
 
 migrateToLatest()

--- a/src/dialect/mysql/mysql-driver.ts
+++ b/src/dialect/mysql/mysql-driver.ts
@@ -90,7 +90,7 @@ export class MysqlDriver implements Driver {
     connection[PRIVATE_RELEASE_METHOD]()
   }
 
-  async destroy(): Promise<void> {
+  async closeConnection(): Promise<void> {
     return new Promise((resolve, reject) => {
       this.#pool!.end((err) => {
         if (err) {
@@ -100,6 +100,10 @@ export class MysqlDriver implements Driver {
         }
       })
     })
+  }
+
+  async destroy(): Promise<void> {
+    return await this.closeConnection()
   }
 }
 

--- a/src/dialect/postgres/postgres-driver.ts
+++ b/src/dialect/postgres/postgres-driver.ts
@@ -79,6 +79,10 @@ export class PostgresDriver implements Driver {
   }
 
   async destroy(): Promise<void> {
+    await this.closeConnection()
+  }
+
+  async closeConnection(): Promise<void> {
     if (this.#pool) {
       const pool = this.#pool
       this.#pool = undefined

--- a/src/dialect/sqlite/sqlite-driver.ts
+++ b/src/dialect/sqlite/sqlite-driver.ts
@@ -53,8 +53,12 @@ export class SqliteDriver implements Driver {
     this.#connectionMutex.unlock()
   }
 
-  async destroy(): Promise<void> {
+  async closeConnection(): Promise<void> {
     this.#db?.close()
+  }
+
+  async destroy(): Promise<void> {
+    await this.closeConnection()
   }
 }
 

--- a/src/driver/driver.ts
+++ b/src/driver/driver.ts
@@ -45,7 +45,12 @@ export interface Driver {
   /**
    * Destroys the driver and releases all resources.
    */
-  destroy(): Promise<void>
+  closeConnection(): Promise<void>
+
+  /**
+   * @deprecated Use `closeConnection` instead.
+   */
+  destroy?(): Promise<void>
 }
 
 export interface TransactionSettings {

--- a/src/driver/dummy-driver.ts
+++ b/src/driver/dummy-driver.ts
@@ -65,6 +65,10 @@ export class DummyDriver implements Driver {
   async destroy(): Promise<void> {
     // Nothing to do here.
   }
+
+  async closeConnection(): Promise<void> {
+    // Nothing to do here.
+  }
 }
 
 class DummyConnection implements DatabaseConnection {

--- a/src/driver/runtime-driver.ts
+++ b/src/driver/runtime-driver.ts
@@ -68,7 +68,7 @@ export class RuntimeDriver implements Driver {
     return this.#driver.rollbackTransaction(connection)
   }
 
-  async destroy(): Promise<void> {
+  async closeConnection(): Promise<void> {
     if (!this.#initPromise) {
       return
     }
@@ -76,13 +76,17 @@ export class RuntimeDriver implements Driver {
     await this.#initPromise
 
     if (!this.#destroyPromise) {
-      this.#destroyPromise = this.#driver.destroy().catch((err) => {
+      this.#destroyPromise = this.#driver.closeConnection().catch((err) => {
         this.#destroyPromise = undefined
         return Promise.reject(err)
       })
     }
 
     await this.#destroyPromise
+  }
+
+  async destroy(): Promise<void> {
+    await this.closeConnection()
   }
 
   #needsLogging(): boolean {

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -345,8 +345,15 @@ export class Kysely<DB>
    *
    * You need to call this when you are done using the `Kysely` instance.
    */
+  async closeConnection(): Promise<void> {
+    await this.#props.driver.closeConnection()
+  }
+
+  /**
+   * @deprecated Use `db.closeConnection()` instead.
+   */
   async destroy(): Promise<void> {
-    await this.#props.driver.destroy()
+    await this.closeConnection()
   }
 
   /**

--- a/test/bun/bun.test.ts
+++ b/test/bun/bun.test.ts
@@ -59,4 +59,4 @@ await Promise.all(dbs.map((db) => query.execute(db)))
 
 console.log('bun test passed')
 
-await Promise.all(dbs.map((db) => db.destroy()))
+await Promise.all(dbs.map((db) => db.closeConnection()))

--- a/test/deno/cdn.test.ts
+++ b/test/deno/cdn.test.ts
@@ -51,4 +51,4 @@ await Promise.all(dbs.map((db) => query.execute(db)))
 
 console.error('CDN deno test passed')
 
-await Promise.all(dbs.map((db) => db.destroy()))
+await Promise.all(dbs.map((db) => db.closeConnection()))

--- a/test/deno/local.test.ts
+++ b/test/deno/local.test.ts
@@ -57,4 +57,4 @@ await Promise.all(dbs.map((db) => query.execute(db)))
 
 console.error('local deno test passed')
 
-await Promise.all(dbs.map((db) => db.destroy()))
+await Promise.all(dbs.map((db) => db.closeConnection()))

--- a/test/node/src/camel-case.test.ts
+++ b/test/node/src/camel-case.test.ts
@@ -68,7 +68,7 @@ for (const dialect of DIALECTS) {
 
     after(async () => {
       await camelDb.schema.dropTable('camelPerson').ifExists().execute()
-      await camelDb.destroy()
+      await camelDb.closeConnection()
       await destroyTest(ctx)
     })
 

--- a/test/node/src/select.test.ts
+++ b/test/node/src/select.test.ts
@@ -843,7 +843,7 @@ for (const dialect of DIALECTS) {
             "'cursor' is not present in your postgres dialect config. It's required to make streaming work in postgres."
           )
 
-          await db.destroy()
+          await db.closeConnection()
         })
       }
     }

--- a/test/node/src/test-setup.ts
+++ b/test/node/src/test-setup.ts
@@ -171,7 +171,7 @@ export async function initTest(
 
 export async function destroyTest(ctx: TestContext): Promise<void> {
   await dropDatabase(ctx.db)
-  await ctx.db.destroy()
+  await ctx.db.closeConnection()
 }
 
 export async function insertPersons(
@@ -304,7 +304,7 @@ async function connect(config: KyselyConfig): Promise<Kysely<Database>> {
       console.error(error)
 
       if (db) {
-        await db.destroy().catch((error) => error)
+        await db.closeConnection().catch((error) => error)
       }
 
       console.log(


### PR DESCRIPTION
While reading the migrations docs, I saw that the driver method to terminate a connection was called destroy. It felt counter-intuitive and dangerous looking for me to call a destroy method on something that is interfacing with my database. I thought I would point that one out to you guys. Let me know what you think!

![image](https://github.com/kysely-org/kysely/assets/5232291/18910a9a-e903-4f7d-9504-21a659ec1275)
