### PR TITLE
Global type config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './kysely.js'
+export * from './type-config.js'
 export * from './query-creator.js'
 
 export * from './expression/expression.js'

--- a/src/query-builder/function-module.ts
+++ b/src/query-builder/function-module.ts
@@ -13,6 +13,7 @@ import {
   ExtractTypeFromStringReference,
 } from '../parser/reference-parser.js'
 import { parseSelectAll } from '../parser/select-parser.js'
+import { GetConfig, GetConfigFallback } from '../type-config.js'
 import { KyselyTypeError } from '../util/type-error.js'
 import { Equals, IsAny } from '../util/type-utils.js'
 import { AggregateFunctionBuilder } from './aggregate-function-builder.js'
@@ -189,7 +190,10 @@ export interface FunctionModule<DB, TB extends keyof DB> {
    * ```
    */
   avg<
-    O extends number | string | null = number | string,
+    O extends number | string | null = GetConfigFallback<
+      'avgType',
+      'floatType'
+    >,
     C extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>
   >(
     column: C
@@ -318,7 +322,10 @@ export interface FunctionModule<DB, TB extends keyof DB> {
    * ```
    */
   count<
-    O extends number | string | bigint,
+    O extends number | string | bigint = GetConfigFallback<
+      'countType',
+      'bigIntType'
+    >,
     C extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>
   >(
     column: C
@@ -393,15 +400,22 @@ export interface FunctionModule<DB, TB extends keyof DB> {
    *   .execute()
    * ```
    */
-  countAll<O extends number | string | bigint, T extends TB = TB>(
+  countAll<
+    O extends number | string | bigint = GetConfigFallback<
+      'countType',
+      'bigIntType'
+    >,
+    T extends TB = TB
+  >(
     table: T
   ): AggregateFunctionBuilder<DB, TB, O>
 
-  countAll<O extends number | string | bigint>(): AggregateFunctionBuilder<
-    DB,
-    TB,
-    O
-  >
+  countAll<
+    O extends number | string | bigint = GetConfigFallback<
+      'countType',
+      'bigIntType'
+    >
+  >(): AggregateFunctionBuilder<DB, TB, O>
 
   /**
    * Calls the `max` function for the column or expression given as the argument.
@@ -576,7 +590,7 @@ export interface FunctionModule<DB, TB extends keyof DB> {
    * ```
    */
   sum<
-    O extends number | string | bigint | null = number | string | bigint,
+    O extends number | string | bigint | null = GetConfig<'sumType'>,
     C extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>
   >(
     column: C

--- a/src/type-config.ts
+++ b/src/type-config.ts
@@ -1,0 +1,50 @@
+declare global {
+  /**
+   * The interface users can extend using interface merging:
+   *
+   * ```ts
+   * declare global {
+   *   interface KyselyTypeConfig {
+   *     bigIntType: number
+   *   }
+   * }
+   * ```
+   *
+   * See {@link DefaultKyselyTypeConfig} for configs that can be
+   * overridden.
+   */
+  interface KyselyTypeConfig {}
+}
+
+interface DefaultKyselyTypeConfig {
+  dateTimeType: Date | string
+  floatType: number | string
+  bigIntType: bigint | number | string
+
+  /**
+   * This type can be used to specify the `sum` function's output type.
+   */
+  sumType: number | string | bigint
+
+  /**
+   * This type can be used to specify the `avg` function's output type.
+   * By default the {@link floatType} is used.
+   */
+  avgType: never
+
+  /**
+   * This type can be used to specify the `count` and `countAll` functions' output type.
+   * By default the {@link bigIntType} is used.
+   */
+  countType: never
+}
+
+export type GetConfig<K extends keyof DefaultKyselyTypeConfig> =
+  K extends keyof KyselyTypeConfig
+    ? KyselyTypeConfig[K]
+    : DefaultKyselyTypeConfig[K]
+
+export type GetConfigFallback<
+  K extends keyof DefaultKyselyTypeConfig,
+  F extends keyof DefaultKyselyTypeConfig
+> = GetConfig<K> extends never ? GetConfig<F> : GetConfig<K>


### PR DESCRIPTION
Adding global user-overridable type config.

This will allow users to use interface merging to configure internal Kysely types like the type that's used for the `bigint` DB data type. By default, Kysely uses annoyingly wide types like `bigint | string | number` since, on the type level, we don't know which dialect is being used and what data type mappings the user has installed in the driver.

The users can do something like this:

```ts
declare global {
  interface KyselyTypeConfig {
    bigIntType: number
  }
}
```

After doing this, for example the `count` function will return a `number` instead of the default `bigint | string | number`. 