### PR TITLE
add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "igalklebanov"
+    versioning-strategy: increase


### PR DESCRIPTION
Hey 👋 

Keeping up with dev dependencies' releases and triggering CI for them will help us catch if Kysely might not work for our users in certain setups, and provide fixes quickly.

We'll be hit with PR spam initially (I'll handle it), but over time it'll be OK.