### PR TITLE
export SelectQueryBuilderImpl

### DIFF
--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -1646,7 +1646,7 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
   ): Promise<ER[]>
 }
 
-class SelectQueryBuilderImpl<DB, TB extends keyof DB, O>
+export class SelectQueryBuilderImpl<DB, TB extends keyof DB, O>
   implements SelectQueryBuilder<DB, TB, O>
 {
   readonly #props: SelectQueryBuilderProps


### PR DESCRIPTION
We have been adding an alternative `.execute()`. I noticed that the actual class (implementation) for SelectQueryBuilder is not exported in recent versions.

The classes for update, delete and insert query builders are already exported.