### PR TITLE
Add support for postgres CYCLE

### DIFF
--- a/src/operation-node/with-node.ts
+++ b/src/operation-node/with-node.ts
@@ -7,7 +7,27 @@ export type WithNodeParams = Omit<WithNode, 'kind' | 'expressions'>
 export interface WithNode extends OperationNode {
   readonly kind: 'WithNode'
   readonly expressions: ReadonlyArray<CommonTableExpressionNode>
-  readonly recursive?: boolean
+  readonly recursive?: RecursiveOptions
+}
+
+export interface RecursiveOptions {
+  cycle?: Cycle
+  // search: Search
+}
+
+export interface Cycle<
+  UsingColumn extends string = string,
+  SetColumnName extends string = string,
+  SetValueType = unknown,
+  ColumnList = Array<unknown>,
+> {
+  columnList: ColumnList
+  using: UsingColumn
+  set: {
+    column: SetColumnName
+    default?: SetValueType
+    to?: SetValueType
+  }
 }
 
 /**

--- a/src/parser/with-parser.ts
+++ b/src/parser/with-parser.ts
@@ -28,9 +28,11 @@ export type QueryCreatorWithCommonTableExpression<
   DB,
   CN extends string,
   CTE,
+  XTRA = unknown,
 > = QueryCreator<
   DB & {
-    [K in ExtractTableFromCommonTableExpressionName<CN>]: ExtractRowFromCommonTableExpression<CTE>
+    [K in ExtractTableFromCommonTableExpressionName<CN>]: ExtractRowFromCommonTableExpression<CTE> &
+      XTRA
   }
 >
 
@@ -51,7 +53,7 @@ type CommonTableExpressionOutput<DB, CN extends string> =
  * For example a CTE `(db) => db.selectFrom('person').select(['id', 'first_name'])`
  * would result in `Pick<Person, 'id' | 'first_name'>`.
  */
-type ExtractRowFromCommonTableExpression<CTE> = CTE extends (
+export type ExtractRowFromCommonTableExpression<CTE> = CTE extends (
   creator: QueryCreator<any>,
 ) => infer Q
   ? Q extends Expression<infer QO>

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -1041,6 +1041,15 @@ export class DefaultQueryCompiler
     }
 
     this.compileList(node.expressions)
+
+    if (node.recursive?.cycle) {
+      const { columnList, using, set } = node.recursive.cycle
+      const columns = columnList.join(', ')
+
+      this.append(
+        ` cycle ${columns} set ${set.column} to ${set.to} default ${set.default} using ${using}`,
+      )
+    }
   }
 
   protected override visitCommonTableExpression(


### PR DESCRIPTION
I tried implementing the CYCLE keyword from Postgres. I got it working but I'm not really sure about the API and parts of the implementation.

So this is more a starting point for a discussion.

About CYCLE: https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-CYCLE

```typescript
const query = nodeTrx
  .withRecursive(
    'ancestors', // I'm not sure if one could use the CTEBuilder callback for cycle (which is used for materialized() right now)
    (db) =>
      db
        .selectFrom('node')
        .where('name', '=', 'node1')
        .select(['name', 'parent'])
        .unionAll(
          db
            .selectFrom('node')
            .innerJoin('ancestors', 'node.name', 'ancestors.parent')
            .select(['node.name', 'node.parent']),
        ),
    {
      cycle: {
        columnList: ['name', 'parent'],
        using: 'path',
        set: {
          column: 'is_cycle',
          default: 0,
          to: 1,
        },
      },
     // search: { ... this could be used for the SEARCH keyword also available in Postgres }
    },
  )
  .selectFrom('ancestors')
  .select(['ancestors.name', 'ancestors.is_cycle', 'ancestors.path'])
```