### PR TITLE
fix create index `using` support @ MySQL.

### DIFF
--- a/src/dialect/mysql/mysql-query-compiler.ts
+++ b/src/dialect/mysql/mysql-query-compiler.ts
@@ -1,3 +1,4 @@
+import { CreateIndexNode } from '../../operation-node/create-index-node.js'
 import { DefaultQueryCompiler } from '../../query-compiler/default-query-compiler.js'
 
 const ID_WRAP_REGEX = /`/g
@@ -33,5 +34,42 @@ export class MysqlQueryCompiler extends DefaultQueryCompiler {
 
   protected override sanitizeIdentifier(identifier: string): string {
     return identifier.replace(ID_WRAP_REGEX, '``')
+  }
+
+  protected override visitCreateIndex(node: CreateIndexNode): void {
+    this.append('create ')
+
+    if (node.unique) {
+      this.append('unique ')
+    }
+
+    this.append('index ')
+
+    if (node.ifNotExists) {
+      this.append('if not exists ')
+    }
+
+    this.visitNode(node.name)
+
+    if (node.using) {
+      this.append(' using ')
+      this.visitNode(node.using)
+    }
+
+    if (node.table) {
+      this.append(' on ')
+      this.visitNode(node.table)
+    }
+
+    if (node.columns) {
+      this.append(' (')
+      this.compileList(node.columns)
+      this.append(')')
+    }
+
+    if (node.where) {
+      this.append(' ')
+      this.visitNode(node.where)
+    }
   }
 }

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -1010,7 +1010,7 @@ for (const dialect of DIALECTS) {
         await builder.execute()
       })
 
-      if (dialect === 'postgres') {
+      if (dialect === 'postgres' || dialect === 'mysql') {
         it('should create an index with a type', async () => {
           const builder = ctx.db.schema
             .createIndex('test_first_name_index')
@@ -1024,7 +1024,7 @@ for (const dialect of DIALECTS) {
               parameters: [],
             },
             mysql: {
-              sql: 'create index `test_first_name_index` on `test` using hash (`first_name`)',
+              sql: 'create index `test_first_name_index` using hash on `test` (`first_name`)',
               parameters: [],
             },
             sqlite: {


### PR DESCRIPTION
Hey :wave:

Currently the way we compile create index queries with the `using` keyword is not aligned with MySQL's spec.
MySQL's spec accepts `using` only before the `on` keyword.

This PR flips the order for MySQL.