### PR TITLE
docs: improve "splitting build, compile and execute code" recipe

### DIFF
--- a/site/docs/recipes/splitting-build-compile-and-execute-code.md
+++ b/site/docs/recipes/splitting-build-compile-and-execute-code.md
@@ -12,6 +12,7 @@ you can instantiate it with the built-in `DummyDriver` class:
 
 ```ts
 import { 
+  Generated,
   DummyDriver,
   Kysely,
   PostgresAdapter,
@@ -19,7 +20,17 @@ import {
   PostgresQueryCompiler,
 } from 'kysely'
 
-const db = new Kysely({
+interface Person {
+  id: Generated<number>
+  first_name: string
+  last_name: string | null
+}
+
+interface Database {
+  person: Person
+}
+
+const db = new Kysely<Database>({
   dialect: {
     createAdapter: () => new PostgresAdapter(),
     createDriver: () => new DummyDriver(),


### PR DESCRIPTION
Follow up from #662. As per your advice that it would be better if all the examples shown in this recipe worked without unintentional errors, I've added a minimal `Database` interface as seen in other places throughout the documentation.

I was very tempted to leave a note about instantiating the `Kysely` instance with an `any` as a generic type parameter, but ultimately opted against, since it might be conflicting with later examples on this page which make use of `InferResult`.

Cheers!