### PR TITLE
Fix Node.js stack traces when code in a transaction throws

### DIFF
--- a/test/node/src/transaction.test.ts
+++ b/test/node/src/transaction.test.ts
@@ -154,6 +154,19 @@ for (const dialect of DIALECTS) {
       }
     })
 
+    it('should retain the full stack trace', async () => {
+      try {
+        await ctx.db.transaction().execute(async (trx) => {
+          await trx.selectFrom('person').where('id', 'in', -1).execute()
+        })
+
+        expect.fail('Expected transaction to fail')
+      } catch (error) {
+        expect((error as Error).stack).to.include('syntax error')
+        expect((error as Error).stack).to.include('transaction.test.js')
+      }
+    })
+
     async function insertPet(
       trx: Transaction<Database>,
       ownerId: number

--- a/test/node/src/transaction.test.ts
+++ b/test/node/src/transaction.test.ts
@@ -10,6 +10,8 @@ import {
   Database,
   insertDefaultDataSet,
 } from './test-setup.js'
+import { DatabaseError as PostgresError } from 'pg'
+import { SqliteError } from 'better-sqlite3'
 
 for (const dialect of DIALECTS) {
   describe(`${dialect}: transaction`, () => {
@@ -162,7 +164,12 @@ for (const dialect of DIALECTS) {
 
         expect.fail('Expected transaction to fail')
       } catch (error) {
-        expect((error as Error).stack).to.include('syntax error')
+        if (dialect === 'sqlite') {
+          expect(error).to.be.instanceOf(SqliteError)
+        } else if (dialect === 'postgres') {
+          expect(error).to.be.instanceOf(PostgresError)
+        }
+
         expect((error as Error).stack).to.include('transaction.test.js')
       }
     })


### PR DESCRIPTION
The error stack was losing context because the Promise chain [must be unbroken](https://cloudreports.net/v8-zero-cost-async-stack-traces/) for the error context to correctly work.

E.x. on an internal codebase:

```ts
await kysely.transaction().execute(async trx => {
  // generates invalid query
  await trx.selectFrom("foo").where("foo_id", 'in', []).execute()
})
```

before:

![Screenshot 2023-08-28 at 4 18 35 PM](https://github.com/kysely-org/kysely/assets/7410405/e049e7e6-4835-4f8d-9cdf-9e955854bb2a)

after:

![Screenshot 2023-08-28 at 4 19 14 PM](https://github.com/kysely-org/kysely/assets/7410405/335c7485-7eac-4ab7-988d-5b34acf341b4)

(`tests/db/tests/db/postgres-error-stacks.test.ts` is the path to the file that throws)

Added test was previously failing.