### PR TITLE
add mssql json helpers.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
       "require": "./dist/cjs/helpers/mysql.js",
       "default": "./dist/cjs/helpers/mysql.js"
     },
+    "./helpers/mssql": {
+      "import": "./dist/esm/helpers/mssql.js",
+      "require": "./dist/cjs/helpers/mssql.js",
+      "default": "./dist/cjs/helpers/mssql.js"
+    },
     "./helpers/sqlite": {
       "import": "./dist/esm/helpers/sqlite.js",
       "require": "./dist/cjs/helpers/sqlite.js",

--- a/src/helpers/mssql.ts
+++ b/src/helpers/mssql.ts
@@ -1,0 +1,173 @@
+import { Expression } from '../expression/expression.js'
+import { RawBuilder } from '../raw-builder/raw-builder.js'
+import { sql } from '../raw-builder/sql.js'
+import { Simplify } from '../util/type-utils.js'
+
+/**
+ * An MS SQL Server helper for aggregating a subquery into a JSON array.
+ * 
+ * NOTE: This helper only works correctly if you've installed the `ParseJSONResultsPlugin`.
+ * Otherwise the nested selections will be returned as JSON strings.
+ * 
+ * The plugin can be installed like this:
+ * 
+ * ```ts
+ * const db = new Kysely({
+ *   dialect: new MssqlDialect(config),
+ *   plugins: [new ParseJSONResultsPlugin()]
+ * })
+ * ```
+ * 
+ * ### Examples
+ * 
+ * ```ts
+ * const result = await db
+ *   .selectFrom('person')
+ *   .select((eb) => [
+ *     'id',
+ *     jsonArrayFrom(
+ *       eb.selectFrom('pet')
+ *         .select(['pet.id as pet_id', 'pet.name'])
+ *         .whereRef('pet.owner_id', '=', 'person.id')
+ *         .orderBy('pet.name')
+ *         .modifyEnd(sql`offset 0 rows`)
+ *     ).as('pets')
+ *   ])
+ *   .execute()
+ * 
+ * result[0].id
+ * result[0].pets[0].pet_id
+ * result[0].pets[0].name
+ * ```
+ * 
+ * The generated SQL (MS SQL Server):
+ * 
+ * ```sql
+ * select "id", (
+ *   select coalesce((select * from (
+ *     select "pet"."id" as "pet_id", "pet"."name"
+ *     from "pet"
+ *     where "pet"."owner_id" = "person"."id"
+ *     order by "pet"."name"
+ *     offset 0 rows
+ *   ) as "agg" for json path, include_null_values), '[]')
+ * ) as "pets"
+ * from "person"
+ * ```
+ */
+export function jsonArrayFrom<O>(
+  expr: Expression<O>
+): RawBuilder<Simplify<O>[]> {
+  return sql`coalesce((select * from ${expr} as agg for json path, include_null_values), '[]')`
+}
+
+/**
+ * An MS SQL Server helper for turning a subquery into a JSON object.
+ * 
+ * The subquery must only return one row.
+ * 
+ * NOTE: This helper only works correctly if you've installed the `ParseJSONResultsPlugin`.
+ * Otherwise the nested selections will be returned as JSON strings.
+ * 
+ * The plugin can be installed like this:
+ * 
+ * ```ts
+ * const db = new Kysely({
+ *   dialect: new MssqlDialect(config),
+ *   plugins: [new ParseJSONResultsPlugin()]
+ * })
+ * ```
+ * 
+ * ### Examples
+ * 
+ * ```ts
+ * const result = await db
+ *   .selectFrom('person')
+ *   .select((eb) => [
+ *     'id',
+ *     jsonObjectFrom(
+ *       eb.selectFrom('pet')
+ *         .select(['pet.id as pet_id', 'pet.name'])
+ *         .whereRef('pet.owner_id', '=', 'person.id')
+ *         .where('pet.is_favorite', '=', 1)
+ *     ).as('favorite_pet')
+ *   ])
+ *   .execute()
+ * 
+ * result[0].id
+ * result[0].favorite_pet.pet_id
+ * result[0].favorite_pet.name
+ * ```
+ * 
+ * The generated SQL (MS SQL Server):
+ * 
+ * ```sql
+ * select "id", (
+ *   select * from (
+ *     select "pet"."id" as "pet_id", "pet"."name"
+ *     from "pet"
+ *     where "pet"."owner_id" = "person"."id"
+ *     and "pet"."is_favorite" = @1
+ *   ) as "agg" for json path, include_null_values, without_array_wrapper
+ * ) as "favorite_pet"
+ * from "person"
+ * ```
+ */
+export function jsonObjectFrom<O>(
+  expr: Expression<O>
+): RawBuilder<Simplify<O> | null> {
+  return sql`(select * from ${expr} as agg for json path, include_null_values, without_array_wrapper)`
+}
+
+/**
+ * The MS SQL Server `json_query` function, single argument variant.
+ * 
+ * NOTE: This helper only works correctly if you've installed the `ParseJSONResultsPlugin`.
+ * Otherwise the nested selections will be returned as JSON strings.
+ * 
+ * The plugin can be installed like this:
+ * 
+ * ```ts
+ * const db = new Kysely({
+ *   dialect: new MssqlDialect(config),
+ *   plugins: [new ParseJSONResultsPlugin()]
+ * })
+ * ```
+ * 
+ * ### Examples
+ * 
+ * ```ts
+ * const result = await db
+ *   .selectFrom('person')
+ *   .select((eb) => [
+ *     'id',
+ *     jsonBuildObject({
+ *       first: eb.ref('first_name'),
+ *       last: eb.ref('last_name'),
+ *       full: eb.fn('concat', ['first_name', eb.val(' '), 'last_name'])
+ *     }).as('name')
+ *   ])
+ *   .execute()
+ * ```
+ * 
+ * The generated SQL (MS SQL Server):
+ * 
+ * ```sql
+ * select "id", json_query(
+ *   '{"first":"'+"first_name"+',"last":"'+"last_name"+',"full":"'+concat("first_name", ' ', "last_name")+'"}'
+ * ) as "name"
+ * from "person"
+ * ```
+ */
+export function jsonBuildObject<O extends Record<string, Expression<unknown>>>(
+  obj: O
+): RawBuilder<
+  Simplify<{
+    [K in keyof O]: O[K] extends Expression<infer V> ? V : never
+  }>
+> {
+  return sql`json_query('{${sql.join(
+    Object.keys(obj).map((k) => sql`"${sql.raw(k)}":"'+${obj[k]}+'"`),
+    sql`,`
+  )}}')`
+}

--- a/test/node/src/json.test.ts
+++ b/test/node/src/json.test.ts
@@ -76,7 +76,7 @@ for (const dialect of DIALECTS) {
   const { jsonArrayFrom, jsonObjectFrom, jsonBuildObject } =
     jsonFunctions[dialect]
 
-  describe.only(`${dialect} json tests`, () => {
+  describe(`${dialect} json tests`, () => {
     let ctx: TestContext
     let db: Kysely<Database & { json_table: JsonTable }>
 

--- a/test/node/src/test-setup.ts
+++ b/test/node/src/test-setup.ts
@@ -37,6 +37,7 @@ import {
   MssqlDialect,
   SelectQueryBuilder,
 } from '../../../'
+import { OrderByDirection, UndirectedOrderByExpression } from '../../../dist/cjs/parser/order-by-parser'
 
 export interface Person {
   id: Generated<number>
@@ -475,5 +476,21 @@ export function limit<QB extends SelectQueryBuilder<any, any, any>>(
     }
 
     return qb.limit(limit) as QB
+  }
+}
+
+export function orderBy<QB extends SelectQueryBuilder<any, any, any>>(
+  orderBy: QB extends SelectQueryBuilder<infer DB, infer TB, infer O>
+    ? UndirectedOrderByExpression<DB, TB, O>
+    : never,
+  direction: OrderByDirection | undefined,
+  dialect: BuiltInDialect
+): (qb: QB) => QB {
+  return (qb) => {
+    if (dialect === 'mssql') {
+      return qb.orderBy(orderBy, sql`${sql.raw(direction ? `${direction} ` : '')}${sql.raw('offset 0 rows')}`) as QB
+    }
+
+    return qb.orderBy(orderBy, direction) as QB
   }
 }


### PR DESCRIPTION
Hey :wave:

This PR adds `jsonArrayFrom`, `jsonObjectFrom` and `jsonBuildObject` helpers for MS SQL Server (mssql).

Just like with SQLite, it requires using `ParseJSONResultsPlugin`.
Unlike other engines, there are no JSON aggregate functions, but an entire [`for json` clause](https://learn.microsoft.com/en-us/sql/relational-databases/json/solve-common-issues-with-json-in-sql-server?view=sql-server-ver16#create-a-nested-json-structure).