### PR TITLE
types: preserve object type unions in $narrowType

### DIFF
--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -167,13 +167,17 @@ export type Equals<T, U> = (<G>() => G extends T ? 1 : 2) extends <
   ? true
   : false
 
-export type NarrowPartial<S, T> = DrainOuterGeneric<{
-  [K in keyof S & string]: K extends keyof T
-    ? T[K] extends S[K]
-      ? T[K]
-      : KyselyTypeError<`$narrowType() call failed: passed type does not exist in '${K}'s type union`>
-    : S[K]
-}>
+export type NarrowPartial<S, T> = DrainOuterGeneric<
+  T extends object
+    ? {
+        [K in keyof S & string]: K extends keyof T
+          ? T[K] extends S[K]
+            ? T[K]
+            : KyselyTypeError<`$narrowType() call failed: passed type does not exist in '${K}'s type union`>
+          : S[K]
+      }
+    : never
+>
 
 export type SqlBool = boolean | 0 | 1
 

--- a/test/typings/shared.d.ts
+++ b/test/typings/shared.d.ts
@@ -36,8 +36,22 @@ export interface Database {
   book: Book
   toy: Toy
   person_metadata: PersonMetadata
+  action: Action
 }
 
+export type Action =
+  | {
+      id: GeneratedAlways<string>
+      type: 'CALL_WEBHOOK'
+      queue_id: null
+      callback_url: string
+    }
+  | {
+      id: GeneratedAlways<string>
+      type: 'DELETE_FROM_QUEUE'
+      queue_id: string
+      callback_url: null
+    }
 export interface Person {
   id: Generated<number>
   first_name: string

--- a/test/typings/test-d/select.test-d.ts
+++ b/test/typings/test-d/select.test-d.ts
@@ -1,5 +1,5 @@
 import { Expression, Kysely, RawBuilder, Selectable, Simplify, sql } from '..'
-import { Database, Person, Pet } from '../shared'
+import { Database, Person } from '../shared'
 import { expectType, expectError } from 'tsd'
 
 async function testSelectSingle(db: Kysely<Database>) {
@@ -94,6 +94,19 @@ async function testSelectSingle(db: Kysely<Database>) {
   expectError(qb.select('not_property'))
   expectError(qb.select('person.not_property'))
   expectError(qb.select('person.not_property as np'))
+
+  // Narrow Type
+  type NarrowTarget =
+    | { queue_id: string; callback_url: null }
+    | { queue_id: null; callback_url: string }
+
+  const [r15] = await db
+    .selectFrom('action')
+    .select(['callback_url', 'queue_id'])
+    .$narrowType<NarrowTarget>()
+    .execute()
+
+  expectType<NarrowTarget>(r15)
 }
 
 async function testSelectAll(db: Kysely<Database>) {


### PR DESCRIPTION
PR to address part of #577. The new test here failed previously, but passes with this change to `NarrowPartial`. There weren't any previous tests for `NarrowPartial`, so let me know if there are any you'd like me to add to make sure that this didn't break anything.