### PR TITLE
fix node-postgres `pool` link

### DIFF
--- a/src/dialect/postgres/postgres-dialect-config.ts
+++ b/src/dialect/postgres/postgres-dialect-config.ts
@@ -9,7 +9,7 @@ export interface PostgresDialectConfig {
    *
    * If a function is provided, it's called once when the first query is executed.
    *
-   * https://node-postgres.com/api/pool
+   * https://node-postgres.com/apis/pool
    */
   pool: PostgresPool | (() => Promise<PostgresPool>)
 
@@ -39,7 +39,7 @@ export interface PostgresDialectConfig {
  *
  * We don't use the type from `pg` here to not have a dependency to it.
  *
- * https://node-postgres.com/api/pool
+ * https://node-postgres.com/apis/pool
  */
 export interface PostgresPool {
   connect(): Promise<PostgresPoolClient>


### PR DESCRIPTION
I was browsing the [PostgresPool](https://kysely-org.github.io/kysely-apidoc/interfaces/PostgresPool.html) section of the documentation and noticed that the link to the node-postgres pool API doc was 404ing as it had `/api/` instead of `/apis/` in the link.

Thought I'd submit a quick PR to fix it.

Thanks!