### PR TITLE
[Docs] Update complex join example to better illustrate the options available (symmetry with `where`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "chai-as-promised": "^7.1.1",
         "chai-subset": "^1.6.0",
         "esbuild": "^0.19.11",
+        "lodash": "^4.17.21",
         "mocha": "^10.2.0",
         "mysql2": "^3.6.5",
         "pg": "^8.11.3",
@@ -2640,6 +2641,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-subset": "^1.6.0",
     "esbuild": "^0.19.11",
+    "lodash": "^4.17.21",
     "mocha": "^10.2.0",
     "mysql2": "^3.6.5",
     "pg": "^8.11.3",

--- a/site/docs/examples/JOIN/0030-complex-join.js
+++ b/site/docs/examples/JOIN/0030-complex-join.js
@@ -4,6 +4,7 @@ export const complexJoin = `await db.selectFrom('person')
     (join) => join
       .onRef('pet.owner_id', '=', 'person.id')
       .on('pet.name', '=', 'Doggo')
+      .on((eb) => eb.or([eb("person.age", ">", 18), eb("person.age", "<", 100)]))
   )
   .selectAll()
   .execute()`

--- a/site/docs/examples/JOIN/0030-complex-join.mdx
+++ b/site/docs/examples/JOIN/0030-complex-join.mdx
@@ -8,8 +8,10 @@ You can provide a function as the second argument to get a join
 builder for creating more complex joins. The join builder has a
 bunch of `on*` methods for building the `on` clause of the join.
 There's basically an equivalent for every `where` method
-(`on`, `onRef` etc.). You can do all the same things with the
-`on` method that you can with the corresponding `where` method.
+(`on`, `onRef` etc.).
+
+You can do all the same things with the
+`on` method that you can with the corresponding `where` method (like [OR expressions for example](https://kysely.dev/docs/examples/WHERE/or-where)).
 See the `where` method documentation for more examples.
 
 import {

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -580,8 +580,10 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    * builder for creating more complex joins. The join builder has a
    * bunch of `on*` methods for building the `on` clause of the join.
    * There's basically an equivalent for every `where` method
-   * (`on`, `onRef` etc.). You can do all the same things with the
-   * `on` method that you can with the corresponding `where` method.
+   * (`on`, `onRef` etc.).
+   *
+   * You can do all the same things with the
+   * `on` method that you can with the corresponding `where` method (like [OR expressions for example](https://kysely.dev/docs/examples/WHERE/or-where)).
    * See the `where` method documentation for more examples.
    *
    * ```ts
@@ -591,6 +593,7 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    *     (join) => join
    *       .onRef('pet.owner_id', '=', 'person.id')
    *       .on('pet.name', '=', 'Doggo')
+   *       .on((eb) => eb.or([eb("person.age", ">", 18), eb("person.age", "<", 100)]))
    *   )
    *   .selectAll()
    *   .execute()


### PR DESCRIPTION
Hello,

when I read the docs I failed to understand how to do OR expressions.

> You can do all the same things with the
`on` method that you can with the corresponding `where` method

The hint at the `where` documentation was not sufficient for me (that's more a me issue though).

So I included a little more information about the options provided by `on`.