### PR TITLE
export SelectQueryBuilderImpl

### DIFF
--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -1646,7 +1646,7 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
   ): Promise<ER[]>
 }
 
-class SelectQueryBuilderImpl<DB, TB extends keyof DB, O>
+export class SelectQueryBuilderImpl<DB, TB extends keyof DB, O>
   implements SelectQueryBuilder<DB, TB, O>
 {
   readonly #props: SelectQueryBuilderProps


### PR DESCRIPTION
this is useful for users extending the library. I'm trying to add a method that allows the user to easily subquery a table, but I need access to the `SelectQueryBuilderImpl` class.
```ts
declare module "kysely/dist/cjs/query-builder/select-query-builder" {
  interface SelectQueryBuilder<DB, TB extends keyof DB, O> {
    ... patch types here
  }
}

SelectQueryBuilderImpl.prototype.selectNested = function (
  this: SelectQueryBuilder<any, any, any>,
  from: string,
  fromCol: string,
  toCol: string
) {
  return this.select((eb) =>
    jsonObjectFrom(
      eb.selectFrom(from).selectAll().whereRef(fromCol, "=", toCol)
    ).as(from)
  );
};

SelectQueryBuilderImpl.prototype.selectNestedArray = function (
  this: SelectQueryBuilder<any, any, any>,
  from: string,
  fromCol: string,
  toCol: string
) {
  return this.select((eb) =>
    jsonArrayFrom(
      eb.selectFrom(from).selectAll().whereRef(fromCol, "=", toCol)
    ).as(from)
  );
};

const res = await ky
  .selectFrom('user')
  .selectNested('role', 'user.roleId', 'role.id')
  .execute();
// returns User & { role: Role } 
```