### PR TITLE
migrate to docker compose v2.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         run: npx playwright install
 
       - name: Run docker compose
-        run: docker-compose up -d
+        run: docker compose up -d
 
       - name: Run node tests
         run: npm test


### PR DESCRIPTION
Hey 👋 

`docker-compose [command]` no longer works in GitHub Actions.
https://docs.docker.com/compose/migrate/