### PR TITLE
Support accessing the last executed migration

### DIFF
--- a/src/migration/migrator.ts
+++ b/src/migration/migrator.ts
@@ -238,6 +238,21 @@ export class Migrator {
     return this.#migrate(() => ({ direction: 'Down', step: 1 }))
   }
 
+  /**
+   * Returns the name last executed migration.
+   * 
+   * @returns the name of the last executed migration when at least one migration
+   * was executed, or `undefined` otherwise.
+   */
+  async getLastExecutedMigrationName(): Promise<MigrationState['lastMigration']> {
+    await this.#ensureMigrationTablesExists();
+    const db = this.#props.db;
+
+    const { lastMigration } = await this.#getState(db)
+
+    return lastMigration
+  }
+  
   async #migrate(
     getMigrationDirectionAndStep: (state: MigrationState) => {
       direction: MigrationDirection

--- a/test/node/src/migration.test.ts
+++ b/test/node/src/migration.test.ts
@@ -794,6 +794,28 @@ for (const dialect of DIALECTS) {
       })
     })
 
+    describe('getLastExecutedMigrationName', () =>{
+      it('should return undefined when no migrations have been executed', async ()=>{
+        const [migrator, executedUpMethods1] = createMigrations([]);
+
+        const lastExecutedMigration = await migrator.getLastExecutedMigrationName();
+
+        expect(lastExecutedMigration).to.eql(undefined);
+      });
+
+      it('should return the name of the last executed migration', async ()=>{
+        const [migrator, executedUpMethods1] = createMigrations([
+          'migration1',
+          'migration2',
+        ]);
+        await migrator.migrateUp();
+
+        const lastExecutedMigration = await migrator.getLastExecutedMigrationName();
+
+        expect(lastExecutedMigration).to.eql('migration1');
+      })
+    });
+
     if (dialect === 'postgres') {
       describe('custom migration tables in a custom schema', () => {
         it('should create custom migration tables in custom schema', async () => {


### PR DESCRIPTION
This allows tools using `Migrator` to inform the current state of the database.