### PR TITLE
Add `allowUnorderedMigrations` option to Migrator

### DIFF
--- a/site/docs/migrations.mdx
+++ b/site/docs/migrations.mdx
@@ -26,19 +26,19 @@ Migrations can use the `Kysely.schema` module to modify the schema. Migrations c
 
 ## Execution order
 
-There are two options for ordering migrations in Kysely: strict and permissive. Both options are based on the alphanumeric ordering of the migration name. In either case, an excellent way to name your migrations is to prefix them with an ISO 8601 date string.
+Migrations will be run in the alpha-numeric order of your migration names. An excellent way to name your migrations is to prefix them with an ISO 8601 date string. 
 
-Strict ordering (the default) will give an error if the alphanumeric order of your migration files does not match the execution order of them in the database. This adds safety by always executing your migrations in the correct, alphanumeric order. 
+By default, Kysely will also ensure this order matches the execution order of any previously executed migrations in your database. If the orders do not match (for example, a new migration was added alphabetically before a previously executed one), an error will be returned. This adds safety by always executing your migrations in the correct, alphanumeric order. 
 
-Permissive ordering will allow new migrations to be run even if they are added alphabetically before ones that have already executed. Permissive ordering works well in large teams where multiple team members may add migrations at the same time in parallel commits without knowing about the other migrations. Permissive ordering will run pending (unexecuted) migrations in order when migrating up. When migrating down, migrations will be undone in the opposite order in which they were executed (reverse sorted by execution timestamp).
+There is also an `allowUnorderedMigrations` option. This option will allow new migrations to be run even if they are added alphabetically before ones that have already executed. Allowing unordered migrations works well in large teams where multiple team members may add migrations at the same time in parallel commits without knowing about the other migrations. Pending (unexecuted) migrations will be run in alpha-numeric order when migrating up. When migrating down, migrations will be undone in the opposite order in which they were executed (reverse sorted by execution timestamp).
 
-To use permissive ordering, pass the `migrationOrder` option to Migrator:
+To allow unordered migrations, pass the `allowUnorderedMigrations` option to Migrator:
 
 ```ts
 const migrator = new Migrator({
   db,
   provider: new FileMigrationProvider(...),
-  migrationOrder: 'permissive'
+  allowUnorderedMigrations: true
 })
 ```
 

--- a/site/docs/migrations.mdx
+++ b/site/docs/migrations.mdx
@@ -26,7 +26,21 @@ Migrations can use the `Kysely.schema` module to modify the schema. Migrations c
 
 ## Execution order
 
-Execution order of the migrations is the alpabetical order of their names. An excellent way to name your migrations is to prefix them with an ISO 8601 date string. A date prefix works well in large teams where multiple team members may add migrations at the same time in parallel commits without knowing about the other migrations.
+There are two options for ordering migrations in Kysely: strict and permissive. Both options are based on the alphanumeric ordering of the migration name. In either case, an excellent way to name your migrations is to prefix them with an ISO 8601 date string.
+
+Strict ordering (the default) will give an error if the alphanumeric order of your migration files does not match the execution order of them in the database. This adds safety by always executing your migrations in the correct, alphanumeric order. 
+
+Permissive ordering will allow new migrations to be run even if they are added alphabetically before ones that have already executed. Permissive ordering works well in large teams where multiple team members may add migrations at the same time in parallel commits without knowing about the other migrations. Permissive ordering will run pending (unexecuted) migrations in order when migrating up. When migrating down, migrations will be undone in the opposite order in which they were executed (reverse sorted by execution timestamp).
+
+To use permissive ordering, pass the `migrationOrder` option to Migrator:
+
+```ts
+const migrator = new Migrator({
+  db,
+  provider: new FileMigrationProvider(...),
+  migrationOrder: 'permissive'
+})
+```
 
 ## Single file vs multiple file migrations
 

--- a/src/migration/migrator.ts
+++ b/src/migration/migrator.ts
@@ -86,8 +86,6 @@ export class Migrator {
     })
   }
 
-  // TODO add getPendingMigrations here too
-
   /**
    * Runs all migrations that have not yet been run.
    *

--- a/src/migration/migrator.ts
+++ b/src/migration/migrator.ts
@@ -485,15 +485,9 @@ export class Migrator {
     migrations: ReadonlyArray<NamedMigration>,
     executedMigrations: ReadonlyArray<string>
   ): ReadonlyArray<NamedMigration> {
-    let pendingMigrations: ReadonlyArray<NamedMigration> = []
-
-    migrations.forEach((migration) => {
-      if (!executedMigrations.includes(migration.name)) {
-        pendingMigrations = [...pendingMigrations, migration]
-      }
+    return migrations.filter((migration) => {
+      return !executedMigrations.includes(migration.name)
     })
-
-    return pendingMigrations
   }
 
   async #resolveMigrations(): Promise<ReadonlyArray<NamedMigration>> {

--- a/src/migration/migrator.ts
+++ b/src/migration/migrator.ts
@@ -510,7 +510,7 @@ export class Migrator {
       .withPlugin(this.#schemaPlugin)
       .selectFrom(this.#migrationTable)
       .select('name')
-      .orderBy('timestamp')
+      .orderBy(['timestamp', 'name'])
       .execute()
 
     return executedMigrations.map((it) => it.name)

--- a/src/migration/migrator.ts
+++ b/src/migration/migrator.ts
@@ -136,7 +136,7 @@ export class Migrator {
    * ```
    */
   async migrateToLatest(): Promise<MigrationResultSet> {
-    return this.#migrate(() => ({direction: 'Up', step: Infinity}))
+    return this.#migrate(() => ({ direction: 'Up', step: Infinity }))
   }
 
   /**
@@ -165,26 +165,43 @@ export class Migrator {
   async migrateTo(
     targetMigrationName: string | NoMigrations
   ): Promise<MigrationResultSet> {
-    return this.#migrate(({ migrations, executedMigrations, pendingMigrations }: MigrationState) => {
-      if (targetMigrationName === NO_MIGRATIONS) {
-        return { direction: 'Down', step: Infinity }
-      }
+    return this.#migrate(
+      ({
+        migrations,
+        executedMigrations,
+        pendingMigrations,
+      }: MigrationState) => {
+        if (targetMigrationName === NO_MIGRATIONS) {
+          return { direction: 'Down', step: Infinity }
+        }
 
-      if (!migrations.find(m => m.name === targetMigrationName as string)) {
-        throw new Error(`migration "${targetMigrationName}" doesn't exist`)
-      }
+        if (
+          !migrations.find((m) => m.name === (targetMigrationName as string))
+        ) {
+          throw new Error(`migration "${targetMigrationName}" doesn't exist`)
+        }
 
-      const executedIndex = executedMigrations.indexOf(targetMigrationName as string)
-      const pendingIndex = pendingMigrations.findIndex(m => m.name === targetMigrationName as string)
+        const executedIndex = executedMigrations.indexOf(
+          targetMigrationName as string
+        )
+        const pendingIndex = pendingMigrations.findIndex(
+          (m) => m.name === (targetMigrationName as string)
+        )
 
-      if (executedIndex !== -1) {
-        return { direction: 'Down', step: executedMigrations.length - executedIndex - 1 }
-      } else if (pendingIndex !== -1) {
-        return { direction: 'Up', step: pendingIndex + 1 }
-      } else {
-        throw new Error(`migration "${targetMigrationName}" isn't executed or pending`)
+        if (executedIndex !== -1) {
+          return {
+            direction: 'Down',
+            step: executedMigrations.length - executedIndex - 1,
+          }
+        } else if (pendingIndex !== -1) {
+          return { direction: 'Up', step: pendingIndex + 1 }
+        } else {
+          throw new Error(
+            `migration "${targetMigrationName}" isn't executed or pending`
+          )
+        }
       }
-    })
+    )
   }
 
   /**
@@ -202,7 +219,7 @@ export class Migrator {
    * ```
    */
   async migrateUp(): Promise<MigrationResultSet> {
-    return this.#migrate(() => ({direction: 'Up', step: 1}))
+    return this.#migrate(() => ({ direction: 'Up', step: 1 }))
   }
 
   /**
@@ -220,11 +237,14 @@ export class Migrator {
    * ```
    */
   async migrateDown(): Promise<MigrationResultSet> {
-    return this.#migrate(() => ({direction: 'Down', step: 1}))
+    return this.#migrate(() => ({ direction: 'Down', step: 1 }))
   }
 
   async #migrate(
-    getMigrationDirectionAndStep: (state: MigrationState) => { direction: MigrationDirection, step: number }
+    getMigrationDirectionAndStep: (state: MigrationState) => {
+      direction: MigrationDirection
+      step: number
+    }
   ): Promise<MigrationResultSet> {
     try {
       await this.#ensureMigrationTablesExists()
@@ -393,7 +413,10 @@ export class Migrator {
   }
 
   async #runMigrations(
-    getMigrationDirectionAndStep: (state: MigrationState) => { direction: MigrationDirection, step: number }
+    getMigrationDirectionAndStep: (state: MigrationState) => {
+      direction: MigrationDirection
+      step: number
+    }
   ): Promise<MigrationResultSet> {
     const adapter = this.#props.db.getExecutor().adapter
 
@@ -412,7 +435,7 @@ export class Migrator {
         if (state.migrations.length === 0) {
           return { results: [] }
         }
-        
+
         const { direction, step } = getMigrationDirectionAndStep(state)
 
         if (step <= 0) {
@@ -447,13 +470,16 @@ export class Migrator {
       this.#ensureMigrationsInOrder(migrations, executedMigrations)
     }
 
-    const pendingMigrations = this.#getPendingMigrations(migrations, executedMigrations)
+    const pendingMigrations = this.#getPendingMigrations(
+      migrations,
+      executedMigrations
+    )
 
     return freeze({
       migrations,
       executedMigrations,
       lastMigration: getLast(executedMigrations),
-      pendingMigrations
+      pendingMigrations,
     })
   }
 
@@ -463,7 +489,7 @@ export class Migrator {
   ): ReadonlyArray<NamedMigration> {
     let pendingMigrations: ReadonlyArray<NamedMigration> = []
 
-    migrations.forEach(migration => {
+    migrations.forEach((migration) => {
       if (!executedMigrations.includes(migration.name)) {
         pendingMigrations = [...pendingMigrations, migration]
       }
@@ -529,15 +555,16 @@ export class Migrator {
     state: MigrationState,
     step: number
   ): Promise<MigrationResultSet> {
-    const migrationsToRollback: ReadonlyArray<NamedMigration> = state.executedMigrations
-      .slice()
-      .reverse()
-      .slice(0, step)
-      .map(name => {
-        return state.migrations.find(it => it.name === name)!
-      })
+    const migrationsToRollback: ReadonlyArray<NamedMigration> =
+      state.executedMigrations
+        .slice()
+        .reverse()
+        .slice(0, step)
+        .map((name) => {
+          return state.migrations.find((it) => it.name === name)!
+        })
 
-    const results: MigrationResult[] = migrationsToRollback.map(migration => {
+    const results: MigrationResult[] = migrationsToRollback.map((migration) => {
       return {
         migrationName: migration.name,
         direction: 'Down',
@@ -580,10 +607,15 @@ export class Migrator {
     return { results }
   }
 
-  async #migrateUp(db: Kysely<any>, state: MigrationState, step: number): Promise<MigrationResultSet> {
-    const migrationsToRun: ReadonlyArray<NamedMigration> = state.pendingMigrations.slice(0, step)
+  async #migrateUp(
+    db: Kysely<any>,
+    state: MigrationState,
+    step: number
+  ): Promise<MigrationResultSet> {
+    const migrationsToRun: ReadonlyArray<NamedMigration> =
+      state.pendingMigrations.slice(0, step)
 
-    const results: MigrationResult[] = migrationsToRun.map(migration => {
+    const results: MigrationResult[] = migrationsToRun.map((migration) => {
       return {
         migrationName: migration.name,
         direction: 'Up',

--- a/test/node/src/migration.test.ts
+++ b/test/node/src/migration.test.ts
@@ -136,7 +136,6 @@ for (const dialect of DIALECTS) {
           { migrationOrder: 'permissive' }
         )
 
-        await migrator1.migrateToLatest()
         const { results: results1 } = await migrator1.migrateToLatest()
 
         const [migrator2, executedUpMethods2] = createMigrations(
@@ -144,7 +143,6 @@ for (const dialect of DIALECTS) {
           { migrationOrder: 'permissive' }
         )
 
-        await migrator2.migrateToLatest()
         const { results: results2 } = await migrator2.migrateToLatest()
 
         expect(results1).to.eql([
@@ -154,23 +152,10 @@ for (const dialect of DIALECTS) {
 
         expect(results2).to.eql([
           { migrationName: 'migration2', direction: 'Up', status: 'Success' },
-          // { migrationName: 'migration4', direction: 'Up', status: 'Success' },
         ])
 
         expect(executedUpMethods1).to.eql(['migration1', 'migration3'])
         expect(executedUpMethods2).to.eql(['migration2'])
-
-        //
-        //
-        // const { error } = await migrator2.migrateToLatest()
-        //
-        // expect(error).to.be.an.instanceOf(Error)
-        // expect(getMessage(error)).to.eql(
-        //   'corrupted migrations: expected previously executed migration migration3 to be at index 1 but migration2 was found in its place. New migrations must always have a name that comes alphabetically after the last executed migration.'
-        // )
-        //
-        // expect(executedUpMethods1).to.eql(['migration1', 'migration3'])
-        // expect(executedUpMethods2).to.eql([])
       })
 
       it('should return an error if a previously executed migration is missing', async () => {

--- a/test/node/src/migration.test.ts
+++ b/test/node/src/migration.test.ts
@@ -401,12 +401,7 @@ for (const dialect of DIALECTS) {
       describe('with permissive ordering enabled', () => {
         it('should migrate up to a specific migration', async () => {
           const [migrator1, executedUpMethods1] = createMigrations(
-            [
-              'migration1',
-              'migration3',
-              'migration4',
-              'migration5',
-            ],
+            ['migration1', 'migration3', 'migration4', 'migration5'],
             { migrationOrder: 'permissive' }
           )
 
@@ -440,28 +435,18 @@ for (const dialect of DIALECTS) {
         })
 
         it('should migrate all the way down', async () => {
-          const [migrator1, executedUpMethods1] = 
-            createMigrations(
-            [
-              'migration1',
-              'migration2',
-              'migration4'
-            ],
+          const [migrator1, executedUpMethods1] = createMigrations(
+            ['migration1', 'migration2', 'migration4'],
             { migrationOrder: 'permissive' }
           )
 
           const { results: results1 } = await migrator1.migrateToLatest()
 
-          const [migrator2, executedUpMethods2, executedDownMethods2] = 
+          const [migrator2, executedUpMethods2, executedDownMethods2] =
             createMigrations(
-            [
-              'migration1',
-              'migration2',
-              'migration3',
-              'migration4'
-            ],
-            { migrationOrder: 'permissive' }
-          )
+              ['migration1', 'migration2', 'migration3', 'migration4'],
+              { migrationOrder: 'permissive' }
+            )
 
           const { results: results2 } = await migrator2.migrateTo(NO_MIGRATIONS)
 
@@ -472,9 +457,21 @@ for (const dialect of DIALECTS) {
           ])
 
           expect(results2).to.eql([
-            { migrationName: 'migration4', direction: 'Down', status: 'Success' },
-            { migrationName: 'migration2', direction: 'Down', status: 'Success' },
-            { migrationName: 'migration1', direction: 'Down', status: 'Success' },
+            {
+              migrationName: 'migration4',
+              direction: 'Down',
+              status: 'Success',
+            },
+            {
+              migrationName: 'migration2',
+              direction: 'Down',
+              status: 'Success',
+            },
+            {
+              migrationName: 'migration1',
+              direction: 'Down',
+              status: 'Success',
+            },
           ])
 
           expect(executedUpMethods1).to.eql([
@@ -491,29 +488,24 @@ for (const dialect of DIALECTS) {
         })
 
         it('should migrate down to a specific migration', async () => {
-          const [migrator1, executedUpMethods1] = 
-            createMigrations(
-            [
-              'migration1',
-              'migration2',
-              'migration3',
-              'migration5'
-            ],
+          const [migrator1, executedUpMethods1] = createMigrations(
+            ['migration1', 'migration2', 'migration3', 'migration5'],
             { migrationOrder: 'permissive' }
           )
 
           const { results: results1 } = await migrator1.migrateTo('migration5')
 
-          const [migrator2, executedUpMethods2, executedDownMethods2] = createMigrations(
-            [
-              'migration1',
-              'migration2',
-              'migration3',
-              'migration4',
-              'migration5'
-            ],
-            { migrationOrder: 'permissive' }
-          )
+          const [migrator2, executedUpMethods2, executedDownMethods2] =
+            createMigrations(
+              [
+                'migration1',
+                'migration2',
+                'migration3',
+                'migration4',
+                'migration5',
+              ],
+              { migrationOrder: 'permissive' }
+            )
 
           const { results: results2 } = await migrator2.migrateTo('migration2')
 
@@ -525,8 +517,16 @@ for (const dialect of DIALECTS) {
           ])
 
           expect(results2).to.eql([
-            { migrationName: 'migration5', direction: 'Down', status: 'Success' },
-            { migrationName: 'migration3', direction: 'Down', status: 'Success' },
+            {
+              migrationName: 'migration5',
+              direction: 'Down',
+              status: 'Success',
+            },
+            {
+              migrationName: 'migration3',
+              direction: 'Down',
+              status: 'Success',
+            },
           ])
 
           expect(executedUpMethods1).to.eql([
@@ -638,14 +638,9 @@ for (const dialect of DIALECTS) {
 
       it('should migrate down one step with permissive ordering enabled', async () => {
         const [migrator1, executedUpMethods1, _executedDownMethods1] =
-          createMigrations(
-            [
-              'migration1',
-              'migration2',
-              'migration4',
-            ],
-            { migrationOrder: 'permissive' }
-          )
+          createMigrations(['migration1', 'migration2', 'migration4'], {
+            migrationOrder: 'permissive',
+          })
 
         await migrator1.migrateToLatest()
 
@@ -680,8 +675,16 @@ for (const dialect of DIALECTS) {
 
         expect(results4).to.eql([])
 
-        expect(executedUpMethods1).to.eql(['migration1', 'migration2', 'migration4'])
-        expect(executedDownMethods2).to.eql(['migration4', 'migration2', 'migration1'])
+        expect(executedUpMethods1).to.eql([
+          'migration1',
+          'migration2',
+          'migration4',
+        ])
+        expect(executedDownMethods2).to.eql([
+          'migration4',
+          'migration2',
+          'migration1',
+        ])
       })
     })
 

--- a/test/node/src/migration.test.ts
+++ b/test/node/src/migration.test.ts
@@ -130,6 +130,49 @@ for (const dialect of DIALECTS) {
         expect(executedUpMethods2).to.eql([])
       })
 
+      it('should run a new migration added before the last executed one with permissive ordering enabled', async () => {
+        const [migrator1, executedUpMethods1] = createMigrations(
+          ['migration1', 'migration3'],
+          { migrationOrder: 'permissive' }
+        )
+
+        await migrator1.migrateToLatest()
+        const { results: results1 } = await migrator1.migrateToLatest()
+
+        const [migrator2, executedUpMethods2] = createMigrations(
+          ['migration1', 'migration2', 'migration3'],
+          { migrationOrder: 'permissive' }
+        )
+
+        await migrator2.migrateToLatest()
+        const { results: results2 } = await migrator2.migrateToLatest()
+
+        expect(results1).to.eql([
+          { migrationName: 'migration1', direction: 'Up', status: 'Success' },
+          { migrationName: 'migration3', direction: 'Up', status: 'Success' },
+        ])
+
+        expect(results2).to.eql([
+          { migrationName: 'migration2', direction: 'Up', status: 'Success' },
+          // { migrationName: 'migration4', direction: 'Up', status: 'Success' },
+        ])
+
+        expect(executedUpMethods1).to.eql(['migration1', 'migration3'])
+        expect(executedUpMethods2).to.eql(['migration2'])
+
+        //
+        //
+        // const { error } = await migrator2.migrateToLatest()
+        //
+        // expect(error).to.be.an.instanceOf(Error)
+        // expect(getMessage(error)).to.eql(
+        //   'corrupted migrations: expected previously executed migration migration3 to be at index 1 but migration2 was found in its place. New migrations must always have a name that comes alphabetically after the last executed migration.'
+        // )
+        //
+        // expect(executedUpMethods1).to.eql(['migration1', 'migration3'])
+        // expect(executedUpMethods2).to.eql([])
+      })
+
       it('should return an error if a previously executed migration is missing', async () => {
         const [migrator1, executedUpMethods1] = createMigrations([
           'migration1',

--- a/test/node/src/migration.test.ts
+++ b/test/node/src/migration.test.ts
@@ -130,17 +130,17 @@ for (const dialect of DIALECTS) {
         expect(executedUpMethods2).to.eql([])
       })
 
-      it('should run a new migration added before the last executed one with permissive ordering enabled', async () => {
+      it('should run a new migration added before the last executed one with allowUnorderedMigrations enabled', async () => {
         const [migrator1, executedUpMethods1] = createMigrations(
           ['migration1', 'migration3'],
-          { migrationOrder: 'permissive' }
+          { allowUnorderedMigrations: true }
         )
 
         const { results: results1 } = await migrator1.migrateToLatest()
 
         const [migrator2, executedUpMethods2] = createMigrations(
           ['migration1', 'migration2', 'migration3', 'migration4'],
-          { migrationOrder: 'permissive' }
+          { allowUnorderedMigrations: true }
         )
 
         const { results: results2 } = await migrator2.migrateToLatest()
@@ -218,18 +218,18 @@ for (const dialect of DIALECTS) {
         expect(executedUpMethods2).to.eql([])
       })
 
-      describe('with permissive ordering', () => {
+      describe('with allowUnorderedMigrations', () => {
         it('should return an error if a previously executed migration is missing', async () => {
           const [migrator1, executedUpMethods1] = createMigrations(
             ['migration1', 'migration2', 'migration3'],
-            { migrationOrder: 'permissive' }
+            { allowUnorderedMigrations: true }
           )
 
           await migrator1.migrateToLatest()
 
           const [migrator2, executedUpMethods2] = createMigrations(
             ['migration2', 'migration3', 'migration4'],
-            { migrationOrder: 'permissive' }
+            { allowUnorderedMigrations: true }
           )
 
           const { error } = await migrator2.migrateToLatest()
@@ -250,12 +250,12 @@ for (const dialect of DIALECTS) {
         it('should return an error if a the last executed migration is not found', async () => {
           const [migrator1, executedUpMethods1] = createMigrations(
             ['migration1', 'migration2', 'migration3'],
-            { migrationOrder: 'permissive' }
+            { allowUnorderedMigrations: true }
           )
 
           const [migrator2, executedUpMethods2] = createMigrations(
             ['migration1', 'migration2', 'migration4'],
-            { migrationOrder: 'permissive' }
+            { allowUnorderedMigrations: true }
           )
 
           await migrator1.migrateToLatest()
@@ -456,11 +456,11 @@ for (const dialect of DIALECTS) {
         expect(executedDownMethods2).to.eql(['migration4', 'migration3'])
       })
 
-      describe('with permissive ordering enabled', () => {
+      describe('with allowUnorderedMigrations enabled', () => {
         it('should migrate up to a specific migration', async () => {
           const [migrator1, executedUpMethods1] = createMigrations(
             ['migration1', 'migration3', 'migration4', 'migration5'],
-            { migrationOrder: 'permissive' }
+            { allowUnorderedMigrations: true }
           )
 
           const { results: results1 } = await migrator1.migrateTo('migration3')
@@ -473,7 +473,7 @@ for (const dialect of DIALECTS) {
               'migration4',
               'migration5',
             ],
-            { migrationOrder: 'permissive' }
+            { allowUnorderedMigrations: true }
           )
 
           const { results: results2 } = await migrator2.migrateTo('migration4')
@@ -495,7 +495,7 @@ for (const dialect of DIALECTS) {
         it('should migrate all the way down', async () => {
           const [migrator1, executedUpMethods1] = createMigrations(
             ['migration1', 'migration2', 'migration4'],
-            { migrationOrder: 'permissive' }
+            { allowUnorderedMigrations: true }
           )
 
           const { results: results1 } = await migrator1.migrateToLatest()
@@ -503,7 +503,7 @@ for (const dialect of DIALECTS) {
           const [migrator2, executedUpMethods2, executedDownMethods2] =
             createMigrations(
               ['migration1', 'migration2', 'migration3', 'migration4'],
-              { migrationOrder: 'permissive' }
+              { allowUnorderedMigrations: true }
             )
 
           const { results: results2 } = await migrator2.migrateTo(NO_MIGRATIONS)
@@ -548,7 +548,7 @@ for (const dialect of DIALECTS) {
         it('should migrate down to a specific migration', async () => {
           const [migrator1, executedUpMethods1] = createMigrations(
             ['migration1', 'migration2', 'migration3', 'migration5'],
-            { migrationOrder: 'permissive' }
+            { allowUnorderedMigrations: true }
           )
 
           const { results: results1 } = await migrator1.migrateTo('migration5')
@@ -562,7 +562,7 @@ for (const dialect of DIALECTS) {
                 'migration4',
                 'migration5',
               ],
-              { migrationOrder: 'permissive' }
+              { allowUnorderedMigrations: true }
             )
 
           const { results: results2 } = await migrator2.migrateTo('migration2')
@@ -655,17 +655,17 @@ for (const dialect of DIALECTS) {
         expect(executedUpMethods2).to.eql([])
       })
 
-      it('should migrate up one step with permissive ordering enabled', async () => {
+      it('should migrate up one step with allowUnorderedMigrations enabled', async () => {
         const [migrator1, executedUpMethods1] = createMigrations(
           ['migration1', 'migration3'],
-          { migrationOrder: 'permissive' }
+          { allowUnorderedMigrations: true }
         )
 
         const { results: results1 } = await migrator1.migrateToLatest()
 
         const [migrator2, executedUpMethods2] = createMigrations(
           ['migration1', 'migration2', 'migration3', 'migration4'],
-          { migrationOrder: 'permissive' }
+          { allowUnorderedMigrations: true }
         )
 
         const { results: results2 } = await migrator2.migrateUp()
@@ -742,10 +742,10 @@ for (const dialect of DIALECTS) {
         expect(executedDownMethods2).to.eql([])
       })
 
-      it('should migrate down one step with permissive ordering enabled', async () => {
+      it('should migrate down one step with allowUnorderedMigrations enabled', async () => {
         const [migrator1, executedUpMethods1, _executedDownMethods1] =
           createMigrations(['migration1', 'migration2', 'migration4'], {
-            migrationOrder: 'permissive',
+            allowUnorderedMigrations: true,
           })
 
         await migrator1.migrateToLatest()
@@ -759,7 +759,7 @@ for (const dialect of DIALECTS) {
               'migration4',
               'migration5',
             ],
-            { migrationOrder: 'permissive' }
+            { allowUnorderedMigrations: true }
           )
 
         const { results: results1 } = await migrator2.migrateDown()


### PR DESCRIPTION
### What is this?

This add an `allowUnorderedMigrations` option to [`MigratorProps`](https://github.com/kysely-org/kysely/blob/1538485c/src/migration/migrator.ts#L598). The options are `true` or `false`, with `false` being the default.

When true, it will allow new migrations to be run even if they are added alphabetically before ones that have already executed.

When false, it will give an error if your migration files are not alphabetically ordered in the same order that they were executed in the database. 

Closes #697

### Why?

If a team has multiple developers, two people can create migrations asynchronously on separate branches. With strict ordering, those migration files have to be merged in the right order (or renamed before merging) or else Kysely will throw an error when trying to migrate them.

Example:

    - Developer A creates migration `2023-09-13-migration-A.ts`
    - Developer B creates migration `2023-09-14-migration-B.ts`
    - Both developers make a PR at roughly the same time
    - Developer B merges their PR and deploys
    - Developer A merges their PR
    - Developer A deploys and tries to run migrations

Kysely will give an error for this with strict ordering. With permissive ordering, the unrun migration is executed.

### Pending migrations vs. executed migrations

This also adds the concept of pending (unexecuted) migrations to Migrator. When migrating up, Migrator will run pending migrations in order for `n` steps. When migrating down, Migrator will consult the database for executed migrations and travel down that list `n` steps. 

This doesn't change the current functionality for ensuring ordered migrations, but also allows out of order ones.

__Some examples:__ 
_(`*` denotes current migration version)_

New migration:
```
Migrations Already Ran:  0  1  2*
Migration Files:         0  1  2  3

Migrate up:              0  1  2  3*
```

Migrate down one:
```
Migrations Already Ran:  0  1  2*
Migration Files:         0  1  2  3

Migrate down:            0  1*
```

New out-of-order migration:
```
Migrations Already Ran:        0  1  2     4*
Migration Files:               0  1  2  3  4  5

Migrate up (strict):           error
Migrate up (permissive):       0  1  2  3  4*
Migrate up again (permissive): 0  1  2  3  4  5*
```

Migrate down with out-of-order migration:
```
Migrations Already Ran:    0  1  2     4*
Migration Files:           0  1  2  3  4  5

Migrate down (strict):     error
Migrate down (permissive): 0  1  2*
```