### PR TITLE
fix `InferResult` not working for merge queries.

### DIFF
--- a/src/query-builder/merge-query-builder.ts
+++ b/src/query-builder/merge-query-builder.ts
@@ -703,7 +703,7 @@ export class WheneableMergeQueryBuilder<
     )
   }
 
-  compile(): CompiledQuery<never> {
+  compile(): CompiledQuery<O> {
     return this.#props.executor.compileQuery(
       this.toOperationNode(),
       this.#props.queryId,

--- a/test/typings/test-d/infer-result.test-d.ts
+++ b/test/typings/test-d/infer-result.test-d.ts
@@ -6,6 +6,7 @@ import {
   InferResult,
   InsertResult,
   Kysely,
+  MergeResult,
   Selectable,
   UpdateResult,
 } from '..'
@@ -127,4 +128,17 @@ function testInferResultDeleteQuery(db: Kysely<Database>) {
   type Expected2 = { id: string }[]
   expectType<Equals<Expected2, InferResult<typeof query2>>>(true)
   expectType<Equals<Expected2, InferResult<typeof compiledQuery2>>>(true)
+}
+
+function testInferResultMergeQuery(db: Kysely<Database>) {
+  const query0 = db
+    .mergeInto('person')
+    .using('pet', 'pet.owner_id', 'person.id')
+    .whenMatched()
+    .thenDelete()
+  const compiledQuery0 = query0.compile()
+
+  type Expected0 = MergeResult
+  expectType<Equals<Expected0, InferResult<typeof query0>>>(true)
+  expectType<Equals<Expected0, InferResult<typeof compiledQuery0>>>(true)
 }


### PR DESCRIPTION
Hey :wave:

This PR fixes `InferResult` not working for merge queries - currently always infers `never`.