### PR TITLE
Updating visitMergeQuery to join `WhenNode`s with a space

### DIFF
--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -1535,7 +1535,7 @@ export class DefaultQueryCompiler
 
     if (node.whens) {
       this.append(' ')
-      this.compileList(node.whens)
+      this.compileList(node.whens, ' ')
     }
 
     if (node.output) {


### PR DESCRIPTION
closes #939

This seems to fix an issue I had when having a `whenMatched` and a `whenNotMatched` in a single merge statement within MSSQL.

All tests passed locally, but I mostly just copied down a different test with a slight addition, so feel free to make any suggestions or changes if it can be improved.

Thanks