### PR TITLE
Add support for extracting original array type for ColumnType array

### DIFF
--- a/src/util/column-type.ts
+++ b/src/util/column-type.ts
@@ -22,7 +22,7 @@ import { DrainOuterGeneric } from './type-utils.js'
  * The above example makes the column optional in inserts
  * and updates, but you can still choose to provide the
  * column. If you want to prevent insertion/update you
- * can se the type as `never`:
+ * can set the type as `never`:
  *
  * ```ts
  * ColumnType<number, never, never>
@@ -88,19 +88,19 @@ type IfNullable<T, K> = undefined extends T ? K : null extends T ? K : never
 type IfNotNullable<T, K> = undefined extends T
   ? never
   : null extends T
-    ? never
-    : T extends never
-      ? never
-      : K
+  ? never
+  : T extends never
+  ? never
+  : K
 
 /**
  * Evaluates to `K` if `T` isn't `never`.
  */
 type IfNotNever<T, K> = T extends never ? never : K
 
-export type SelectType<T> = T extends ColumnType<infer S, any, any> ? S : T
-export type InsertType<T> = T extends ColumnType<any, infer I, any> ? I : T
-export type UpdateType<T> = T extends ColumnType<any, any, infer U> ? U : T
+export type SelectType<T> = T extends ColumnType<infer S, any, any> ? S : T extends ColumnType<infer S, any, any>[] ? S[] : T
+export type InsertType<T> = T extends ColumnType<any, infer I, any> ? I : T extends ColumnType<any, infer I, any>[] ? I[] : T
+export type UpdateType<T> = T extends ColumnType<any, any, infer U> ? U : T extends ColumnType<any, any, infer U>[] ? U[] : T
 
 /**
  * Keys of `R` whose `InsertType` values can be `null` or `undefined`.

--- a/test/typings/shared.d.ts
+++ b/test/typings/shared.d.ts
@@ -37,6 +37,7 @@ export interface Database {
   toy: Toy
   person_metadata: PersonMetadata
   action: Action
+  big_numbers: BigNumbers
 }
 
 export type Action =
@@ -88,4 +89,12 @@ export interface PersonMetadata {
   schedule: JSONColumnType<{ name: string; time: string }[][][]>
   record: JSONColumnType<Record<string, string>>
   array: JSONColumnType<Array<string>>
+}
+
+type Int8 = ColumnType<string, string | number | bigint, string | number | bigint>
+
+export interface BigNumbers {
+  id: Generated<number>
+  one_number: Int8
+  numbers_array: Int8[]
 }

--- a/test/typings/test-d/insert.test-d.ts
+++ b/test/typings/test-d/insert.test-d.ts
@@ -268,3 +268,17 @@ async function testOutput(db: Kysely<Database>) {
   expectError(db.insertInto('person').output('deleted.age').values(person))
   expectError(db.insertInto('person').outputAll('deleted').values(person))
 }
+
+async function testColumnType(db: Kysely<Database>) {
+  const record = {
+    one_number: BigInt(123),
+    numbers_array: [123, '456', BigInt(789)]
+  }
+
+  const [r1] = await db
+    .insertInto('big_numbers')
+    .values(record)
+    .execute()
+
+  expectType<InsertResult>(r1)
+}

--- a/test/typings/test-d/select.test-d.ts
+++ b/test/typings/test-d/select.test-d.ts
@@ -445,6 +445,15 @@ async function testManyNestedSubqueries(db: Kysely<Database>) {
   }>(r)
 }
 
+async function testColumnType(db: Kysely<Database>) {
+  const [r1] = await db
+  .selectFrom('big_numbers')
+  .select(['one_number', 'numbers_array'])
+  .execute()
+
+  expectType<{ one_number: string, numbers_array: string[] }>(r1)
+}
+
 export function jsonArrayFrom<O>(
   expr: Expression<O>,
 ): RawBuilder<Simplify<O>[]> {

--- a/test/typings/test-d/update.test-d.ts
+++ b/test/typings/test-d/update.test-d.ts
@@ -59,3 +59,17 @@ async function testUpdate(db: Kysely<Database>) {
 
   db.updateTable('person').set(mutationObject)
 }
+
+async function testColumnType(db: Kysely<Database>) {
+  const record = {
+    one_number: BigInt(123),
+    numbers_array: [123, '456', BigInt(789)]
+  }
+
+  const [r1] = await db
+    .updateTable('big_numbers')
+    .set(record)
+    .execute()
+
+  expectType<UpdateResult>(r1)
+}


### PR DESCRIPTION
Fixes #957 

- `SelectType<T>`, `InsertType<T>` and `UpdateType<T>` definitions were extended to allow for extraction of the underlying type for ColumnType array.
- Typings tests were added for all of the above (i.e. select, insert, update).

For more information about the rationale, read description of #957 .