### PR TITLE
Add Xata as a dialect

### DIFF
--- a/site/docs/dialects.md
+++ b/site/docs/dialects.md
@@ -19,6 +19,7 @@ A dialect is the glue between Kysely and the underlying database engine. Check t
 | AWS RDS Data API | https://github.com/serverless-stack/kysely-data-api |
 | SurrealDB | https://github.com/igalklebanov/kysely-surrealdb |
 | Neon | https://github.com/seveibar/kysely-neon |
+| Xata | https://github.com/xataio/client-ts/tree/main/packages/plugin-client-kysely |
 | AWS S3 Select | https://github.com/igalklebanov/kysely-s3-select |
 | libSQL/sqld | https://github.com/libsql/kysely-libsql |
 | SingleStore Data API | https://github.com/igalklebanov/kysely-singlestore |


### PR DESCRIPTION
Xata is a serverless data platform built on top of PostgreSQL, as a new feature we are now exposing SQL over HTTP and we have built a driver for Kysely.

Implementation: https://github.com/xataio/client-ts/blob/main/packages/plugin-client-kysely/src/driver.ts