### PR TITLE
docs: fix "splitting build, compile and execute code" recipe

### DIFF
--- a/site/docs/recipes/splitting-build-compile-and-execute-code.md
+++ b/site/docs/recipes/splitting-build-compile-and-execute-code.md
@@ -15,7 +15,6 @@ import {
   DummyDriver,
   Kysely,
   PostgresAdapter,
-  PostgresCompiler,
   PostgresIntrospector,
   PostgresQueryCompiler,
 } from 'kysely'


### PR DESCRIPTION
In the site documentation there is a recipe for ["Splitting build, compile and execute code"](https://kysely.dev/docs/recipes/splitting-build-compile-and-execute-code#cold-kysely-instances) which is importing a non-existing export for `PostgresCompiler`.

```
'"kysely"' has no exported member named 'PostgresCompiler'. Did you mean 'PostgresQueryCompiler'?
```

I don't know where this is coming from, perhaps from an earlier version of Kysely, but either way I think that part is no longer needed.

As a side note, I think this line should include a generic parameter passed to `Kysely`, or maybe just an `any`? Not sure what the best practice is, I guess it depends what one is trying to achieve.

https://github.com/kysely-org/kysely/blob/ce1502d0765b7220109cdb8aff32c822beebadf2/site/docs/recipes/splitting-build-compile-and-execute-code.md?plain=1#L23

If you pass nothing and follow along with the examples from the recipe, you will get typescript errors.