### PR TITLE
Added `clearGroupBy()`

### DIFF
--- a/src/operation-node/select-query-node.ts
+++ b/src/operation-node/select-query-node.ts
@@ -218,4 +218,11 @@ export const SelectQueryNode = freeze({
       orderBy: undefined,
     })
   },
+
+  cloneWithoutGroupBy(select: SelectQueryNode): SelectQueryNode {
+    return freeze({
+      ...select,
+      groupBy: undefined,
+    })
+  },
 })

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -1508,7 +1508,7 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    * ```ts
    * db.selectFrom('person')
    *   .selectAll()
-   *   .orderBy('id')
+   *   .groupBy('id')
    *   .clearGroupBy()
    * ```
    *

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -1501,6 +1501,26 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
   clearOrderBy(): SelectQueryBuilder<DB, TB, O>
 
   /**
+   * Clears `group by` clause from the query.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * db.selectFrom('person')
+   *   .selectAll()
+   *   .orderBy('id')
+   *   .clearGroupBy()
+   * ```
+   *
+   * The generated SQL(PostgreSQL):
+   *
+   * ```sql
+   * select * from "person"
+   * ```
+   */
+  clearGroupBy(): SelectQueryBuilder<DB, TB, O>
+
+  /**
    * Simply calls the provided function passing `this` as the only argument. `$call` returns
    * what the provided function returns.
    *
@@ -2276,6 +2296,13 @@ class SelectQueryBuilderImpl<DB, TB extends keyof DB, O>
     return new SelectQueryBuilderImpl<DB, TB, O>({
       ...this.#props,
       queryNode: SelectQueryNode.cloneWithoutOrderBy(this.#props.queryNode),
+    })
+  }
+
+  clearGroupBy(): SelectQueryBuilder<DB, TB, O> {
+    return new SelectQueryBuilderImpl<DB, TB, O>({
+      ...this.#props,
+      queryNode: SelectQueryNode.cloneWithoutGroupBy(this.#props.queryNode),
     })
   }
 

--- a/test/node/src/clear.test.ts
+++ b/test/node/src/clear.test.ts
@@ -395,5 +395,32 @@ for (const dialect of DIALECTS) {
         },
       })
     })
+
+    it('should clear groupBy', () => {
+      const query = ctx.db
+        .selectFrom('person')
+        .selectAll()
+        .groupBy('id')
+        .clearGroupBy()
+
+      testSql(query, dialect, {
+        postgres: {
+          sql: `select * from "person"`,
+          parameters: [],
+        },
+        mysql: {
+          sql: 'select * from `person`',
+          parameters: [],
+        },
+        mssql: {
+          sql: `select * from "person"`,
+          parameters: [],
+        },
+        sqlite: {
+          sql: `select * from "person"`,
+          parameters: [],
+        },
+      })
+    })
   })
 }


### PR DESCRIPTION
Adds the option to remove group by clause from `SelectQueryBuilder` using `clearGroupBy()` (as discussed in https://discord.com/channels/890118421587578920/1073948476590792786/threads/1221117943081996429)

I've only added a single node test, should I add additional ones for other environments? 

---
Unrelated to this PR in particular: I had some issues making tests for mssql work. After following https://github.com/kysely-org/kysely/issues/906 it worked. Maybe we should add this to the Contribution Guidelines? Additionally I've had issues with prettier modifying indentation and tsc complaining about `Duplicate identifier 'Prepend'` – I had to manually disable lib checks. I'm running on node v20.8.0 and npm 10.1.0