### PR TITLE
add `objectStrategy` option that allows to not mutate result objects/arrays @ `ParseJSONResultsPlugin`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kysely",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kysely",
-      "version": "0.27.2",
+      "version": "0.27.3",
       "license": "MIT",
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.8",

--- a/src/plugin/parse-json-results/parse-json-results-plugin.ts
+++ b/src/plugin/parse-json-results/parse-json-results-plugin.ts
@@ -60,7 +60,7 @@ export class ParseJSONResultsPlugin implements KyselyPlugin {
 }
 
 function parseArray<T>(arr: T[], objectStrategy: ObjectStrategy): T[] {
-  const target = objectStrategy === 'create' ? [] : arr
+  const target = objectStrategy === 'create' ? new Array(arr.length) : arr
 
   for (let i = 0; i < arr.length; ++i) {
     target[i] = parse(arr[i], objectStrategy) as T

--- a/src/plugin/parse-json-results/parse-json-results-plugin.ts
+++ b/src/plugin/parse-json-results/parse-json-results-plugin.ts
@@ -15,19 +15,14 @@ export interface ParseJSONResultsPluginOptions {
    *
    * This can result in runtime errors if some objects/arrays are readonly.
    *
-   * When `'spread'`, arrays and objects are spread (`...`) into new arrays and
-   * objects. This is least efficient time-wise, but safe from readonly runtime
-   * errors.
-   *
-   * When `'create'`, new arrays and objects are created. This is least efficient
-   * space-wise, but safe from readonly runtime errors.
+   * When `'create'`, new arrays and objects are created to avoid such errors.
    *
    * Defaults to `'in-place'`.
    */
   objectStrategy?: ObjectStrategy
 }
 
-type ObjectStrategy = 'in-place' | 'spread' | 'create'
+type ObjectStrategy = 'in-place' | 'create'
 
 /**
  * Parses JSON strings in query results into JSON objects.
@@ -65,10 +60,6 @@ export class ParseJSONResultsPlugin implements KyselyPlugin {
 }
 
 function parseArray<T>(arr: T[], objectStrategy: ObjectStrategy): T[] {
-  if (objectStrategy === 'spread') {
-    arr = [...arr]
-  }
-
   const target = objectStrategy === 'create' ? [] : arr
 
   for (let i = 0; i < arr.length; ++i) {
@@ -114,10 +105,6 @@ function parseObject(
   obj: Record<string, unknown>,
   objectStrategy: ObjectStrategy,
 ): Record<string, unknown> {
-  if (objectStrategy === 'spread') {
-    obj = { ...obj }
-  }
-
   const target = objectStrategy === 'create' ? {} : obj
 
   for (const key in obj) {

--- a/test/node/src/parse-json-results-plugin.test.ts
+++ b/test/node/src/parse-json-results-plugin.test.ts
@@ -1,7 +1,7 @@
 import { ParseJSONResultsPlugin } from '../../..'
 import { createQueryId } from '../../../dist/cjs/util/query-id.js'
 
-describe.only('ParseJSONResultsPlugin', () => {
+describe('ParseJSONResultsPlugin', () => {
   describe("when `objectStrategy` is 'create'", () => {
     let plugin: ParseJSONResultsPlugin
 

--- a/test/node/src/parse-json-results-plugin.test.ts
+++ b/test/node/src/parse-json-results-plugin.test.ts
@@ -1,0 +1,27 @@
+import { ParseJSONResultsPlugin } from '../../..'
+import { createQueryId } from '../../../dist/cjs/util/query-id.js'
+
+describe.only('ParseJSONResultsPlugin', () => {
+  describe("when `objectStrategy` is 'create'", () => {
+    let plugin: ParseJSONResultsPlugin
+
+    beforeEach(() => {
+      plugin = new ParseJSONResultsPlugin({ objectStrategy: 'create' })
+    })
+
+    it('should parse JSON results that contain readonly arrays/objects', async () => {
+      await plugin.transformResult({
+        queryId: createQueryId(),
+        result: {
+          rows: [
+            Object.freeze({
+              id: 1,
+              carIds: Object.freeze([1, 2, 3]),
+              metadata: JSON.stringify({ foo: 'bar' }),
+            }),
+          ],
+        },
+      })
+    })
+  })
+})


### PR DESCRIPTION
Hey :wave:

This PR offers a way to avoid nasty runtime errors when result objects/arrays have non-writable props when parsing using `ParseJSONResultsPlugin`.

The default strategy is `'in-place'` (similar to how the plugin behaves in latest version).

In large objects/arrays, the new `create` strategy might significantly differ in memory consumption, as it fills new objects/arrays instead of mutating the existing ones.