### PR TITLE
fix: `WithSchemaPlugin` is adding schema to table function arguments and causes db errors in `json_agg` and `to_json`.

### DIFF
--- a/test/node/src/with-schema.test.ts
+++ b/test/node/src/with-schema.test.ts
@@ -227,11 +227,12 @@ for (const dialect of DIALECTS.filter(
             .select((eb) => [
               eb.fn.jsonAgg('pet').as('one'),
               eb.fn.jsonAgg(eb.table('pet')).as('two'),
+              eb.fn.jsonAgg('pet').orderBy('pet.name', 'desc').as('three'),
             ])
 
           testSql(query, dialect, {
             postgres: {
-              sql: 'select json_agg("pet") as "one", json_agg("pet") as "two" from "mammals"."pet"',
+              sql: 'select json_agg("pet") as "one", json_agg("pet") as "two", json_agg("pet" order by "mammals"."pet"."name" desc) as "three" from "mammals"."pet"',
               parameters: [],
             },
             mysql: NOT_SUPPORTED,

--- a/test/node/src/with-schema.test.ts
+++ b/test/node/src/with-schema.test.ts
@@ -218,6 +218,52 @@ for (const dialect of DIALECTS.filter(
 
         await query.execute()
       })
+
+      if (dialect === 'postgres') {
+        it('should not add schema for json_agg parameters', async () => {
+          const query = ctx.db
+            .withSchema('mammals')
+            .selectFrom('pet')
+            .select((eb) => [
+              eb.fn.jsonAgg('pet').as('one'),
+              eb.fn.jsonAgg(eb.table('pet')).as('two'),
+            ])
+
+          testSql(query, dialect, {
+            postgres: {
+              sql: 'select json_agg("pet") as "one", json_agg("pet") as "two" from "mammals"."pet"',
+              parameters: [],
+            },
+            mysql: NOT_SUPPORTED,
+            mssql: NOT_SUPPORTED,
+            sqlite: NOT_SUPPORTED,
+          })
+
+          await query.execute()
+        })
+
+        it('should not add schema for to_json parameters', async () => {
+          const query = ctx.db
+            .withSchema('mammals')
+            .selectFrom('pet')
+            .select((eb) => [
+              eb.fn.toJson('pet').as('one'),
+              eb.fn.toJson(eb.table('pet')).as('two'),
+            ])
+
+          testSql(query, dialect, {
+            postgres: {
+              sql: 'select to_json("pet") as "one", to_json("pet") as "two" from "mammals"."pet"',
+              parameters: [],
+            },
+            mysql: NOT_SUPPORTED,
+            mssql: NOT_SUPPORTED,
+            sqlite: NOT_SUPPORTED,
+          })
+
+          await query.execute()
+        })
+      }
     })
 
     describe('insert into', () => {


### PR DESCRIPTION
Hey :wave:

Recently we've added `eb.fn.jsonAgg` and `eb.fn.toJson`. Both accept table names or `sql.table`/`eb.table` as arguments.

`WithSchemaPlugin` adds schema names to the arguments, resulting in DB errors.
https://onecompiler.com/postgresql/435rdy7de

This makes the plugin unusable anytime such functions are used, which is annoying.

This PR ensures that the plugin leaves `TableNode`s in specific functions' (currently, we know of `jsonAgg` and `toJson`, but there might be more) arguments as-is (no schema is added).