### PR TITLE
feat: add 'add column if not exists' for postgres

### DIFF
--- a/src/operation-node/column-definition-node.ts
+++ b/src/operation-node/column-definition-node.ts
@@ -28,6 +28,7 @@ export interface ColumnDefinitionNode extends OperationNode {
   readonly endModifiers?: ReadonlyArray<OperationNode>
   readonly nullsNotDistinct?: boolean
   readonly identity?: boolean
+  readonly ifNotExists?: boolean
 }
 
 /**

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -452,6 +452,7 @@ export class OperationNodeTransformer {
       endModifiers: this.transformNodeList(node.endModifiers),
       nullsNotDistinct: node.nullsNotDistinct,
       identity: node.identity,
+      ifNotExists: node.ifNotExists,
     })
   }
 

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -607,6 +607,10 @@ export class DefaultQueryCompiler
   }
 
   protected override visitColumnDefinition(node: ColumnDefinitionNode): void {
+    if (node.ifNotExists) {
+      this.append('if not exists ')
+    }
+
     this.visitNode(node.column)
 
     this.append(' ')

--- a/src/schema/column-definition-builder.ts
+++ b/src/schema/column-definition-builder.ts
@@ -377,6 +377,16 @@ export class ColumnDefinitionBuilder implements OperationNodeSource {
   }
 
   /**
+   * Adds `if not exists` specifier.
+   * This only works for PostgreSQL.
+   */
+  ifNotExists(): ColumnDefinitionBuilder {
+    return new ColumnDefinitionBuilder(
+      ColumnDefinitionNode.cloneWith(this.#node, { ifNotExists: true }),
+    )
+  }
+
+  /**
    * This can be used to add any additional SQL to the end of the column definition.
    *
    * ### Examples

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -299,7 +299,7 @@ for (const dialect of DIALECTS) {
           const builder = ctx.db.schema
             .createTable('test')
             .addColumn('a', 'integer', (col) =>
-              col.identity().notNull().primaryKey()
+              col.identity().notNull().primaryKey(),
             )
             .addColumn('b', 'integer', (col) =>
               col
@@ -2320,6 +2320,24 @@ for (const dialect of DIALECTS) {
             testSql(builder, dialect, {
               postgres: {
                 sql: 'alter table "test" add column "desc" varchar(20) unique nulls not distinct',
+                parameters: [],
+              },
+              mysql: NOT_SUPPORTED,
+              mssql: NOT_SUPPORTED,
+              sqlite: NOT_SUPPORTED,
+            })
+
+            await builder.execute()
+          })
+
+          it('should add a column with "if not exists" modifier', async () => {
+            const builder = ctx.db.schema
+              .alterTable('test')
+              .addColumn('desc', 'varchar(20)', (cb) => cb.ifNotExists())
+
+            testSql(builder, dialect, {
+              postgres: {
+                sql: 'alter table "test" add column if not exists "desc" varchar(20)',
                 parameters: [],
               },
               mysql: NOT_SUPPORTED,


### PR DESCRIPTION
Implements `ADD COLUMN IF NOT EXISTS`.

If I'm not mistaken this is only supported by Postgres (https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-DESC-ADD-COLUMN).

Let me know if there's something to improve upon. 

