### PR TITLE
implement additional query builder clear methods

### DIFF
--- a/src/operation-node/delete-query-node.ts
+++ b/src/operation-node/delete-query-node.ts
@@ -52,6 +52,15 @@ export const DeleteQueryNode = freeze({
     })
   },
 
+  cloneWithoutOrderBy(
+    deleteNode: DeleteQueryNode
+  ): DeleteQueryNode {
+    return freeze({
+      ...deleteNode,
+      orderBy: undefined,
+    })
+  },
+
   cloneWithLimit(
     deleteNode: DeleteQueryNode,
     limit: LimitNode
@@ -59,6 +68,15 @@ export const DeleteQueryNode = freeze({
     return freeze({
       ...deleteNode,
       limit,
+    })
+  },
+
+  cloneWithoutLimit(
+    deleteNode: DeleteQueryNode
+  ): DeleteQueryNode {
+    return freeze({
+      ...deleteNode,
+      limit: undefined,
     })
   },
 

--- a/src/operation-node/query-node.ts
+++ b/src/operation-node/query-node.ts
@@ -67,6 +67,13 @@ export const QueryNode = freeze({
     })
   },
 
+  cloneWithoutReturning<T extends HasReturning>(node: T): T {
+    return freeze({
+      ...node,
+      returning: undefined,
+    })
+  },
+
   cloneWithoutWhere<T extends HasWhere>(node: T): T {
     return freeze({
       ...node,

--- a/src/query-builder/delete-query-builder.ts
+++ b/src/query-builder/delete-query-builder.ts
@@ -565,6 +565,83 @@ export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
   }
 
   /**
+   * Clears all `returning` clauses from the query.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * db.deleteFrom('pet')
+   *   .returningAll()
+   *   .where('name', '=', 'Max')
+   *   .clearReturning()
+   * ```
+   *
+   * The generated SQL(PostgreSQL):
+   *
+   * ```sql
+   * delete from "pet" where "name" = "Max"
+   * ```
+   */
+  clearReturning(): DeleteQueryBuilder<DB, TB, DeleteResult> {
+    return new DeleteQueryBuilder({
+      ...this.#props,
+      queryNode: QueryNode.cloneWithoutReturning(this.#props.queryNode),
+    })
+  }
+
+  /**
+   * Clears the `limit` clause from the query.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * db.deleteFrom('pet')
+   *   .returningAll()
+   *   .where('name', '=', 'Max')
+   *   .limit(5)
+   *   .clearLimit()
+   * ```
+   *
+   * The generated SQL(PostgreSQL):
+   *
+   * ```sql
+   * delete from "pet" where "name" = "Max" returning *
+   * ```
+   */
+  clearLimit(): DeleteQueryBuilder<DB, TB, O> {
+    return new DeleteQueryBuilder<DB, TB, O>({
+      ...this.#props,
+      queryNode: DeleteQueryNode.cloneWithoutLimit(this.#props.queryNode),
+    })
+  }
+
+  /**
+   * Clears the `order by` clause from the query.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * db.deleteFrom('pet')
+   *   .returningAll()
+   *   .where('name', '=', 'Max')
+   *   .orderBy('id')
+   *   .clearOrderBy()
+   * ```
+   *
+   * The generated SQL(PostgreSQL):
+   *
+   * ```sql
+   * delete from "pet" where "name" = "Max" returning *
+   * ```
+   */
+  clearOrderBy(): DeleteQueryBuilder<DB, TB, O> {
+    return new DeleteQueryBuilder<DB, TB, O>({
+      ...this.#props,
+      queryNode: DeleteQueryNode.cloneWithoutOrderBy(this.#props.queryNode),
+    })
+  }
+
+  /**
    * Adds an `order by` clause to the query.
    *
    * `orderBy` calls are additive. To order by multiple columns, call `orderBy`

--- a/src/query-builder/insert-query-builder.ts
+++ b/src/query-builder/insert-query-builder.ts
@@ -608,6 +608,31 @@ export class InsertQueryBuilder<DB, TB extends keyof DB, O>
   }
 
   /**
+   * Clears all `returning` clauses from the query.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * db.insertInto('person')
+   *   .values({ first_name: 'James', last_name: 'Smith', age: 42 })
+   *   .returning(['first_name'])
+   *   .clearReturning()
+   * ```
+   *
+   * The generated SQL(PostgreSQL):
+   *
+   * ```sql
+   * insert into "person" ("James", "Smith", 42)
+   * ```
+   */
+  clearReturning(): InsertQueryBuilder<DB, TB, InsertResult> {
+    return new InsertQueryBuilder({
+      ...this.#props,
+      queryNode: QueryNode.cloneWithoutReturning(this.#props.queryNode),
+    })
+  }
+
+  /**
    * Simply calls the provided function passing `this` as the only argument. `$call` returns
    * what the provided function returns.
    *

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -1282,6 +1282,24 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    */
   clearSelect(): SelectQueryBuilder<DB, TB, {}>
 
+  /**
+   * Clears all `where` clauses from the query.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * db.selectFrom('person')
+   *   .selectAll()
+   *   .where('first_name', '=', 'James')
+   *   .clearWhere()
+   * ```
+   *
+   * The generated SQL(PostgreSQL):
+   *
+   * ```sql
+   * select * from "person"
+   * ```
+   */
   clearWhere(): SelectQueryBuilder<DB, TB, O>
 
   /**

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -1282,24 +1282,6 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    */
   clearSelect(): SelectQueryBuilder<DB, TB, {}>
 
-  /**
-   * Clears all `where` clauses from the query.
-   *
-   * ### Examples
-   *
-   * ```ts
-   * db.selectFrom('person')
-   *   .selectAll()
-   *   .where('first_name', '=', 'James')
-   *   .clearWhere()
-   * ```
-   *
-   * The generated SQL(PostgreSQL):
-   *
-   * ```sql
-   * select * from "person"
-   * ```
-   */
   clearWhere(): SelectQueryBuilder<DB, TB, O>
 
   /**

--- a/src/query-builder/update-query-builder.ts
+++ b/src/query-builder/update-query-builder.ts
@@ -123,6 +123,24 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
     })
   }
 
+  /**
+   * Clears all `where` clauses from the query.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * db.updateTable('person')
+   *   .set({ age: 39 })
+   *   .where('name', '=', 'John')
+   *   .clearWhere()
+   * ```
+   *
+   * The generated SQL(PostgreSQL):
+   *
+   * ```sql
+   * update "person" set "age" = 39
+   * ```
+   */
   clearWhere(): UpdateQueryBuilder<DB, UT, TB, O> {
     return new UpdateQueryBuilder({
       ...this.#props,
@@ -591,6 +609,32 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
         this.#props.queryNode,
         parseSelectAll()
       ),
+    })
+  }
+
+  /**
+   * Clears all `returning` clauses from the query.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * db.updateTable('person')
+   *   .returningAll()
+   *   .set({ age: 39 })
+   *   .where('first_name', '=', 'John')
+   *   .clearReturning()
+   * ```
+   *
+   * The generated SQL(PostgreSQL):
+   *
+   * ```sql
+   * update "person" set "age" = 39 where "first_name" = "John"
+   * ```
+   */
+  clearReturning(): UpdateQueryBuilder<DB, UT, TB, UpdateResult> {
+    return new UpdateQueryBuilder({
+      ...this.#props,
+      queryNode: QueryNode.cloneWithoutReturning(this.#props.queryNode),
     })
   }
 

--- a/src/query-builder/update-query-builder.ts
+++ b/src/query-builder/update-query-builder.ts
@@ -123,24 +123,6 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
     })
   }
 
-  /**
-   * Clears all `where` clauses from the query.
-   *
-   * ### Examples
-   *
-   * ```ts
-   * db.updateTable('person')
-   *   .set({ age: 39 })
-   *   .where('name', '=', 'John')
-   *   .clearWhere()
-   * ```
-   *
-   * The generated SQL(PostgreSQL):
-   *
-   * ```sql
-   * update "person" set "age" = 39
-   * ```
-   */
   clearWhere(): UpdateQueryBuilder<DB, UT, TB, O> {
     return new UpdateQueryBuilder({
       ...this.#props,

--- a/test/node/src/clear.test.ts
+++ b/test/node/src/clear.test.ts
@@ -182,6 +182,88 @@ for (const dialect of DIALECTS) {
       })
     })
 
+    it('InsertQueryBuilder should clear returning', () => {
+      const query = ctx.db
+        .insertInto('person')
+        .values({ first_name: 'Bruce', last_name: 'Willis', gender: 'male' })
+        .returning(['first_name'])
+        .clearReturning()
+
+      testSql(query, dialect, {
+        postgres: {
+          sql: `insert into "person" ("first_name", "last_name", "gender") values ($1, $2, $3)`,
+          parameters: ['Bruce', 'Willis', 'male'],
+        },
+        mysql: {
+          sql: 'insert into `person` (`first_name`, `last_name`, `gender`) values (?, ?, ?)',
+          parameters: ['Bruce', 'Willis', 'male'],
+        },
+        mssql: {
+          sql: `insert into "person" ("first_name", "last_name", "gender") values (@1, @2, @3)`,
+          parameters: ['Bruce', 'Willis', 'male'],
+        },
+        sqlite: {
+          sql: `insert into "person" ("first_name", "last_name", "gender") values (?, ?, ?)`,
+          parameters: ['Bruce', 'Willis', 'male'],
+        },
+      })
+    })
+
+    it('UpdateQueryBuilder should clear returning', () => {
+      const query = ctx.db
+        .updateTable('person')
+        .set({ marital_status: 'married' })
+        .where('first_name', '=', 'Bruce')
+        .returning(['first_name'])
+        .clearReturning()
+
+      testSql(query, dialect, {
+        postgres: {
+          sql: `update "person" set "marital_status" = $1 where "first_name" = $2`,
+          parameters: ['married', 'Bruce'],
+        },
+        mysql: {
+          sql: 'update `person` set `marital_status` = ? where `first_name` = ?',
+          parameters: ['married', 'Bruce'],
+        },
+        mssql: {
+          sql: `update "person" set "marital_status" = @1 where "first_name" = @2`,
+          parameters: ['married', 'Bruce'],
+        },
+        sqlite: {
+          sql: `update "person" set "marital_status" = ? where "first_name" = ?`,
+          parameters: ['married', 'Bruce'],
+        },
+      })
+    })
+
+    it('DeleteQueryBuilder should clear returning', () => {
+      const query = ctx.db
+        .deleteFrom('person')
+        .where('first_name', '=', 'James')
+        .returning(['first_name'])
+        .clearReturning()
+
+      testSql(query, dialect, {
+        postgres: {
+          sql: `delete from "person" where "first_name" = $1`,
+          parameters: ['James'],
+        },
+        mysql: {
+          sql: 'delete from `person` where `first_name` = ?',
+          parameters: ['James'],
+        },
+        mssql: {
+          sql: `delete from "person" where "first_name" = @1`,
+          parameters: ['James'],
+        },
+        sqlite: {
+          sql: `delete from "person" where "first_name" = ?`,
+          parameters: ['James'],
+        },
+      })
+    })
+
     it('should clear orderBy', () => {
       const query = ctx.db
         .selectFrom('person')
@@ -209,6 +291,33 @@ for (const dialect of DIALECTS) {
       })
     })
 
+    it('DeleteQueryBuilder clear orderBy', () => {
+      const query = ctx.db
+        .deleteFrom('person')
+        .where('gender', '=', 'male')
+        .orderBy('id')
+        .clearOrderBy()
+
+      testSql(query, dialect, {
+        postgres: {
+          sql: `delete from "person" where "gender" = $1`,
+          parameters: ['male'],
+        },
+        mysql: {
+          sql: 'delete from `person` where `gender` = ?',
+          parameters: ['male'],
+        },
+        mssql: {
+          sql: `delete from "person" where "gender" = @1`,
+          parameters: ['male'],
+        },
+        sqlite: {
+          sql: `delete from "person" where "gender" = ?`,
+          parameters: ['male'],
+        },
+      })
+    })
+
     if (dialect === 'postgres' || dialect === 'mysql' || dialect === 'sqlite') {
       it('should clear limit', () => {
         const query = ctx.db
@@ -230,6 +339,30 @@ for (const dialect of DIALECTS) {
           sqlite: {
             sql: `select * from "person"`,
             parameters: [],
+          },
+        })
+      })
+
+      it('DeleteQueryBuilder should clear limit', () => {
+        const query = ctx.db
+          .deleteFrom('person')
+          .where('gender', '=', 'male')
+          .limit(1)
+          .clearLimit()
+
+        testSql(query, dialect, {
+          postgres: {
+            sql: `delete from "person" where "gender" = $1`,
+            parameters: ['male'],
+          },
+          mysql: {
+            sql: 'delete from `person` where `gender` = ?',
+            parameters: ['male'],
+          },
+          mssql: NOT_SUPPORTED,
+          sqlite: {
+            sql: `delete from "person" where "gender" = ?`,
+            parameters: ['male'],
           },
         })
       })

--- a/test/typings/test-d/clear.test-d.ts
+++ b/test/typings/test-d/clear.test-d.ts
@@ -21,3 +21,71 @@ async function testClearSelect(db: Kysely<Database>) {
 
   expectType<{ age: number }>(r2)
 }
+
+async function testClearInsert(db: Kysely<Database>) {
+  const r1 = await db
+    .insertInto('person')
+    .values({ first_name: 'Bruce', last_name: 'Willis', age: 68, gender: 'male' })
+    .returning(['first_name', 'gender'])
+    .clearReturning()
+    .returning('id')
+    .executeTakeFirstOrThrow()
+
+  expectType<{ id: number }>(r1)
+
+  const r2 = await db
+    .insertInto('person')
+    .values({ first_name: 'Bruce', last_name: 'Willis', age: 68, gender: 'male' })
+    .returningAll()
+    .clearReturning()
+    .returning('age')
+    .executeTakeFirstOrThrow()
+
+  expectType<{ age: number }>(r2)
+}
+
+async function testClearUpdate(db: Kysely<Database>) {
+  const r1 = await db
+    .updateTable('person')
+    .set({ age: 76 })
+    .where('first_name', '=', 'Arnold')
+    .returning(['first_name', 'gender'])
+    .clearReturning()
+    .returning('id')
+    .executeTakeFirstOrThrow()
+
+  expectType<{ id: number }>(r1)
+
+  const r2 = await db
+    .updateTable('person')
+    .set({ age: 76 })
+    .where('first_name', '=', 'Arnold')
+    .returningAll()
+    .clearReturning()
+    .returning('age')
+    .executeTakeFirstOrThrow()
+
+  expectType<{ age: number }>(r2)
+}
+
+async function testClearDelete(db: Kysely<Database>) {
+  const r1 = await db
+    .deleteFrom('person')
+    .where('first_name', '=', 'Bruce')
+    .returning(['first_name', 'gender'])
+    .clearReturning()
+    .returning('id')
+    .executeTakeFirstOrThrow()
+
+  expectType<{ id: number }>(r1)
+
+  const r2 = await db
+    .deleteFrom('person')
+    .where('first_name', '=', 'Bruce')
+    .returningAll()
+    .clearReturning()
+    .returning('age')
+    .executeTakeFirstOrThrow()
+
+  expectType<{ age: number }>(r2)
+}


### PR DESCRIPTION
- Include `clearReturning()` method in `InsertQueryBuilder`, `UpdateQueryBuilder` and `DeleteQueryBuilder`
- Include `clearLimit()` and `clearOrderBy()` in `DeleteQueryBuilder`