### PR TITLE
Correct import of pg in examples

### DIFF
--- a/example/src/app.ts
+++ b/example/src/app.ts
@@ -12,7 +12,7 @@ import { Router } from './router'
 import { userController } from './user/user.controller'
 import { ControllerError } from './util/errors'
 import { isObject } from './util/object'
-import { Pool } from 'pg'
+import pg from 'pg'
 
 export class App {
   #config: Config
@@ -27,7 +27,7 @@ export class App {
     this.#router = new Router()
     this.#db = new Kysely<Database>({
       dialect: new PostgresDialect({
-        pool: async () => new Pool(this.#config.database),
+        pool: async () => new pg.Pool(this.#config.database),
       }),
     })
 

--- a/example/src/migrate-to-latest.ts
+++ b/example/src/migrate-to-latest.ts
@@ -8,12 +8,12 @@ import {
   PostgresDialect,
   FileMigrationProvider,
 } from 'kysely'
-import { Pool } from 'pg'
+import pg from 'pg'
 
 async function migrateToLatest() {
   const db = new Kysely<Database>({
     dialect: new PostgresDialect({
-      pool: new Pool(config.database),
+      pool: new pg.Pool(config.database),
     }),
   })
 

--- a/site/docs/migrations.mdx
+++ b/site/docs/migrations.mdx
@@ -127,7 +127,7 @@ Kysely doesn't have a CLI for running migrations and probably never will. This i
 
 ```ts
 import * as path from 'path'
-import { Pool } from 'pg'
+import pg from 'pg'
 import { promises as fs } from 'fs'
 import {
   Kysely,
@@ -139,7 +139,7 @@ import {
 async function migrateToLatest() {
   const db = new Kysely<Database>({
     dialect: new PostgresDialect({
-      pool: new Pool({
+      pool: new pg.Pool({
         host: 'localhost',
         database: 'kysely_test',
       }),

--- a/src/dialect/postgres/postgres-dialect.ts
+++ b/src/dialect/postgres/postgres-dialect.ts
@@ -16,10 +16,10 @@ import { PostgresDialectConfig } from './postgres-dialect-config.js'
  * The constructor takes an instance of {@link PostgresDialectConfig}.
  *
  * ```ts
- * import { Pool } from 'pg'
+ * import pg from 'pg'
  *
  * new PostgresDialect({
- *   pool: new Pool({
+ *   pool: new pg.Pool({
  *     database: 'some_db',
  *     host: 'localhost',
  *   })
@@ -30,10 +30,10 @@ import { PostgresDialectConfig } from './postgres-dialect-config.js'
  * can be a function:
  *
  * ```ts
- * import { Pool } from 'pg'
+ * import pg from 'pg'
  *
  * new PostgresDialect({
- *   pool: async () => new Pool({
+ *   pool: async () => new pg.Pool({
  *     database: 'some_db',
  *     host: 'localhost',
  *   })


### PR DESCRIPTION
The pg package doesn't support ESM so the current imports are incorrect - see <https://github.com/brianc/node-postgres/issues/3060>.

This MR updates the docs so that the examples work after copy/pasting them.