### PR TITLE
Add array overlap operator (`&&`) to `COMPARISON_OPERATORS`

### DIFF
--- a/src/operation-node/operator-node.ts
+++ b/src/operation-node/operator-node.ts
@@ -21,6 +21,7 @@ export const COMPARISON_OPERATORS = [
   'not ilike',
   '@>',
   '<@',
+  '&&',
   '?',
   '?&',
   '!<',


### PR DESCRIPTION
This PR adds the [array overlap operator](https://www.postgresql.org/docs/current/functions-array.html) (`&&`) to the list of allowed comparison operators.

`&&` has been added in PostgreSQL 8.2, along with the `@>` and `<@` comparison operators, which are already supported by Kysely.