### PR TITLE
chore: warn instead of throwing error if transform returns different nodes

### DIFF
--- a/src/query-executor/query-executor-base.ts
+++ b/src/query-executor/query-executor-base.ts
@@ -37,7 +37,7 @@ export abstract class QueryExecutorBase implements QueryExecutor {
       if (transformedNode.kind === node.kind) {
         node = transformedNode as T
       } else {
-        throw new Error(
+        console.warn(
           [
             `KyselyPlugin.transformQuery must return a node`,
             `of the same kind that was given to it.`,

--- a/src/query-executor/query-executor-base.ts
+++ b/src/query-executor/query-executor-base.ts
@@ -34,9 +34,7 @@ export abstract class QueryExecutorBase implements QueryExecutor {
 
       // We need to do a runtime check here. There is no good way
       // to write types that enforce this constraint.
-      if (transformedNode.kind === node.kind) {
-        node = transformedNode as T
-      } else {
+      if (transformedNode.kind !== node.kind) {
         console.warn(
           [
             `KyselyPlugin.transformQuery must return a node`,
@@ -46,6 +44,8 @@ export abstract class QueryExecutorBase implements QueryExecutor {
           ].join(' '),
         )
       }
+
+      node = transformedNode as T
     }
 
     return node


### PR DESCRIPTION
allows us to return a different node. 

Specific use case here https://discord.com/channels/890118421587578920/1223240368703799418/1223240368703799418 where I want to be able to safely detect empty array inserts and transform them into no ops with a plugin.