### PR TITLE
Rename tidb serverless driver to tidb cloud serverless driver

### DIFF
--- a/site/docs/dialects.md
+++ b/site/docs/dialects.md
@@ -27,4 +27,4 @@ A dialect is the glue between Kysely and the underlying database engine. Check t
 | Fetch driver                  | https://github.com/andersgee/kysely-fetch-driver                            |
 | SQLite WASM                   | https://github.com/DallasHoff/sqlocal                                       |
 | Deno SQLite                   | https://gitlab.com/soapbox-pub/kysely-deno-sqlite                           |
-| TiDB Serverless Driver        | https://github.com/tidbcloud/kysely                                         |
+| TiDB Cloud Serverless Driver  | https://github.com/tidbcloud/kysely                                         |


### PR DESCRIPTION
We are releasing the serverless driver today. The name is changed to TiDB Cloud serverless driver.