### PR TITLE
Support select queries without from clause

### DIFF
--- a/src/expression/expression-builder.ts
+++ b/src/expression/expression-builder.ts
@@ -265,7 +265,7 @@ export interface ExpressionBuilder<DB, TB extends keyof DB> {
    * This method accepts the same inputs as {@link SelectQueryBuilder.select}. See its
    * documentation for examples.
    */
-  select<SE extends SelectExpression<DB, TB>>(
+  selectNoFrom<SE extends SelectExpression<DB, TB>>(
     selection: SelectArg<DB, TB, SE>
   ): SelectQueryBuilder<DB, TB, Selection<DB, TB, SE>>
 
@@ -878,7 +878,7 @@ export function createExpressionBuilder<DB, TB extends keyof DB>(
       })
     },
 
-    select<SE extends SelectExpression<DB, TB>>(
+    selectNoFrom<SE extends SelectExpression<DB, TB>>(
       selection: SelectArg<DB, TB, SE>
     ): SelectQueryBuilder<DB, TB, Selection<DB, TB, SE>> {
       return createSelectQueryBuilder({

--- a/src/operation-node/select-query-node.ts
+++ b/src/operation-node/select-query-node.ts
@@ -18,7 +18,7 @@ import { SetOperationNode } from './set-operation-node.js'
 
 export interface SelectQueryNode extends OperationNode {
   readonly kind: 'SelectQueryNode'
-  readonly from: FromNode
+  readonly from?: FromNode
   readonly selections?: ReadonlyArray<SelectionNode>
   readonly distinctOn?: ReadonlyArray<OperationNode>
   readonly joins?: ReadonlyArray<JoinNode>
@@ -43,7 +43,14 @@ export const SelectQueryNode = freeze({
     return node.kind === 'SelectQueryNode'
   },
 
-  create(
+  create(withNode?: WithNode): SelectQueryNode {
+    return freeze({
+      kind: 'SelectQueryNode',
+      ...(withNode && { with: withNode }),
+    })
+  },
+
+  createFrom(
     fromItems: ReadonlyArray<OperationNode>,
     withNode?: WithNode
   ): SelectQueryNode {

--- a/src/parser/parse-utils.ts
+++ b/src/parser/parse-utils.ts
@@ -20,7 +20,7 @@ export function createSelectQueryBuilder(): SelectQueryBuilder<any, any, any> {
   return newSelectQueryBuilder({
     queryId: createQueryId(),
     executor: NOOP_QUERY_EXECUTOR,
-    queryNode: SelectQueryNode.create(parseTableExpressionOrList([])),
+    queryNode: SelectQueryNode.createFrom(parseTableExpressionOrList([])),
   })
 }
 

--- a/src/plugin/camel-case/camel-case-plugin.ts
+++ b/src/plugin/camel-case/camel-case-plugin.ts
@@ -1,12 +1,6 @@
 import { QueryResult } from '../../driver/database-connection.js'
 import { RootOperationNode } from '../../query-compiler/query-compiler.js'
-import {
-  isArrayBufferOrView,
-  isBuffer,
-  isDate,
-  isObject,
-  isPlainObject,
-} from '../../util/object-utils.js'
+import { isPlainObject } from '../../util/object-utils.js'
 import { UnknownRow } from '../../util/type-utils.js'
 import {
   KyselyPlugin,
@@ -97,9 +91,9 @@ export interface CamelCasePluginOptions {
  * ```
  *
  * As you can see from the example, __everything__ needs to be defined
- * in camelCase in the typescript code: the table names, the columns,
- * schemas, __everything__. When using the `CamelCasePlugin` Kysely
- * works as if the database was defined in camelCase.
+ * in camelCase in the typescript code: table names, columns, schemas,
+ * __everything__. When using the `CamelCasePlugin` Kysely works as if
+ * the database was defined in camelCase.
  *
  * There are various options you can give to the plugin to modify
  * the way identifiers are converted. See {@link CamelCasePluginOptions}.

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -151,24 +151,27 @@ export class DefaultQueryCompiler
       this.append(' ')
     }
 
-    this.append('select ')
+    this.append('select')
 
     if (node.distinctOn) {
-      this.compileDistinctOn(node.distinctOn)
       this.append(' ')
+      this.compileDistinctOn(node.distinctOn)
     }
 
-    if (node.frontModifiers && node.frontModifiers.length > 0) {
-      this.compileList(node.frontModifiers, ' ')
+    if (node.frontModifiers?.length) {
       this.append(' ')
+      this.compileList(node.frontModifiers, ' ')
     }
 
     if (node.selections) {
-      this.compileList(node.selections)
       this.append(' ')
+      this.compileList(node.selections)
     }
 
-    this.visitNode(node.from)
+    if (node.from) {
+      this.append(' ')
+      this.visitNode(node.from)
+    }
 
     if (node.joins) {
       this.append(' ')
@@ -210,7 +213,7 @@ export class DefaultQueryCompiler
       this.visitNode(node.offset)
     }
 
-    if (node.endModifiers && node.endModifiers.length > 0) {
+    if (node.endModifiers?.length) {
       this.append(' ')
       this.compileList(node.endModifiers, ' ')
     }
@@ -944,7 +947,7 @@ export class DefaultQueryCompiler
       if (!node.materialized) {
         this.append('not ')
       }
-      
+
       this.append('materialized ')
     }
 

--- a/src/query-creator.ts
+++ b/src/query-creator.ts
@@ -200,12 +200,12 @@ export class QueryCreator<DB> {
    *
    * If you want to create a `select from` query, use the `selectFrom` method instead.
    * This one can be used to create a plain `select` statement without a `from` clause.
-   * 
+   *
    * This method accepts the same inputs as {@link SelectQueryBuilder.select}. See its
    * documentation for more examples.
-   * 
+   *
    * ### Examples
-   * 
+   *
    * ```ts
    * const result = db.select((eb) => [
    *   eb.selectFrom('person')
@@ -213,7 +213,7 @@ export class QueryCreator<DB> {
    *     .where('first_name', '=', 'Jennifer')
    *     .limit(1)
    *     .as('jennifer_id'),
-   * 
+   *
    *   eb.selectFrom('pet')
    *     .select('id')
    *     .where('name', '=', 'Doggo')
@@ -221,11 +221,11 @@ export class QueryCreator<DB> {
    *     .as('doggo_id')
    *   ])
    *   .executeTakeFirstOrThrow()
-   * 
+   *
    * console.log(result.jennifer_id)
    * console.log(result.doggo_id)
    * ```
-   * 
+   *
    * The generated SQL (PostgreSQL):
    *
    * ```sql
@@ -242,7 +242,7 @@ export class QueryCreator<DB> {
    * ) as "doggo_id"
    * ```
    */
-  select<SE extends SelectExpression<DB, never>>(
+  selectNoFrom<SE extends SelectExpression<DB, never>>(
     selection: SelectArg<DB, never, SE>
   ): SelectQueryBuilder<DB, never, Selection<DB, never, SE>> {
     return createSelectQueryBuilder({

--- a/test/node/src/select.test.ts
+++ b/test/node/src/select.test.ts
@@ -849,8 +849,8 @@ for (const dialect of DIALECTS) {
     }
 
     it('should create a select statement without a `from` clause', async () => {
-      const query = ctx.db.select((eb) => [
-        eb.select(eb.lit(1).as('one')).as('one'),
+      const query = ctx.db.selectNoFrom((eb) => [
+        eb.selectNoFrom(eb.lit(1).as('one')).as('one'),
         eb
           .selectFrom('person')
           .select('first_name')

--- a/test/typings/test-d/expression.test-d.ts
+++ b/test/typings/test-d/expression.test-d.ts
@@ -151,15 +151,15 @@ async function testExpressionBuilderSelect(
   eb: ExpressionBuilder<Database, 'person'>
 ) {
   expectAssignable<Expression<{ first_name: string }>>(
-    eb.select(eb.val('Jennifer').as('first_name'))
+    eb.selectNoFrom(eb.val('Jennifer').as('first_name'))
   )
 
   expectAssignable<Expression<{ first_name: string }>>(
-    eb.select((eb) => eb.val('Jennifer').as('first_name'))
+    eb.selectNoFrom((eb) => eb.val('Jennifer').as('first_name'))
   )
 
   expectAssignable<Expression<{ first_name: string; last_name: string }>>(
-    eb.select([
+    eb.selectNoFrom([
       eb.val('Jennifer').as('first_name'),
       eb(eb.val('Anis'), '||', eb.val('ton')).as('last_name'),
     ])
@@ -168,7 +168,7 @@ async function testExpressionBuilderSelect(
   expectAssignable<
     Expression<{ first_name: string; last_name: string | null }>
   >(
-    eb.select((eb) => [
+    eb.selectNoFrom((eb) => [
       eb.val('Jennifer').as('first_name'),
       eb.selectFrom('person').select('last_name').limit(1).as('last_name'),
     ])
@@ -176,11 +176,13 @@ async function testExpressionBuilderSelect(
 
   const r1 = await db
     .selectFrom('person as p')
-    .select((eb) => [eb.select('p.age').as('age')])
+    .select((eb) => [eb.selectNoFrom('p.age').as('age')])
     .executeTakeFirstOrThrow()
   expectType<{ age: number | null }>(r1)
 
   expectError(
-    db.selectFrom('person').select((eb) => [eb.select('pet.name').as('name')])
+    db
+      .selectFrom('person')
+      .select((eb) => [eb.selectNoFrom('pet.name').as('name')])
   )
 }

--- a/test/typings/test-d/select-no-from.test-d.ts
+++ b/test/typings/test-d/select-no-from.test-d.ts
@@ -1,0 +1,31 @@
+import { Kysely, SqlBool, sql } from '..'
+import { Database } from '../shared'
+import { expectType } from 'tsd'
+
+async function testSelectNoFrom(db: Kysely<Database>) {
+  const r1 = await db
+    .selectNoFrom(sql<'bar'>`select 'bar'`.as('foo'))
+    .executeTakeFirstOrThrow()
+  expectType<{ foo: 'bar' }>(r1)
+
+  const r2 = await db
+    .selectNoFrom((eb) => eb(eb.val(1), '=', 1).as('very_useful'))
+    .executeTakeFirstOrThrow()
+  expectType<{ very_useful: SqlBool }>(r2)
+
+  const r3 = await db
+    .selectNoFrom([
+      sql<'bar'>`select 'bar'`.as('foo'),
+      db.selectFrom('pet').select('id').limit(1).as('pet_id'),
+    ])
+    .executeTakeFirstOrThrow()
+  expectType<{ foo: 'bar'; pet_id: string | null }>(r3)
+
+  const r4 = await db
+    .selectNoFrom((eb) => [
+      eb(eb.val(1), '=', 1).as('very_useful'),
+      eb.selectFrom('pet').select('id').limit(1).as('pet_id'),
+    ])
+    .executeTakeFirstOrThrow()
+  expectType<{ very_useful: SqlBool; pet_id: string | null }>(r4)
+}

--- a/test/typings/test-d/select.test-d.ts
+++ b/test/typings/test-d/select.test-d.ts
@@ -1,42 +1,6 @@
-import {
-  Expression,
-  Kysely,
-  RawBuilder,
-  Selectable,
-  Simplify,
-  SqlBool,
-  sql,
-} from '..'
+import { Expression, Kysely, RawBuilder, Selectable, Simplify, sql } from '..'
 import { Database, Person } from '../shared'
 import { expectType, expectError } from 'tsd'
-
-async function testPlainSelect(db: Kysely<Database>) {
-  const r1 = await db
-    .select(sql<'bar'>`select 'bar'`.as('foo'))
-    .executeTakeFirstOrThrow()
-  expectType<{ foo: 'bar' }>(r1)
-
-  const r2 = await db
-    .select((eb) => eb(eb.val(1), '=', 1).as('very_useful'))
-    .executeTakeFirstOrThrow()
-  expectType<{ very_useful: SqlBool }>(r2)
-
-  const r3 = await db
-    .select([
-      sql<'bar'>`select 'bar'`.as('foo'),
-      db.selectFrom('pet').select('id').limit(1).as('pet_id'),
-    ])
-    .executeTakeFirstOrThrow()
-  expectType<{ foo: 'bar'; pet_id: string | null }>(r3)
-
-  const r4 = await db
-    .select((eb) => [
-      eb(eb.val(1), '=', 1).as('very_useful'),
-      eb.selectFrom('pet').select('id').limit(1).as('pet_id'),
-    ])
-    .executeTakeFirstOrThrow()
-  expectType<{ very_useful: SqlBool; pet_id: string | null }>(r4)
-}
 
 async function testSelectSingle(db: Kysely<Database>) {
   const qb = db.selectFrom('person')

--- a/test/typings/test-d/select.test-d.ts
+++ b/test/typings/test-d/select.test-d.ts
@@ -1,6 +1,42 @@
-import { Expression, Kysely, RawBuilder, Selectable, Simplify, sql } from '..'
+import {
+  Expression,
+  Kysely,
+  RawBuilder,
+  Selectable,
+  Simplify,
+  SqlBool,
+  sql,
+} from '..'
 import { Database, Person } from '../shared'
 import { expectType, expectError } from 'tsd'
+
+async function testPlainSelect(db: Kysely<Database>) {
+  const r1 = await db
+    .select(sql<'bar'>`select 'bar'`.as('foo'))
+    .executeTakeFirstOrThrow()
+  expectType<{ foo: 'bar' }>(r1)
+
+  const r2 = await db
+    .select((eb) => eb(eb.val(1), '=', 1).as('very_useful'))
+    .executeTakeFirstOrThrow()
+  expectType<{ very_useful: SqlBool }>(r2)
+
+  const r3 = await db
+    .select([
+      sql<'bar'>`select 'bar'`.as('foo'),
+      db.selectFrom('pet').select('id').limit(1).as('pet_id'),
+    ])
+    .executeTakeFirstOrThrow()
+  expectType<{ foo: 'bar'; pet_id: string | null }>(r3)
+
+  const r4 = await db
+    .select((eb) => [
+      eb(eb.val(1), '=', 1).as('very_useful'),
+      eb.selectFrom('pet').select('id').limit(1).as('pet_id'),
+    ])
+    .executeTakeFirstOrThrow()
+  expectType<{ very_useful: SqlBool; pet_id: string | null }>(r4)
+}
 
 async function testSelectSingle(db: Kysely<Database>) {
   const qb = db.selectFrom('person')


### PR DESCRIPTION
This has been requested a lot. Let's hope knex peeps don't get too confused.

`select` returns `SelectQueryBuilder` that has join methods that are not supported without a `from` clause. The alternative was copy-pasting the whole `SelectQueryBuilder` without the join methods. I think this is the lesser evil.