### PR TITLE
add proof-of-concept for join ... using

### DIFF
--- a/src/parser/join-parser.ts
+++ b/src/parser/join-parser.ts
@@ -36,6 +36,14 @@ type AnyJoinColumnWithTable<DB, TB extends keyof DB, TE> = AnyColumnWithTable<
   FromTables<DB, TB, TE>
 >
 
+export type JoinUsingExpression<
+  DB,
+  TB extends keyof DB,
+  TE
+> = DrainOuterGeneric<
+  AnyJoinColumn<DB, TB, never> & AnyJoinColumn<DB, never, TE>
+>
+
 export function parseJoin(joinType: JoinType, args: any[]): JoinNode {
   if (args.length === 3) {
     return parseSingleOnJoin(joinType, args[0], args[1], args[2])

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -4,6 +4,7 @@ import { SelectModifierNode } from '../operation-node/select-modifier-node.js'
 import {
   JoinCallbackExpression,
   JoinReferenceExpression,
+  JoinUsingExpression,
   parseJoin,
 } from '../parser/join-parser.js'
 import { TableExpression } from '../parser/table-parser.js'
@@ -638,6 +639,14 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
   >(
     table: TE,
     callback: FN
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
+  innerJoinUsing<
+    TE extends TableExpression<DB, TB>,
+    C extends JoinUsingExpression<DB, TB, TE>
+  >(
+    table: TE,
+    columns: readonly [C, ...C[]]
   ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
 
   /**
@@ -1841,6 +1850,11 @@ class SelectQueryBuilderImpl<DB, TB extends keyof DB, O>
         parseJoin('InnerJoin', args)
       ),
     })
+  }
+
+  innerJoinUsing(...args: any): any {
+    // TODO
+    return this
   }
 
   leftJoin(...args: any): any {

--- a/test/typings/test-d/join.test-d.ts
+++ b/test/typings/test-d/join.test-d.ts
@@ -178,6 +178,20 @@ async function testJoin(db: Kysely<Database>) {
         join.onRef('movie.id', '=', 'person.id')
       )
   )
+
+  // Join using
+  db.selectFrom('pet')
+    .innerJoinUsing('book', ['name'])
+    .selectAll()
+    .executeTakeFirstOrThrow()
+
+  db.selectFrom('person as a')
+    .innerJoinUsing('person as b', ['first_name', 'last_name'])
+    .select(['a.id', 'b.id'])
+    .executeTakeFirstOrThrow()
+
+  // Refer to column that's not present in both tables
+  expectError(db.selectFrom('person').innerJoinUsing('movie', ['last_name']))
 }
 
 async function testManyJoins(db: Kysely<Database>) {


### PR DESCRIPTION
This is a proof-of-concept for #730. It mainly features `JoinUsingExpression` which calculates the columns present in both tables.

I'm using my originally proposed syntax `innerJoinUsing` for a couple of reasons:
1. Since `JoinBuilder` has type parameters `TB` and `TE` union'd together, it would be difficult to implement a `JoinUsingExpression` without refactoring `JoinBuilder`'s interface
2. The `join ... using` clause cannot be combined with `join ... on`, so there's no use being able to chain together `join.using(...).on(...).onRef(...)`

But if you still prefer the callback syntax, I'm sure we could make it work