### PR TITLE
Support tuples

### DIFF
--- a/src/expression/expression-builder.ts
+++ b/src/expression/expression-builder.ts
@@ -72,6 +72,17 @@ import {
   Selection,
   parseSelectArg,
 } from '../parser/select-parser.js'
+import {
+  RefTuple2,
+  RefTuple3,
+  RefTuple4,
+  RefTuple5,
+  ValTuple2,
+  ValTuple3,
+  ValTuple4,
+  ValTuple5,
+} from '../parser/tuple-parser.js'
+import { TupleNode } from '../operation-node/tuple-node.js'
 
 export interface ExpressionBuilder<DB, TB extends keyof DB> {
   /**
@@ -473,6 +484,184 @@ export interface ExpressionBuilder<DB, TB extends keyof DB> {
   val<VE>(
     value: VE
   ): ExpressionWrapper<DB, TB, ExtractTypeFromValueExpression<VE>>
+
+  /**
+   * Creates a tuple expression.
+   *
+   * This creates a tuple using column references by default. See {@link valTuple}
+   * if you need to create value tuples.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * db.selectFrom('person')
+   *   .selectAll('person')
+   *   .where(({ eb, tuple, valTuple }) => eb(
+   *     tuple('first_name', 'last_name'),
+   *     'in',
+   *     [
+   *       valTuple('Jennifer', 'Aniston'),
+   *       valTuple('Sylvester', 'Stallone')
+   *     ]
+   *   ))
+   * ```
+   *
+   * The generated SQL (PostgreSQL):
+   *
+   * ```sql
+   * select
+   *   "person".*
+   * from
+   *   "person"
+   * where
+   *   ("first_name", "last_name")
+   *   in
+   *   (
+   *     ($1, $2),
+   *     ($3, $4)
+   *   )
+   * ```
+   *
+   * In the next example a reference tuple is compared to a subquery. Note that
+   * in this case you need to use the {@link @SelectQueryBuilder.$asTuple | $asTuple}
+   * function:
+   *
+   * ```ts
+   * db.selectFrom('person')
+   *   .selectAll('person')
+   *   .where(({ eb, tuple, selectFrom }) => eb(
+   *     tuple('first_name', 'last_name'),
+   *     'in',
+   *     selectFrom('pet')
+   *       .select(['name', 'species'])
+   *       .where('species', '!=', 'cat')
+   *       .$asTuple('name', 'species')
+   *   ))
+   * ```
+   *
+   * The generated SQL (PostgreSQL):
+   *
+   * ```sql
+   * select
+   *   "person".*
+   * from
+   *   "person"
+   * where
+   *   ("first_name", "last_name")
+   *   in
+   *   (
+   *     select "name", "species"
+   *     from "pet"
+   *     where "species" != $1
+   *   )
+   * ```
+   */
+  tuple<
+    R1 extends ReferenceExpression<DB, TB>,
+    R2 extends ReferenceExpression<DB, TB>
+  >(
+    value1: R1,
+    value2: R2
+  ): ExpressionWrapper<DB, TB, RefTuple2<DB, TB, R1, R2>>
+
+  tuple<
+    R1 extends ReferenceExpression<DB, TB>,
+    R2 extends ReferenceExpression<DB, TB>,
+    R3 extends ReferenceExpression<DB, TB>
+  >(
+    value1: R1,
+    value2: R2,
+    value3: R3
+  ): ExpressionWrapper<DB, TB, RefTuple3<DB, TB, R1, R2, R3>>
+
+  tuple<
+    R1 extends ReferenceExpression<DB, TB>,
+    R2 extends ReferenceExpression<DB, TB>,
+    R3 extends ReferenceExpression<DB, TB>,
+    R4 extends ReferenceExpression<DB, TB>
+  >(
+    value1: R1,
+    value2: R2,
+    value3: R3,
+    value4: R4
+  ): ExpressionWrapper<DB, TB, RefTuple4<DB, TB, R1, R2, R3, R4>>
+
+  tuple<
+    R1 extends ReferenceExpression<DB, TB>,
+    R2 extends ReferenceExpression<DB, TB>,
+    R3 extends ReferenceExpression<DB, TB>,
+    R4 extends ReferenceExpression<DB, TB>,
+    R5 extends ReferenceExpression<DB, TB>
+  >(
+    value1: R1,
+    value2: R2,
+    value3: R3,
+    value4: R4,
+    value5: R5
+  ): ExpressionWrapper<DB, TB, RefTuple5<DB, TB, R1, R2, R3, R4, R5>>
+
+  /**
+   * Creates a value tuple expression.
+   *
+   * This creates a tuple using values by default. See {@link tuple} if you need to create
+   * tuples using column references.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * db.selectFrom('person')
+   *   .selectAll('person')
+   *   .where(({ eb, tuple, valTuple }) => eb(
+   *     tuple('first_name', 'last_name'),
+   *     'in',
+   *     [
+   *       valTuple('Jennifer', 'Aniston'),
+   *       valTuple('Sylvester', 'Stallone')
+   *     ]
+   *   ))
+   * ```
+   *
+   * The generated SQL (PostgreSQL):
+   *
+   * ```sql
+   * select
+   *   "person".*
+   * from
+   *   "person"
+   * where
+   *   ("first_name", "last_name")
+   *   in
+   *   (
+   *     ($1, $2),
+   *     ($3, $4)
+   *   )
+   * ```
+   */
+  valTuple<V1, V2>(
+    value1: V1,
+    value2: V2
+  ): ExpressionWrapper<DB, TB, ValTuple2<V1, V2>>
+
+  valTuple<V1, V2, V3>(
+    value1: V1,
+    value2: V2,
+    value3: V3
+  ): ExpressionWrapper<DB, TB, ValTuple3<V1, V2, V3>>
+
+  valTuple<V1, V2, V3, V4>(
+    value1: V1,
+    value2: V2,
+    value3: V3,
+    value4: V4
+  ): ExpressionWrapper<DB, TB, ValTuple4<V1, V2, V3, V4>>
+
+  valTuple<V1, V2, V3, V4, V5>(
+    value1: V1,
+    value2: V2,
+    value3: V3,
+    value4: V4,
+    value5: V5
+  ): ExpressionWrapper<DB, TB, ValTuple5<V1, V2, V3, V4, V5>>
 
   /**
    * Returns a literal value expression.
@@ -948,6 +1137,22 @@ export function createExpressionBuilder<DB, TB extends keyof DB>(
       value: VE
     ): ExpressionWrapper<DB, TB, ExtractTypeFromValueExpression<VE>> {
       return new ExpressionWrapper(parseValueExpressionOrList(value))
+    },
+
+    tuple(
+      ...values: ReadonlyArray<ReferenceExpression<any, any>>
+    ): ExpressionWrapper<DB, TB, any> {
+      return new ExpressionWrapper(
+        TupleNode.create(values.map(parseReferenceExpression))
+      )
+    },
+
+    valTuple(
+      ...values: ReadonlyArray<unknown>
+    ): ExpressionWrapper<DB, TB, any> {
+      return new ExpressionWrapper(
+        TupleNode.create(values.map(parseValueExpression))
+      )
     },
 
     lit<VE extends number | boolean | null>(

--- a/src/expression/expression-builder.ts
+++ b/src/expression/expression-builder.ts
@@ -488,7 +488,7 @@ export interface ExpressionBuilder<DB, TB extends keyof DB> {
   /**
    * Creates a tuple expression.
    *
-   * This creates a tuple using column references by default. See {@link valTuple}
+   * This creates a tuple using column references by default. See {@link tuple}
    * if you need to create value tuples.
    *
    * ### Examples
@@ -496,12 +496,12 @@ export interface ExpressionBuilder<DB, TB extends keyof DB> {
    * ```ts
    * db.selectFrom('person')
    *   .selectAll('person')
-   *   .where(({ eb, tuple, valTuple }) => eb(
-   *     tuple('first_name', 'last_name'),
+   *   .where(({ eb, refTuple, tuple }) => eb(
+   *     refTuple('first_name', 'last_name'),
    *     'in',
    *     [
-   *       valTuple('Jennifer', 'Aniston'),
-   *       valTuple('Sylvester', 'Stallone')
+   *       tuple('Jennifer', 'Aniston'),
+   *       tuple('Sylvester', 'Stallone')
    *     ]
    *   ))
    * ```
@@ -529,8 +529,8 @@ export interface ExpressionBuilder<DB, TB extends keyof DB> {
    * ```ts
    * db.selectFrom('person')
    *   .selectAll('person')
-   *   .where(({ eb, tuple, selectFrom }) => eb(
-   *     tuple('first_name', 'last_name'),
+   *   .where(({ eb, refTuple, selectFrom }) => eb(
+   *     refTuple('first_name', 'last_name'),
    *     'in',
    *     selectFrom('pet')
    *       .select(['name', 'species'])
@@ -556,7 +556,7 @@ export interface ExpressionBuilder<DB, TB extends keyof DB> {
    *   )
    * ```
    */
-  tuple<
+  refTuple<
     R1 extends ReferenceExpression<DB, TB>,
     R2 extends ReferenceExpression<DB, TB>
   >(
@@ -564,7 +564,7 @@ export interface ExpressionBuilder<DB, TB extends keyof DB> {
     value2: R2
   ): ExpressionWrapper<DB, TB, RefTuple2<DB, TB, R1, R2>>
 
-  tuple<
+  refTuple<
     R1 extends ReferenceExpression<DB, TB>,
     R2 extends ReferenceExpression<DB, TB>,
     R3 extends ReferenceExpression<DB, TB>
@@ -574,7 +574,7 @@ export interface ExpressionBuilder<DB, TB extends keyof DB> {
     value3: R3
   ): ExpressionWrapper<DB, TB, RefTuple3<DB, TB, R1, R2, R3>>
 
-  tuple<
+  refTuple<
     R1 extends ReferenceExpression<DB, TB>,
     R2 extends ReferenceExpression<DB, TB>,
     R3 extends ReferenceExpression<DB, TB>,
@@ -586,7 +586,7 @@ export interface ExpressionBuilder<DB, TB extends keyof DB> {
     value4: R4
   ): ExpressionWrapper<DB, TB, RefTuple4<DB, TB, R1, R2, R3, R4>>
 
-  tuple<
+  refTuple<
     R1 extends ReferenceExpression<DB, TB>,
     R2 extends ReferenceExpression<DB, TB>,
     R3 extends ReferenceExpression<DB, TB>,
@@ -603,7 +603,7 @@ export interface ExpressionBuilder<DB, TB extends keyof DB> {
   /**
    * Creates a value tuple expression.
    *
-   * This creates a tuple using values by default. See {@link tuple} if you need to create
+   * This creates a tuple using values by default. See {@link refTuple} if you need to create
    * tuples using column references.
    *
    * ### Examples
@@ -611,12 +611,12 @@ export interface ExpressionBuilder<DB, TB extends keyof DB> {
    * ```ts
    * db.selectFrom('person')
    *   .selectAll('person')
-   *   .where(({ eb, tuple, valTuple }) => eb(
-   *     tuple('first_name', 'last_name'),
+   *   .where(({ eb, refTuple, tuple }) => eb(
+   *     refTuple('first_name', 'last_name'),
    *     'in',
    *     [
-   *       valTuple('Jennifer', 'Aniston'),
-   *       valTuple('Sylvester', 'Stallone')
+   *       tuple('Jennifer', 'Aniston'),
+   *       tuple('Sylvester', 'Stallone')
    *     ]
    *   ))
    * ```
@@ -637,25 +637,25 @@ export interface ExpressionBuilder<DB, TB extends keyof DB> {
    *   )
    * ```
    */
-  valTuple<V1, V2>(
+  tuple<V1, V2>(
     value1: V1,
     value2: V2
   ): ExpressionWrapper<DB, TB, ValTuple2<V1, V2>>
 
-  valTuple<V1, V2, V3>(
+  tuple<V1, V2, V3>(
     value1: V1,
     value2: V2,
     value3: V3
   ): ExpressionWrapper<DB, TB, ValTuple3<V1, V2, V3>>
 
-  valTuple<V1, V2, V3, V4>(
+  tuple<V1, V2, V3, V4>(
     value1: V1,
     value2: V2,
     value3: V3,
     value4: V4
   ): ExpressionWrapper<DB, TB, ValTuple4<V1, V2, V3, V4>>
 
-  valTuple<V1, V2, V3, V4, V5>(
+  tuple<V1, V2, V3, V4, V5>(
     value1: V1,
     value2: V2,
     value3: V3,
@@ -1139,7 +1139,7 @@ export function createExpressionBuilder<DB, TB extends keyof DB>(
       return new ExpressionWrapper(parseValueExpressionOrList(value))
     },
 
-    tuple(
+    refTuple(
       ...values: ReadonlyArray<ReferenceExpression<any, any>>
     ): ExpressionWrapper<DB, TB, any> {
       return new ExpressionWrapper(
@@ -1147,9 +1147,7 @@ export function createExpressionBuilder<DB, TB extends keyof DB>(
       )
     },
 
-    valTuple(
-      ...values: ReadonlyArray<unknown>
-    ): ExpressionWrapper<DB, TB, any> {
+    tuple(...values: ReadonlyArray<unknown>): ExpressionWrapper<DB, TB, any> {
       return new ExpressionWrapper(
         TupleNode.create(values.map(parseValueExpression))
       )

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,7 @@ export * from './operation-node/json-reference-node.js'
 export * from './operation-node/json-path-leg-node.js'
 export * from './operation-node/json-path-node.js'
 export * from './operation-node/json-operator-chain-node.js'
+export * from './operation-node/tuple-node.js'
 
 export * from './util/column-type.js'
 export * from './util/compilable.js'

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -86,6 +86,7 @@ import { JSONReferenceNode } from './json-reference-node.js'
 import { JSONPathNode } from './json-path-node.js'
 import { JSONPathLegNode } from './json-path-leg-node.js'
 import { JSONOperatorChainNode } from './json-operator-chain-node.js'
+import { TupleNode } from './tuple-node.js'
 
 /**
  * Transforms an operation node tree into another one.
@@ -206,6 +207,7 @@ export class OperationNodeTransformer {
     JSONPathNode: this.transformJSONPath.bind(this),
     JSONPathLegNode: this.transformJSONPathLeg.bind(this),
     JSONOperatorChainNode: this.transformJSONOperatorChain.bind(this),
+    TupleNode: this.transformTuple.bind(this),
   })
 
   transformNode<T extends OperationNode | undefined>(node: T): T {
@@ -959,6 +961,13 @@ export class OperationNodeTransformer {
     return requireAllProps<JSONOperatorChainNode>({
       kind: 'JSONOperatorChainNode',
       operator: this.transformNode(node.operator),
+      values: this.transformNodeList(node.values),
+    })
+  }
+
+  protected transformTuple(node: TupleNode): TupleNode {
+    return requireAllProps<TupleNode>({
+      kind: 'TupleNode',
       values: this.transformNodeList(node.values),
     })
   }

--- a/src/operation-node/operation-node-visitor.ts
+++ b/src/operation-node/operation-node-visitor.ts
@@ -88,6 +88,7 @@ import { JSONReferenceNode } from './json-reference-node.js'
 import { JSONPathNode } from './json-path-node.js'
 import { JSONPathLegNode } from './json-path-leg-node.js'
 import { JSONOperatorChainNode } from './json-operator-chain-node.js'
+import { TupleNode } from './tuple-node.js'
 
 export abstract class OperationNodeVisitor {
   protected readonly nodeStack: OperationNode[] = []
@@ -183,6 +184,7 @@ export abstract class OperationNodeVisitor {
     JSONPathNode: this.visitJSONPath.bind(this),
     JSONPathLegNode: this.visitJSONPathLeg.bind(this),
     JSONOperatorChainNode: this.visitJSONOperatorChain.bind(this),
+    TupleNode: this.visitTuple.bind(this),
   })
 
   protected readonly visitNode = (node: OperationNode): void => {
@@ -286,4 +288,5 @@ export abstract class OperationNodeVisitor {
   protected abstract visitJSONPath(node: JSONPathNode): void
   protected abstract visitJSONPathLeg(node: JSONPathLegNode): void
   protected abstract visitJSONOperatorChain(node: JSONOperatorChainNode): void
+  protected abstract visitTuple(node: TupleNode): void
 }

--- a/src/operation-node/operation-node.ts
+++ b/src/operation-node/operation-node.ts
@@ -84,6 +84,7 @@ export type OperationNodeKind =
   | 'JSONPathNode'
   | 'JSONPathLegNode'
   | 'JSONOperatorChainNode'
+  | 'TupleNode'
 
 export interface OperationNode {
   readonly kind: OperationNodeKind

--- a/src/operation-node/tuple-node.ts
+++ b/src/operation-node/tuple-node.ts
@@ -1,0 +1,23 @@
+import { freeze } from '../util/object-utils.js'
+import { OperationNode } from './operation-node.js'
+
+export interface TupleNode extends OperationNode {
+  readonly kind: 'TupleNode'
+  readonly values: ReadonlyArray<OperationNode>
+}
+
+/**
+ * @internal
+ */
+export const TupleNode = freeze({
+  is(node: OperationNode): node is TupleNode {
+    return node.kind === 'TupleNode'
+  },
+
+  create(values: ReadonlyArray<OperationNode>): TupleNode {
+    return freeze({
+      kind: 'TupleNode',
+      values: freeze(values),
+    })
+  },
+})

--- a/src/parser/select-parser.ts
+++ b/src/parser/select-parser.ts
@@ -42,11 +42,13 @@ export type SelectArg<
   | ReadonlyArray<SE>
   | ((eb: ExpressionBuilder<DB, TB>) => ReadonlyArray<SE>)
 
-export type Selection<DB, TB extends keyof DB, SE> = {
-  [A in ExtractAliasFromSelectExpression<SE>]: SelectType<
-    ExtractTypeFromSelectExpression<DB, TB, SE, A>
-  >
-}
+export type Selection<DB, TB extends keyof DB, SE> = [SE] extends [unknown]
+  ? {
+      [A in ExtractAliasFromSelectExpression<SE>]: SelectType<
+        ExtractTypeFromSelectExpression<DB, TB, SE, A>
+      >
+    }
+  : never
 
 type ExtractAliasFromSelectExpression<SE> = SE extends string
   ? ExtractAliasFromStringSelectExpression<SE>
@@ -151,11 +153,13 @@ type ExtractTypeFromStringSelectExpression<
     : never
   : never
 
-export type AllSelection<DB, TB extends keyof DB> = Selectable<{
-  [C in AnyColumn<DB, TB>]: {
-    [T in TB]: C extends keyof DB[T] ? DB[T][C] : never
-  }[TB]
-}>
+export type AllSelection<DB, TB extends keyof DB> = [DB] extends [unknown]
+  ? Selectable<{
+      [C in AnyColumn<DB, TB>]: {
+        [T in TB]: C extends keyof DB[T] ? DB[T][C] : never
+      }[TB]
+    }>
+  : never
 
 export function parseSelectArg(
   selection: SelectArg<any, any, SelectExpression<any, any>>

--- a/src/parser/tuple-parser.ts
+++ b/src/parser/tuple-parser.ts
@@ -1,0 +1,73 @@
+import { ExtractTypeFromReferenceExpression } from './reference-parser.js'
+import { ExtractTypeFromValueExpression } from './value-parser.js'
+
+export type RefTuple2<DB, TB extends keyof DB, R1, R2> = [R1] extends [unknown]
+  ? [
+      ExtractTypeFromReferenceExpression<DB, TB, R1>,
+      ExtractTypeFromReferenceExpression<DB, TB, R2>
+    ]
+  : never
+
+export type RefTuple3<DB, TB extends keyof DB, R1, R2, R3> = [R1] extends [
+  unknown
+]
+  ? [
+      ExtractTypeFromReferenceExpression<DB, TB, R1>,
+      ExtractTypeFromReferenceExpression<DB, TB, R2>,
+      ExtractTypeFromReferenceExpression<DB, TB, R3>
+    ]
+  : never
+
+export type RefTuple4<DB, TB extends keyof DB, R1, R2, R3, R4> = [R1] extends [
+  unknown
+]
+  ? [
+      ExtractTypeFromReferenceExpression<DB, TB, R1>,
+      ExtractTypeFromReferenceExpression<DB, TB, R2>,
+      ExtractTypeFromReferenceExpression<DB, TB, R3>,
+      ExtractTypeFromReferenceExpression<DB, TB, R4>
+    ]
+  : never
+
+export type RefTuple5<DB, TB extends keyof DB, R1, R2, R3, R4, R5> = [
+  R1
+] extends [unknown]
+  ? [
+      ExtractTypeFromReferenceExpression<DB, TB, R1>,
+      ExtractTypeFromReferenceExpression<DB, TB, R2>,
+      ExtractTypeFromReferenceExpression<DB, TB, R3>,
+      ExtractTypeFromReferenceExpression<DB, TB, R4>,
+      ExtractTypeFromReferenceExpression<DB, TB, R5>
+    ]
+  : never
+
+export type ValTuple2<V1, V2> = [V1] extends [unknown]
+  ? [ExtractTypeFromValueExpression<V1>, ExtractTypeFromValueExpression<V2>]
+  : never
+
+export type ValTuple3<V1, V2, V3> = V1 extends any
+  ? [
+      ExtractTypeFromValueExpression<V1>,
+      ExtractTypeFromValueExpression<V2>,
+      ExtractTypeFromValueExpression<V3>
+    ]
+  : never
+
+export type ValTuple4<V1, V2, V3, V4> = [V1] extends [unknown]
+  ? [
+      ExtractTypeFromValueExpression<V1>,
+      ExtractTypeFromValueExpression<V2>,
+      ExtractTypeFromValueExpression<V3>,
+      ExtractTypeFromValueExpression<V4>
+    ]
+  : never
+
+export type ValTuple5<V1, V2, V3, V4, V5> = [V1] extends [unknown]
+  ? [
+      ExtractTypeFromValueExpression<V1>,
+      ExtractTypeFromValueExpression<V2>,
+      ExtractTypeFromValueExpression<V3>,
+      ExtractTypeFromValueExpression<V4>,
+      ExtractTypeFromValueExpression<V5>
+    ]
+  : never

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -71,6 +71,7 @@ import { KyselyTypeError } from '../util/type-error.js'
 import { Selectable } from '../util/column-type.js'
 import { Streamable } from '../util/streamable.js'
 import { ExpressionOrFactory } from '../parser/expression-parser.js'
+import { ExpressionWrapper } from '../expression/expression-wrapper.js'
 
 export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
   extends WhereInterface<DB, TB>,
@@ -1415,6 +1416,87 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
   $castTo<T>(): SelectQueryBuilder<DB, TB, T>
 
   /**
+   * Changes the output type from an object to a tuple.
+   *
+   * This doesn't affect the generated SQL in any way. This function is
+   * just a necessary evil when you need to convert a query's output
+   * record type to a tuple type. Typescript doesn't currently offer
+   * tools to do this automatically (without insane hackery).
+   *
+   * The returned object can no longer be executed. It can only be used
+   * as a subquery.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * const result = await db
+   *   .selectFrom('person')
+   *   .selectAll('person')
+   *   .where(({ eb, tuple, selectFrom }) => eb(
+   *     tuple('first_name', 'last_name'),
+   *     'in',
+   *     selectFrom('pet')
+   *       .select(['name', 'species'])
+   *       .where('pet.species', '!=', 'cat')
+   *       .$asTuple('name', 'species')
+   *   ))
+   * ```
+   *
+   * The generated SQL(PostgreSQL):
+   *
+   * ```sql
+   * select
+   *   "person".*
+   * from
+   *   "person"
+   * where
+   *   ("first_name", "last_name")
+   *   in
+   *   (
+   *     select "name", "species"
+   *     from "pet"
+   *     where "pet"."species" != $1
+   *   )
+   * ```
+   */
+  $asTuple<K1 extends keyof O, K2 extends keyof O>(
+    key1: K1,
+    key2: K2
+  ): ExpressionWrapper<DB, TB, [O[K1], O[K2]]>
+
+  $asTuple<K1 extends keyof O, K2 extends keyof O, K3 extends keyof O>(
+    key1: K1,
+    key2: K2,
+    key3: K3
+  ): ExpressionWrapper<DB, TB, [O[K1], O[K2], O[K3]]>
+
+  $asTuple<
+    K1 extends keyof O,
+    K2 extends keyof O,
+    K3 extends keyof O,
+    K4 extends keyof O
+  >(
+    key1: K1,
+    key2: K2,
+    key3: K3,
+    key4: K4
+  ): ExpressionWrapper<DB, TB, [O[K1], O[K2], O[K3], O[K4]]>
+
+  $asTuple<
+    K1 extends keyof O,
+    K2 extends keyof O,
+    K3 extends keyof O,
+    K4 extends keyof O,
+    K5 extends keyof O
+  >(
+    key1: K1,
+    key2: K2,
+    key3: K3,
+    key4: K4,
+    key5: K5
+  ): ExpressionWrapper<DB, TB, [O[K1], O[K2], O[K3], O[K4], O[K5]]>
+
+  /**
    * Narrows (parts of) the output type of the query.
    *
    * Kysely tries to be as type-safe as possible, but in some cases we have to make
@@ -1964,6 +2046,10 @@ class SelectQueryBuilderImpl<DB, TB extends keyof DB, O>
     ? SelectQueryBuilder<DB, TB, T>
     : KyselyTypeError<`$assertType() call failed: The type passed in is not equal to the output type of the query.`> {
     return new SelectQueryBuilderImpl(this.#props) as unknown as any
+  }
+
+  $asTuple(): ExpressionWrapper<DB, TB, any> {
+    return new ExpressionWrapper(this.toOperationNode())
   }
 
   withPlugin(plugin: KyselyPlugin): SelectQueryBuilder<DB, TB, O> {

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -1459,42 +1459,54 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    *   )
    * ```
    */
-  $asTuple<K1 extends keyof O, K2 extends keyof O>(
+  $asTuple<K1 extends keyof O, K2 extends Exclude<keyof O, K1>>(
     key1: K1,
     key2: K2
-  ): ExpressionWrapper<DB, TB, [O[K1], O[K2]]>
-
-  $asTuple<K1 extends keyof O, K2 extends keyof O, K3 extends keyof O>(
-    key1: K1,
-    key2: K2,
-    key3: K3
-  ): ExpressionWrapper<DB, TB, [O[K1], O[K2], O[K3]]>
+  ): keyof O extends K1 | K2
+    ? ExpressionWrapper<DB, TB, [O[K1], O[K2]]>
+    : KyselyTypeError<'$asTuple() call failed: All selected columns must be provided as arguments'>
 
   $asTuple<
     K1 extends keyof O,
-    K2 extends keyof O,
-    K3 extends keyof O,
-    K4 extends keyof O
+    K2 extends Exclude<keyof O, K1>,
+    K3 extends Exclude<keyof O, K1 | K2>
+  >(
+    key1: K1,
+    key2: K2,
+    key3: K3
+  ): keyof O extends K1 | K2 | K3
+    ? ExpressionWrapper<DB, TB, [O[K1], O[K2], O[K3]]>
+    : KyselyTypeError<'$asTuple() call failed: All selected columns must be provided as arguments'>
+
+  $asTuple<
+    K1 extends keyof O,
+    K2 extends Exclude<keyof O, K1>,
+    K3 extends Exclude<keyof O, K1 | K2>,
+    K4 extends Exclude<keyof O, K1 | K2 | K3>
   >(
     key1: K1,
     key2: K2,
     key3: K3,
     key4: K4
-  ): ExpressionWrapper<DB, TB, [O[K1], O[K2], O[K3], O[K4]]>
+  ): keyof O extends K1 | K2 | K3 | K4
+    ? ExpressionWrapper<DB, TB, [O[K1], O[K2], O[K3], O[K4]]>
+    : KyselyTypeError<'$asTuple() call failed: All selected columns must be provided as arguments'>
 
   $asTuple<
     K1 extends keyof O,
-    K2 extends keyof O,
-    K3 extends keyof O,
-    K4 extends keyof O,
-    K5 extends keyof O
+    K2 extends Exclude<keyof O, K1>,
+    K3 extends Exclude<keyof O, K1 | K2>,
+    K4 extends Exclude<keyof O, K1 | K2 | K3>,
+    K5 extends Exclude<keyof O, K1 | K2 | K3 | K4>
   >(
     key1: K1,
     key2: K2,
     key3: K3,
     key4: K4,
     key5: K5
-  ): ExpressionWrapper<DB, TB, [O[K1], O[K2], O[K3], O[K4], O[K5]]>
+  ): keyof O extends K1 | K2 | K3 | K4 | K5
+    ? ExpressionWrapper<DB, TB, [O[K1], O[K2], O[K3], O[K4], O[K5]]>
+    : KyselyTypeError<'$asTuple() call failed: All selected columns must be provided as arguments'>
 
   /**
    * Narrows (parts of) the output type of the query.

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -1432,8 +1432,8 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    * const result = await db
    *   .selectFrom('person')
    *   .selectAll('person')
-   *   .where(({ eb, tuple, selectFrom }) => eb(
-   *     tuple('first_name', 'last_name'),
+   *   .where(({ eb, refTuple, selectFrom }) => eb(
+   *     refTuple('first_name', 'last_name'),
    *     'in',
    *     selectFrom('pet')
    *       .select(['name', 'species'])

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -100,6 +100,7 @@ import { JSONReferenceNode } from '../operation-node/json-reference-node.js'
 import { JSONPathNode } from '../operation-node/json-path-node.js'
 import { JSONPathLegNode } from '../operation-node/json-path-leg-node.js'
 import { JSONOperatorChainNode } from '../operation-node/json-operator-chain-node.js'
+import { TupleNode } from '../operation-node/tuple-node.js'
 
 export class DefaultQueryCompiler
   extends OperationNodeVisitor
@@ -445,6 +446,12 @@ export class DefaultQueryCompiler
   }
 
   protected override visitValueList(node: ValueListNode): void {
+    this.append('(')
+    this.compileList(node.values)
+    this.append(')')
+  }
+
+  protected override visitTuple(node: TupleNode): void {
     this.append('(')
     this.compileList(node.values)
     this.append(')')

--- a/src/util/column-type.ts
+++ b/src/util/column-type.ts
@@ -149,9 +149,11 @@ export type UpdateKeys<R> = {
  * // }
  * ```
  */
-export type Selectable<R> = {
-  [K in NonNeverSelectKeys<R>]: SelectType<R[K]>
-}
+export type Selectable<R> = [R] extends [unknown]
+  ? {
+      [K in NonNeverSelectKeys<R>]: SelectType<R[K]>
+    }
+  : never
 
 /**
  * Given a table interface, extracts the insert type from all
@@ -174,11 +176,13 @@ export type Selectable<R> = {
  * // }
  * ```
  */
-export type Insertable<R> = {
-  [K in NonNullableInsertKeys<R>]: InsertType<R[K]>
-} & {
-  [K in NullableInsertKeys<R>]?: InsertType<R[K]>
-}
+export type Insertable<R> = [R] extends [unknown]
+  ? {
+      [K in NonNullableInsertKeys<R>]: InsertType<R[K]>
+    } & {
+      [K in NullableInsertKeys<R>]?: InsertType<R[K]>
+    }
+  : never
 
 /**
  * Given a table interface, extracts the update type from all
@@ -200,6 +204,8 @@ export type Insertable<R> = {
  * // }
  * ```
  */
-export type Updateable<R> = {
-  [K in UpdateKeys<R>]?: UpdateType<R[K]>
-}
+export type Updateable<R> = [R] extends [unknown]
+  ? {
+      [K in UpdateKeys<R>]?: UpdateType<R[K]>
+    }
+  : never

--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -35,19 +35,23 @@ import { KyselyTypeError } from './type-error.js'
  * // Columns == 'id' | 'name' | 'species'
  * ```
  */
-export type AnyColumn<DB, TB extends keyof DB> = DrainOuterGeneric<
-  {
-    [T in TB]: keyof DB[T]
-  }[TB] &
-    string
->
+export type AnyColumn<DB, TB extends keyof DB> = [DB] extends [unknown]
+  ? {
+      [T in TB]: keyof DB[T]
+    }[TB] &
+      string
+  : never
 
 /**
  * Extracts a column type.
  */
-export type ExtractColumnType<DB, TB extends keyof DB, C> = {
-  [T in TB]: C extends keyof DB[T] ? DB[T][C] : never
-}[TB]
+export type ExtractColumnType<DB, TB extends keyof DB, C> = [C] extends [
+  unknown
+]
+  ? {
+      [T in TB]: C extends keyof DB[T] ? DB[T][C] : never
+    }[TB]
+  : never
 
 /**
  * Given a database type and a union of table names in that db, returns

--- a/test/node/src/select.test.ts
+++ b/test/node/src/select.test.ts
@@ -936,39 +936,5 @@ for (const dialect of DIALECTS) {
         expect(result[0]).to.eql({ one: 1, person_first_name: 'Arnold' })
       }
     })
-
-    it.skip('perf', async () => {
-      const ids = Array.from({ length: 100 }).map(() =>
-        Math.round(Math.random() * 1000)
-      )
-
-      function test() {
-        return ctx.db
-          .updateTable('person')
-          .set({
-            first_name: 'foo',
-            last_name: 'bar',
-            id: 100,
-            gender: 'other',
-          })
-          .where('id', 'in', ids)
-          .compile()
-      }
-
-      // Warmup
-      for (let i = 0; i < 1000; ++i) {
-        test()
-      }
-
-      const time = Date.now()
-      const N = 100000
-
-      for (let i = 0; i < N; ++i) {
-        test()
-      }
-
-      const endTime = Date.now()
-      console.log((endTime - time) / N)
-    })
   })
 }

--- a/test/node/src/where.test.ts
+++ b/test/node/src/where.test.ts
@@ -460,9 +460,9 @@ for (const dialect of DIALECTS) {
           .selectFrom('person')
           .selectAll()
           .where((eb) =>
-            eb(eb.tuple('first_name', 'last_name'), 'in', [
-              eb.valTuple('Jennifer', 'Aniston'),
-              eb.valTuple('Sylvester', 'Stallone'),
+            eb(eb.refTuple('first_name', 'last_name'), 'in', [
+              eb.tuple('Jennifer', 'Aniston'),
+              eb.tuple('Sylvester', 'Stallone'),
             ])
           )
           .orderBy('first_name asc')
@@ -504,7 +504,7 @@ for (const dialect of DIALECTS) {
           .selectAll()
           .where((eb) =>
             eb(
-              eb.tuple('first_name', 'last_name'),
+              eb.refTuple('first_name', 'last_name'),
               'in',
               eb
                 .selectFrom('person as p2')

--- a/test/typings/test-d/expression.test-d.ts
+++ b/test/typings/test-d/expression.test-d.ts
@@ -221,3 +221,50 @@ async function textExpressionBuilderAny(
   // Not an array
   expectError(eb(eb.val('Jen'), '=', eb.fn.any('id')))
 }
+
+function testExpressionBuilderTuple(db: Kysely<Database>) {
+  db.selectFrom('person')
+    .selectAll()
+    .where(({ eb, tuple, valTuple }) =>
+      eb(tuple('first_name', 'last_name'), 'in', [
+        valTuple('Jennifer', 'Aniston'),
+        valTuple('Sylvester', 'Stallone'),
+      ])
+    )
+
+  db.selectFrom('person')
+    .selectAll()
+    .where(({ eb, tuple, selectFrom }) =>
+      eb(
+        tuple('first_name', 'last_name'),
+        'in',
+        selectFrom('person')
+          .select(['first_name', 'last_name'])
+          .$asTuple('first_name', 'last_name')
+      )
+    )
+
+  // Wrong tuple type
+  expectError(
+    db
+      .selectFrom('person')
+      .where(({ eb, tuple, valTuple }) =>
+        eb(tuple('first_name', 'last_name'), 'in', [
+          valTuple('Jennifer', 'Aniston'),
+          valTuple('Sylvester', 1),
+        ])
+      )
+  )
+
+  // Wrong tuple length
+  expectError(
+    db
+      .selectFrom('person')
+      .where(({ eb, tuple, valTuple }) =>
+        eb(tuple('first_name', 'last_name'), 'in', [
+          valTuple('Jennifer', 'Aniston', 'Extra'),
+          valTuple('Sylvester', 'Stallone'),
+        ])
+      )
+  )
+}

--- a/test/typings/test-d/expression.test-d.ts
+++ b/test/typings/test-d/expression.test-d.ts
@@ -225,18 +225,18 @@ async function textExpressionBuilderAny(
 function testExpressionBuilderTuple(db: Kysely<Database>) {
   db.selectFrom('person')
     .selectAll()
-    .where(({ eb, tuple, valTuple }) =>
-      eb(tuple('first_name', 'last_name'), 'in', [
-        valTuple('Jennifer', 'Aniston'),
-        valTuple('Sylvester', 'Stallone'),
+    .where(({ eb, refTuple, tuple }) =>
+      eb(refTuple('first_name', 'last_name'), 'in', [
+        tuple('Jennifer', 'Aniston'),
+        tuple('Sylvester', 'Stallone'),
       ])
     )
 
   db.selectFrom('person')
     .selectAll()
-    .where(({ eb, tuple, selectFrom }) =>
+    .where(({ eb, refTuple, selectFrom }) =>
       eb(
-        tuple('first_name', 'last_name'),
+        refTuple('first_name', 'last_name'),
         'in',
         selectFrom('person')
           .select(['first_name', 'last_name'])
@@ -248,10 +248,10 @@ function testExpressionBuilderTuple(db: Kysely<Database>) {
   expectError(
     db
       .selectFrom('person')
-      .where(({ eb, tuple, valTuple }) =>
-        eb(tuple('first_name', 'last_name'), 'in', [
-          valTuple('Jennifer', 'Aniston'),
-          valTuple('Sylvester', 1),
+      .where(({ eb, refTuple, tuple }) =>
+        eb(refTuple('first_name', 'last_name'), 'in', [
+          tuple('Jennifer', 'Aniston'),
+          tuple('Sylvester', 1),
         ])
       )
   )
@@ -260,10 +260,10 @@ function testExpressionBuilderTuple(db: Kysely<Database>) {
   expectError(
     db
       .selectFrom('person')
-      .where(({ eb, tuple, valTuple }) =>
-        eb(tuple('first_name', 'last_name'), 'in', [
-          valTuple('Jennifer', 'Aniston', 'Extra'),
-          valTuple('Sylvester', 'Stallone'),
+      .where(({ eb, refTuple, tuple }) =>
+        eb(refTuple('first_name', 'last_name'), 'in', [
+          tuple('Jennifer', 'Aniston', 'Extra'),
+          tuple('Sylvester', 'Stallone'),
         ])
       )
   )

--- a/test/typings/test-d/expression.test-d.ts
+++ b/test/typings/test-d/expression.test-d.ts
@@ -267,4 +267,22 @@ function testExpressionBuilderTuple(db: Kysely<Database>) {
         ])
       )
   )
+
+  // Not all selected columns provided for $asTuple
+  expectType<
+    KyselyTypeError<'$asTuple() call failed: All selected columns must be provided as arguments'>
+  >(
+    db
+      .selectFrom('person')
+      .select(['first_name', 'last_name', 'age'])
+      .$asTuple('first_name', 'last_name')
+  )
+
+  // Duplicate column provided for $asTuple
+  expectError(
+    db
+      .selectFrom('person')
+      .select(['first_name', 'last_name'])
+      .$asTuple('first_name', 'last_name', 'last_name')
+  )
 }


### PR DESCRIPTION
This PR adds tuple support. After trying out a bunch of options, I ended up with a function overload approach up to tuples of length five. There's also a partially unsafe `$asTuple` function in `SelectQueryBuilder` that I don't love.

The reason for my choices basically boils down to the fact that typescript doesn't allow the index of a type in an union to be observed. They've stated in some issues that it will never be observable.

Because of this, there's no (sane) conversion from an object to a tuple, which is why the `$asTuple` method is necessary. If you google this, there is a solution, but it takes around 3 gigabytes of memory to convert a single object to a tuple, so that's a hard no-no.

Using function overloads instead of a recursive type (like the one in coalesce) is also due to performance AND autocompletion issues. The recursive type immediately caused ~one second delays and I wasn't able to get autocompletion to work. Just like we don't currently have autocompletion in `coalesce` after the first argument.

Having a maximum length of five for tuples shouldn't be an issue. My guess is that the most common use case for this is composite primary keys and the length for those is usually 2 or 3. We can also add more overloads if someone requests them.

Closes #367