### PR TITLE
site: 'timestamp' instead of 'text' on migration example

### DIFF
--- a/site/docs/migrations.mdx
+++ b/site/docs/migrations.mdx
@@ -84,7 +84,7 @@ export async function up(db: Kysely<any>): Promise<void> {
     .addColumn('first_name', 'text', (col) => col.notNull())
     .addColumn('last_name', 'text')
     .addColumn('gender', 'text', (col) => col.notNull())
-    .addColumn('created_at', 'text', (col) =>
+    .addColumn('created_at', 'timestamp', (col) =>
       col.defaultTo(sql`CURRENT_TIMESTAMP`).notNull()
     )
     .execute()


### PR DESCRIPTION
Small update on the SQLite migration example from the website: https://kysely.dev/docs/migrations#sqlite-migration-example

Replace this:

```typescript
    .addColumn('created_at', 'text', (col) =>
      col.defaultTo(sql`CURRENT_TIMESTAMP`).notNull()
    )
```

With this:

```typescript
    .addColumn('created_at', 'timestamp', (col) =>
      col.defaultTo(sql`CURRENT_TIMESTAMP`).notNull()
    )
```