### PR TITLE
add `ControlledTransaction`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,14 +69,6 @@
     "Sami Koskimäki <sami@jakso.me>",
     "Igal Klebanov <igalklebanov@gmail.com>"
   ],
-  "peerDependencies": {
-    "tedious": "~18.x"
-  },
-  "peerDependenciesMeta": {
-    "tedious": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.11",
     "@types/chai": "^4.3.17",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,14 @@
     "Sami Koskimäki <sami@jakso.me>",
     "Igal Klebanov <igalklebanov@gmail.com>"
   ],
+  "peerDependencies": {
+    "tedious": "~18.x"
+  },
+  "peerDependenciesMeta": {
+    "tedious": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.11",
     "@types/chai": "^4.3.17",

--- a/scripts/copy-interface-documentation.js
+++ b/scripts/copy-interface-documentation.js
@@ -22,7 +22,7 @@ const OBJECT_REGEXES = [
   /^(?:export )?declare (?:abstract )?class (\w+)/,
   /^(?:export )?interface (\w+)/,
 ]
-const GENERIC_ARGUMENTS_REGEX = /<[\w"'`,{}=| ]+>/g
+const GENERIC_ARGUMENTS_REGEX = /<[\w"'`,{}=|\[\] ]+>/g
 const JSDOC_START_REGEX = /^\s+\/\*\*/
 const JSDOC_END_REGEX = /^\s+\*\//
 
@@ -123,7 +123,7 @@ function parseObjects(file) {
 function parseImplements(line) {
   if (!line.endsWith('{')) {
     console.warn(
-      `skipping object declaration "${line}". Expected it to end with "{"'`
+      `skipping object declaration "${line}". Expected it to end with "{"'`,
     )
     return []
   }
@@ -225,7 +225,7 @@ function findDocProperty(files, object, propertyName) {
     }
 
     const interfaceProperty = interfaceObject.properties.find(
-      (it) => it.name === propertyName
+      (it) => it.name === propertyName,
     )
 
     if (interfaceProperty?.doc) {

--- a/src/dialect/mssql/mssql-dialect-config.ts
+++ b/src/dialect/mssql/mssql-dialect-config.ts
@@ -65,17 +65,14 @@ export interface Tedious {
 
 export interface TediousConnection {
   beginTransaction(
-    callback: (error?: Error | null, transactionDescriptor?: any) => void,
-    name?: string,
-    isolationLevel?: number,
+    callback: (error?: Error | null) => void,
+    transactionId?: string | undefined,
+    isolationLevel?: number | undefined,
   ): void
   cancel(): boolean
   close(): void
-  commitTransaction(
-    callback: (error?: Error | null) => void,
-    name?: string,
-  ): void
-  connect(callback?: (error?: Error) => void): void
+  commitTransaction(callback: (error?: Error | null) => void): void
+  connect(callback: (error?: Error | null) => void): void
   execSql(request: TediousRequest): void
   off(event: 'error', listener: (error: unknown) => void): this
   off(event: string, listener: (...args: any[]) => void): this

--- a/src/dialect/mssql/mssql-dialect-config.ts
+++ b/src/dialect/mssql/mssql-dialect-config.ts
@@ -65,14 +65,20 @@ export interface Tedious {
 
 export interface TediousConnection {
   beginTransaction(
-    callback: (error?: Error | null) => void,
-    transactionId?: string | undefined,
+    callback: (
+      err: Error | null | undefined,
+      transactionDescriptor?: any,
+    ) => void,
+    name?: string | undefined,
     isolationLevel?: number | undefined,
   ): void
   cancel(): boolean
   close(): void
-  commitTransaction(callback: (error?: Error | null) => void): void
-  connect(callback: (error?: Error | null) => void): void
+  commitTransaction(
+    callback: (err: Error | null | undefined) => void,
+    name?: string | undefined,
+  ): void
+  connect(connectListener: (err?: Error) => void): void
   execSql(request: TediousRequest): void
   off(event: 'error', listener: (error: unknown) => void): this
   off(event: string, listener: (...args: any[]) => void): this
@@ -80,12 +86,15 @@ export interface TediousConnection {
   on(event: string, listener: (...args: any[]) => void): this
   once(event: 'end', listener: () => void): this
   once(event: string, listener: (...args: any[]) => void): this
-  reset(callback: (error?: Error | null) => void): void
+  reset(callback: (err: Error | null | undefined) => void): void
   rollbackTransaction(
-    callback: (error?: Error | null) => void,
-    name?: string,
+    callback: (err: Error | null | undefined) => void,
+    name?: string | undefined,
   ): void
-  saveTransaction(callback: (error?: Error | null) => void, name: string): void
+  saveTransaction(
+    callback: (err: Error | null | undefined) => void,
+    name: string,
+  ): void
 }
 
 export type TediousIsolationLevel = Record<string, number>

--- a/src/dialect/mssql/mssql-dialect-config.ts
+++ b/src/dialect/mssql/mssql-dialect-config.ts
@@ -1,3 +1,5 @@
+import type { Connection, ISOLATION_LEVEL, Request, TYPES } from 'tedious'
+
 export interface MssqlDialectConfig {
   /**
    * This dialect uses the `tarn` package to manage the connection pool to your

--- a/src/dialect/mssql/mssql-dialect-config.ts
+++ b/src/dialect/mssql/mssql-dialect-config.ts
@@ -1,5 +1,3 @@
-import { Request } from 'tedious'
-
 export interface MssqlDialectConfig {
   /**
    * This dialect uses the `tarn` package to manage the connection pool to your

--- a/src/dialect/mssql/mssql-dialect-config.ts
+++ b/src/dialect/mssql/mssql-dialect-config.ts
@@ -1,4 +1,4 @@
-import type { Connection, ISOLATION_LEVEL, Request, TYPES } from 'tedious'
+import { Request } from 'tedious'
 
 export interface MssqlDialectConfig {
   /**

--- a/src/dialect/mssql/mssql-driver.ts
+++ b/src/dialect/mssql/mssql-driver.ts
@@ -23,15 +23,12 @@ import {
   TarnPool,
   Tedious,
   TediousColumnValue,
-  TediousConnection,
-  TediousRequest,
 } from './mssql-dialect-config.js'
 import { CompiledQuery } from '../../query-compiler/compiled-query.js'
 import { extendStackTrace } from '../../util/stack-trace-utils.js'
 import { randomString } from '../../util/random-string.js'
 import { Deferred } from '../../util/deferred.js'
-import { parseSavepointCommand } from '../../parser/savepoint-parser.js'
-import { QueryCompiler } from '../../query-compiler/query-compiler.js'
+import type { Connection, Request } from 'tedious'
 
 const PRIVATE_RELEASE_METHOD = Symbol()
 const PRIVATE_DESTROY_METHOD = Symbol()
@@ -119,10 +116,10 @@ export class MssqlDriver implements Driver {
 }
 
 class MssqlConnection implements DatabaseConnection {
-  readonly #connection: TediousConnection
+  readonly #connection: Connection
   readonly #tedious: Tedious
 
-  constructor(connection: TediousConnection, tedious: Tedious) {
+  constructor(connection: Connection, tedious: Tedious) {
     this.#connection = connection
     this.#tedious = tedious
 
@@ -339,7 +336,7 @@ interface PlainDeferred<O> {
 }
 
 class MssqlRequest<O> {
-  readonly #request: TediousRequest
+  readonly #request: Request
   readonly #rows: O[]
   readonly #streamChunkSize: number | undefined
   readonly #subscribers: Record<
@@ -399,7 +396,7 @@ class MssqlRequest<O> {
     this.#attachListeners()
   }
 
-  get request(): TediousRequest {
+  get request(): Request {
     return this.#request
   }
 

--- a/src/dialect/mssql/mssql-driver.ts
+++ b/src/dialect/mssql/mssql-driver.ts
@@ -100,12 +100,6 @@ export class MssqlDriver implements Driver {
     await connection.rollbackTransaction(savepointName)
   }
 
-  async releaseSavepoint(): Promise<void> {
-    throw new Error(
-      'MS SQL Server (mssql) does not support releasing savepoints',
-    )
-  }
-
   async releaseConnection(connection: MssqlConnection): Promise<void> {
     await connection[PRIVATE_RELEASE_METHOD]()
     this.#pool.release(connection)

--- a/src/dialect/mssql/mssql-driver.ts
+++ b/src/dialect/mssql/mssql-driver.ts
@@ -23,12 +23,13 @@ import {
   TarnPool,
   Tedious,
   TediousColumnValue,
+  TediousConnection,
+  TediousRequest,
 } from './mssql-dialect-config.js'
 import { CompiledQuery } from '../../query-compiler/compiled-query.js'
 import { extendStackTrace } from '../../util/stack-trace-utils.js'
 import { randomString } from '../../util/random-string.js'
 import { Deferred } from '../../util/deferred.js'
-import type { Connection, Request } from 'tedious'
 
 const PRIVATE_RELEASE_METHOD = Symbol()
 const PRIVATE_DESTROY_METHOD = Symbol()
@@ -116,10 +117,10 @@ export class MssqlDriver implements Driver {
 }
 
 class MssqlConnection implements DatabaseConnection {
-  readonly #connection: Connection
+  readonly #connection: TediousConnection
   readonly #tedious: Tedious
 
-  constructor(connection: Connection, tedious: Tedious) {
+  constructor(connection: TediousConnection, tedious: Tedious) {
     this.#connection = connection
     this.#tedious = tedious
 
@@ -336,7 +337,7 @@ interface PlainDeferred<O> {
 }
 
 class MssqlRequest<O> {
-  readonly #request: Request
+  readonly #request: TediousRequest
   readonly #rows: O[]
   readonly #streamChunkSize: number | undefined
   readonly #subscribers: Record<
@@ -396,7 +397,7 @@ class MssqlRequest<O> {
     this.#attachListeners()
   }
 
-  get request(): Request {
+  get request(): TediousRequest {
     return this.#request
   }
 

--- a/src/dialect/mysql/mysql-driver.ts
+++ b/src/dialect/mysql/mysql-driver.ts
@@ -3,7 +3,9 @@ import {
   QueryResult,
 } from '../../driver/database-connection.js'
 import { Driver, TransactionSettings } from '../../driver/driver.js'
+import { parseSavepointCommand } from '../../parser/savepoint-parser.js'
 import { CompiledQuery } from '../../query-compiler/compiled-query.js'
+import { QueryCompiler } from '../../query-compiler/query-compiler.js'
 import { isFunction, isObject, freeze } from '../../util/object-utils.js'
 import { extendStackTrace } from '../../util/stack-trace-utils.js'
 import {
@@ -88,6 +90,36 @@ export class MysqlDriver implements Driver {
 
   async rollbackTransaction(connection: DatabaseConnection): Promise<void> {
     await connection.executeQuery(CompiledQuery.raw('rollback'))
+  }
+
+  async savepoint(
+    connection: DatabaseConnection,
+    savepointName: string,
+    compileQuery: QueryCompiler['compileQuery'],
+  ): Promise<void> {
+    await connection.executeQuery(
+      compileQuery(parseSavepointCommand('savepoint', savepointName)),
+    )
+  }
+
+  async rollbackToSavepoint(
+    connection: DatabaseConnection,
+    savepointName: string,
+    compileQuery: QueryCompiler['compileQuery'],
+  ): Promise<void> {
+    await connection.executeQuery(
+      compileQuery(parseSavepointCommand('rollback to', savepointName)),
+    )
+  }
+
+  async releaseSavepoint(
+    connection: DatabaseConnection,
+    savepointName: string,
+    compileQuery: QueryCompiler['compileQuery'],
+  ): Promise<void> {
+    await connection.executeQuery(
+      compileQuery(parseSavepointCommand('release savepoint', savepointName)),
+    )
   }
 
   async releaseConnection(connection: MysqlConnection): Promise<void> {

--- a/src/dialect/postgres/postgres-driver.ts
+++ b/src/dialect/postgres/postgres-driver.ts
@@ -3,7 +3,14 @@ import {
   QueryResult,
 } from '../../driver/database-connection.js'
 import { Driver, TransactionSettings } from '../../driver/driver.js'
+import { IdentifierNode } from '../../operation-node/identifier-node.js'
+import { RawNode } from '../../operation-node/raw-node.js'
+import { parseSavepointCommand } from '../../parser/savepoint-parser.js'
 import { CompiledQuery } from '../../query-compiler/compiled-query.js'
+import {
+  QueryCompiler,
+  RootOperationNode,
+} from '../../query-compiler/query-compiler.js'
 import { isFunction, freeze } from '../../util/object-utils.js'
 import { extendStackTrace } from '../../util/stack-trace-utils.js'
 import {
@@ -76,6 +83,36 @@ export class PostgresDriver implements Driver {
 
   async rollbackTransaction(connection: DatabaseConnection): Promise<void> {
     await connection.executeQuery(CompiledQuery.raw('rollback'))
+  }
+
+  async savepoint(
+    connection: DatabaseConnection,
+    savepointName: string,
+    compileQuery: QueryCompiler['compileQuery'],
+  ): Promise<void> {
+    await connection.executeQuery(
+      compileQuery(parseSavepointCommand('savepoint', savepointName)),
+    )
+  }
+
+  async rollbackToSavepoint(
+    connection: DatabaseConnection,
+    savepointName: string,
+    compileQuery: QueryCompiler['compileQuery'],
+  ): Promise<void> {
+    await connection.executeQuery(
+      compileQuery(parseSavepointCommand('rollback to', savepointName)),
+    )
+  }
+
+  async releaseSavepoint(
+    connection: DatabaseConnection,
+    savepointName: string,
+    compileQuery: QueryCompiler['compileQuery'],
+  ): Promise<void> {
+    await connection.executeQuery(
+      compileQuery(parseSavepointCommand('release', savepointName)),
+    )
   }
 
   async releaseConnection(connection: PostgresConnection): Promise<void> {

--- a/src/dialect/sqlite/sqlite-driver.ts
+++ b/src/dialect/sqlite/sqlite-driver.ts
@@ -4,7 +4,9 @@ import {
 } from '../../driver/database-connection.js'
 import { Driver } from '../../driver/driver.js'
 import { SelectQueryNode } from '../../operation-node/select-query-node.js'
+import { parseSavepointCommand } from '../../parser/savepoint-parser.js'
 import { CompiledQuery } from '../../query-compiler/compiled-query.js'
+import { QueryCompiler } from '../../query-compiler/query-compiler.js'
 import { freeze, isFunction } from '../../util/object-utils.js'
 import { SqliteDatabase, SqliteDialectConfig } from './sqlite-dialect-config.js'
 
@@ -48,6 +50,36 @@ export class SqliteDriver implements Driver {
 
   async rollbackTransaction(connection: DatabaseConnection): Promise<void> {
     await connection.executeQuery(CompiledQuery.raw('rollback'))
+  }
+
+  async savepoint(
+    connection: DatabaseConnection,
+    savepointName: string,
+    compileQuery: QueryCompiler['compileQuery'],
+  ): Promise<void> {
+    await connection.executeQuery(
+      compileQuery(parseSavepointCommand('savepoint', savepointName)),
+    )
+  }
+
+  async rollbackToSavepoint(
+    connection: DatabaseConnection,
+    savepointName: string,
+    compileQuery: QueryCompiler['compileQuery'],
+  ): Promise<void> {
+    await connection.executeQuery(
+      compileQuery(parseSavepointCommand('rollback to', savepointName)),
+    )
+  }
+
+  async releaseSavepoint(
+    connection: DatabaseConnection,
+    savepointName: string,
+    compileQuery: QueryCompiler['compileQuery'],
+  ): Promise<void> {
+    await connection.executeQuery(
+      compileQuery(parseSavepointCommand('release', savepointName)),
+    )
   }
 
   async releaseConnection(): Promise<void> {

--- a/src/driver/driver.ts
+++ b/src/driver/driver.ts
@@ -1,3 +1,4 @@
+import { QueryCompiler } from '../query-compiler/query-compiler.js'
 import { ArrayItemType } from '../util/type-utils.js'
 import { DatabaseConnection } from './database-connection.js'
 
@@ -36,6 +37,33 @@ export interface Driver {
    * Rolls back a transaction.
    */
   rollbackTransaction(connection: DatabaseConnection): Promise<void>
+
+  /**
+   * Establishses a new savepoint within a transaction.
+   */
+  savepoint?(
+    connection: DatabaseConnection,
+    savepointName: string,
+    compileQuery: QueryCompiler['compileQuery'],
+  ): Promise<void>
+
+  /**
+   * Rolls back to a savepoint within a transaction.
+   */
+  rollbackToSavepoint?(
+    connection: DatabaseConnection,
+    savepointName: string,
+    compileQuery: QueryCompiler['compileQuery'],
+  ): Promise<void>
+
+  /**
+   * Releases a savepoint within a transaction.
+   */
+  releaseSavepoint?(
+    connection: DatabaseConnection,
+    savepointName: string,
+    compileQuery: QueryCompiler['compileQuery'],
+  ): Promise<void>
 
   /**
    * Releases a connection back to the pool.

--- a/src/driver/dummy-driver.ts
+++ b/src/driver/dummy-driver.ts
@@ -65,6 +65,18 @@ export class DummyDriver implements Driver {
   async destroy(): Promise<void> {
     // Nothing to do here.
   }
+
+  async releaseSavepoint(): Promise<void> {
+    // Nothing to do here.
+  }
+
+  async rollbackToSavepoint(): Promise<void> {
+    // Nothing to do here.
+  }
+
+  async savepoint(): Promise<void> {
+    // Nothing to do here.
+  }
 }
 
 class DummyConnection implements DatabaseConnection {

--- a/src/driver/runtime-driver.ts
+++ b/src/driver/runtime-driver.ts
@@ -95,7 +95,7 @@ export class RuntimeDriver implements Driver {
       return this.#driver.savepoint(connection, savepointName, compileQuery)
     }
 
-    throw new Error('savepoints are not supported by this driver')
+    throw new Error('The `savepoint` method is not supported by this driver')
   }
 
   rollbackToSavepoint(
@@ -111,7 +111,9 @@ export class RuntimeDriver implements Driver {
       )
     }
 
-    throw new Error('savepoints are not supported by this driver')
+    throw new Error(
+      'The `rollbackToSavepoint` method is not supported by this driver',
+    )
   }
 
   releaseSavepoint(
@@ -127,7 +129,9 @@ export class RuntimeDriver implements Driver {
       )
     }
 
-    throw new Error('savepoints are not supported by this driver')
+    throw new Error(
+      'The `releaseSavepoint` method is not supported by this driver',
+    )
   }
 
   async destroy(): Promise<void> {

--- a/src/driver/runtime-driver.ts
+++ b/src/driver/runtime-driver.ts
@@ -1,4 +1,5 @@
 import { CompiledQuery } from '../query-compiler/compiled-query.js'
+import { QueryCompiler } from '../query-compiler/query-compiler.js'
 import { Log } from '../util/log.js'
 import { performanceNow } from '../util/performance-now.js'
 import { DatabaseConnection, QueryResult } from './database-connection.js'
@@ -83,6 +84,50 @@ export class RuntimeDriver implements Driver {
 
   rollbackTransaction(connection: DatabaseConnection): Promise<void> {
     return this.#driver.rollbackTransaction(connection)
+  }
+
+  savepoint(
+    connection: DatabaseConnection,
+    savepointName: string,
+    compileQuery: QueryCompiler['compileQuery'],
+  ): Promise<void> {
+    if (this.#driver.savepoint) {
+      return this.#driver.savepoint(connection, savepointName, compileQuery)
+    }
+
+    throw new Error('savepoints are not supported by this driver')
+  }
+
+  rollbackToSavepoint(
+    connection: DatabaseConnection,
+    savepointName: string,
+    compileQuery: QueryCompiler['compileQuery'],
+  ): Promise<void> {
+    if (this.#driver.rollbackToSavepoint) {
+      return this.#driver.rollbackToSavepoint(
+        connection,
+        savepointName,
+        compileQuery,
+      )
+    }
+
+    throw new Error('savepoints are not supported by this driver')
+  }
+
+  releaseSavepoint(
+    connection: DatabaseConnection,
+    savepointName: string,
+    compileQuery: QueryCompiler['compileQuery'],
+  ): Promise<void> {
+    if (this.#driver.releaseSavepoint) {
+      return this.#driver.releaseSavepoint(
+        connection,
+        savepointName,
+        compileQuery,
+      )
+    }
+
+    throw new Error('savepoints are not supported by this driver')
   }
 
   async destroy(): Promise<void> {

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -22,10 +22,7 @@ import {
 } from './query-builder/function-module.js'
 import { Log, LogConfig } from './util/log.js'
 import { QueryExecutorProvider } from './query-executor/query-executor-provider.js'
-import {
-  DatabaseConnection,
-  QueryResult,
-} from './driver/database-connection.js'
+import { QueryResult } from './driver/database-connection.js'
 import { CompiledQuery } from './query-compiler/compiled-query.js'
 import { createQueryId, QueryId } from './util/query-id.js'
 import { Compilable, isCompilable } from './util/compilable.js'
@@ -755,11 +752,6 @@ interface ControlledTransactionBuilderProps extends TransactionBuilderProps {
   readonly releaseConnection?: boolean
 }
 
-preventAwait(
-  ControlledTransactionBuilder,
-  "don't await ControlledTransactionBuilder instances directly. To execute the transaction you need to call the `execute` method",
-)
-
 export class ControlledTransaction<
   DB,
   S extends string[] = [],
@@ -1037,8 +1029,3 @@ export class Command<T> {
     return await this.#cb()
   }
 }
-
-preventAwait(
-  Command,
-  "don't await Command instances directly. Call the `execute` method",
-)

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -795,11 +795,6 @@ interface ControlledTransactionProps extends KyselyProps {
   readonly releaseConnectionWhenDone?: boolean
 }
 
-preventAwait(
-  ControlledTransaction,
-  "don't await ControlledTransaction instances directly. To commit or rollback the transaction you need to call the `commit` or `rollback` method",
-)
-
 export class Command<T> {
   readonly #cb: () => Promise<T>
 

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -711,10 +711,7 @@ export class ControlledTransaction<
         this.#compileQuery,
       )
 
-      return new ControlledTransaction({
-        ...this.#props,
-        connection: this.#props.connection,
-      })
+      return new ControlledTransaction({ ...this.#props })
     })
   }
 
@@ -730,10 +727,7 @@ export class ControlledTransaction<
         this.#compileQuery,
       )
 
-      return new ControlledTransaction({
-        ...this.#props,
-        connection: this.#props.connection,
-      })
+      return new ControlledTransaction({ ...this.#props })
     })
   }
 
@@ -749,11 +743,37 @@ export class ControlledTransaction<
         this.#compileQuery,
       )
 
-      return new ControlledTransaction({
-        ...this.#props,
-        connection: this.#props.connection,
-      })
+      return new ControlledTransaction({ ...this.#props })
     })
+  }
+
+  override withPlugin(plugin: KyselyPlugin): ControlledTransaction<DB, S> {
+    return new ControlledTransaction({
+      ...this.#props,
+      executor: this.#props.executor.withPlugin(plugin),
+    })
+  }
+
+  override withoutPlugins(): ControlledTransaction<DB, S> {
+    return new ControlledTransaction({
+      ...this.#props,
+      executor: this.#props.executor.withoutPlugins(),
+    })
+  }
+
+  override withSchema(schema: string): ControlledTransaction<DB, S> {
+    return new ControlledTransaction({
+      ...this.#props,
+      executor: this.#props.executor.withPluginAtFront(
+        new WithSchemaPlugin(schema),
+      ),
+    })
+  }
+
+  override withTables<
+    T extends Record<string, Record<string, any>>,
+  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S> {
+    return new ControlledTransaction({ ...this.#props })
   }
 
   #assertNotCommittedOrRolledBackBeforeAllExecutions() {

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -786,6 +786,23 @@ export class ControlledTransaction<
     return this.#isRolledBack
   }
 
+  /**
+   * Commits the transaction.
+   *
+   * See {@link rollback}.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * try {
+   *   await doSomething(trx)
+   *
+   *   await trx.commit().execute()
+   * } catch (error) {
+   *   await trx.rollback().execute()
+   * }
+   * ```
+   */
   commit(): Command<void> {
     this.#assertNotCommittedOrRolledBack()
 
@@ -796,6 +813,23 @@ export class ControlledTransaction<
     })
   }
 
+  /**
+   * Rolls back the transaction.
+   *
+   * See {@link commit} and {@link rollbackToSavepoint}.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * try {
+   *   await doSomething(trx)
+   *
+   *   await trx.commit().execute()
+   * } catch (error) {
+   *   await trx.rollback().execute()
+   * }
+   * ```
+   */
   rollback(): Command<void> {
     this.#assertNotCommittedOrRolledBack()
 
@@ -806,6 +840,27 @@ export class ControlledTransaction<
     })
   }
 
+  /**
+   * Creates a savepoint with a given name.
+   *
+   * See {@link rollbackToSavepoint} and {@link releaseSavepoint}.
+   *
+   * For a type-safe experience, you should use the returned instance from now on.
+   *
+   * ### Examples
+   *
+   * ```ts
+   *   await insertJennifer(trx)
+   *
+   *   const trxAfterJennifer = await trx.savepoint('after_jennifer').execute()
+   *
+   *   try {
+   *     await doSomething(trxAfterJennifer)
+   *   } catch (error) {
+   *     await trxAfterJennifer.rollbackToSavepoint('after_jennifer').execute()
+   *   }
+   * ```
+   */
   savepoint<SN extends string>(
     savepointName: SN extends S ? never : SN,
   ): Command<ControlledTransaction<DB, [...S, SN]>> {
@@ -822,6 +877,28 @@ export class ControlledTransaction<
     })
   }
 
+  /**
+   * Rolls back to a savepoint with a given name.
+   *
+   * See {@link savepoint} and {@link releaseSavepoint}.
+   *
+   * You must use the same instance returned by {@link savepoint}, or
+   * escape the type-check by using `as any`.
+   *
+   * ### Examples
+   *
+   * ```ts
+   *   await insertJennifer(trx)
+   *
+   *   const trxAfterJennifer = await trx.savepoint('after_jennifer').execute()
+   *
+   *   try {
+   *     await doSomething(trxAfterJennifer)
+   *   } catch (error) {
+   *     await trxAfterJennifer.rollbackToSavepoint('after_jennifer').execute()
+   *   }
+   * ```
+   */
   rollbackToSavepoint<SN extends S[number]>(
     savepointName: SN,
   ): Command<ControlledTransaction<DB, RollbackToSavepoint<S, SN>>> {
@@ -838,6 +915,32 @@ export class ControlledTransaction<
     })
   }
 
+  /**
+   * Releases a savepoint with a given name.
+   *
+   * See {@link savepoint} and {@link rollbackToSavepoint}.
+   *
+   * You must use the same instance returned by {@link savepoint}, or
+   * escape the type-check by using `as any`.
+   *
+   * ### Examples
+   *
+   * ```ts
+   *   await insertJennifer(trx)
+   *
+   *   const trxAfterJennifer = await trx.savepoint('after_jennifer').execute()
+   *
+   *   try {
+   *     await doSomething(trxAfterJennifer)
+   *   } catch (error) {
+   *     await trxAfterJennifer.rollbackToSavepoint('after_jennifer').execute()
+   *   }
+   *
+   *   await trxAfterJennifer.releaseSavepoint('after_jennifer').execute()
+   *
+   *   await doSomethingElse(trx)
+   * ```
+   */
   releaseSavepoint<SN extends S[number]>(
     savepointName: SN,
   ): Command<ControlledTransaction<DB, ReleaseSavepoint<S, SN>>> {

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -275,7 +275,12 @@ export class Kysely<DB>
    * The {@link ControlledTransactionBuilder.execute} method can then be called
    * to start the transaction and return a {@link ControlledTransaction}.
    *
-   * A {@link ControlledTransaction} allows you to commit and rollback manually, execute savepoint commands. It extends {@link Transaction} which extends {@link Kysely}, so you can run queries inside the transaction.
+   * A {@link ControlledTransaction} allows you to commit and rollback manually,
+   * execute savepoint commands. It extends {@link Transaction} which extends {@link Kysely},
+   * so you can run queries inside the transaction. Once the transaction is committed,
+   * or rolled back, it can't be used anymore - all queries will throw an error.
+   * This is to prevent accidentally running queries outside the transaction - where
+   * atomicity is not guaranteed anymore.
    *
    * ### Examples
    *

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -281,8 +281,11 @@ export class Kysely<DB>
    *
    * <!-- siteExample("transactions", "Controlled transaction", 11) -->
    *
-   * A controlled transaction allows you to commit and rollback manually, execute savepoint commands, and queries in general. In this example we start a transaction, use it to insert two rows and then commit the transaction.
-   * If an error is thrown, we catch it and rollback the transaction.
+   * A controlled transaction allows you to commit and rollback manually, execute
+   * savepoint commands, and queries in general.
+   *
+   * In this example we start a transaction, use it to insert two rows and then commit
+   * the transaction. If an error is thrown, we catch it and rollback the transaction.
    *
    * ```ts
    * const trx = await db.startTransaction().execute()
@@ -310,6 +313,63 @@ export class Kysely<DB>
    *   await trx.commit().execute()
    *
    *   return catto
+   * } catch (error) {
+   *   await trx.rollback().execute()
+   * }
+   * ```
+   *
+   * <!-- siteExample("transactions", "Controlled transaction /w savepoints", 12) -->
+   *
+   * A controlled transaction allows you to commit and rollback manually, execute
+   * savepoint commands, and queries in general.
+   *
+   * In this example we start a transaction, insert a person, create a savepoint,
+   * try inserting a toy and a pet, and if an error is thrown, we rollback to the
+   * savepoint. Eventually we release the savepoint, insert an audit record and
+   * commit the transaction. If an error is thrown, we catch it and rollback the
+   * transaction.
+   *
+   * ```ts
+   * const trx = await db.startTransaction().execute()
+   *
+   * try {
+   *   const jennifer = await trx
+   *     .insertInto('person')
+   *     .values({
+   *       first_name: 'Jennifer',
+   *       last_name: 'Aniston',
+   *       age: 40,
+   *     })
+   *     .returning('id')
+   *     .executeTakeFirstOrThrow()
+   *
+   *   const trxAfterJennifer = await trx.savepoint('after_jennifer').execute()
+   *
+   *   try {
+   *     const bone = await trxAfterJennifer
+   *       .insertInto('toy')
+   *       .values({ name: 'Bone', price: 1.99 })
+   *       .returning('id')
+   *       .executeTakeFirstOrThrow()
+   *
+   *     await trxAfterJennifer
+   *       .insertInto('pet')
+   *       .values({
+   *         owner_id: jennifer.id,
+   *         name: 'Catto',
+   *         species: 'cat',
+   *         favorite_toy_id: bone.id,
+   *       })
+   *       .execute()
+   *   } catch (error) {
+   *     await trxAfterJennifer.rollbackToSavepoint('after_jennifer').execute()
+   *   }
+   *
+   *   await trxAfterJennifer.releaseSavepoint('after_jennifer').execute()
+   *
+   *   await trx.insertInto('audit').values({ action: 'added Jennifer' }).execute()
+   *
+   *   await trx.commit().execute()
    * } catch (error) {
    *   await trx.rollback().execute()
    * }

--- a/src/parser/savepoint-parser.ts
+++ b/src/parser/savepoint-parser.ts
@@ -1,0 +1,12 @@
+import { IdentifierNode } from '../operation-node/identifier-node.js'
+import { RawNode } from '../operation-node/raw-node.js'
+
+export function parseSavepointCommand(
+  command: string,
+  savepointName: string,
+): RawNode {
+  return RawNode.createWithChildren([
+    RawNode.createWithSql(`${command} `),
+    IdentifierNode.create(savepointName), // ensures savepointName gets sanitized
+  ])
+}

--- a/src/parser/savepoint-parser.ts
+++ b/src/parser/savepoint-parser.ts
@@ -1,6 +1,24 @@
 import { IdentifierNode } from '../operation-node/identifier-node.js'
 import { RawNode } from '../operation-node/raw-node.js'
 
+export type RollbackToSavepoint<
+  S extends string[],
+  SN extends S[number],
+> = S extends [...infer L extends string[], infer R]
+  ? R extends SN
+    ? S
+    : RollbackToSavepoint<L, SN>
+  : never
+
+export type ReleaseSavepoint<
+  S extends string[],
+  SN extends S[number],
+> = S extends [...infer L extends string[], infer R]
+  ? R extends SN
+    ? L
+    : ReleaseSavepoint<L, SN>
+  : never
+
 export function parseSavepointCommand(
   command: string,
   savepointName: string,

--- a/src/util/provide-controlled-connection.ts
+++ b/src/util/provide-controlled-connection.ts
@@ -1,0 +1,27 @@
+import { ConnectionProvider } from '../driver/connection-provider.js'
+import { DatabaseConnection } from '../driver/database-connection.js'
+import { Deferred } from './deferred.js'
+
+export async function provideControlledConnection(
+  connectionProvider: ConnectionProvider,
+): Promise<ControlledConnection> {
+  const connectionDefer = new Deferred<DatabaseConnection>()
+  const connectionReleaseDefer = new Deferred<void>()
+
+  connectionProvider
+    .provideConnection(async (connection) => {
+      connectionDefer.resolve(connection)
+
+      return await connectionReleaseDefer.promise
+    })
+    .catch((ex) => connectionDefer.reject(ex))
+
+  const connection = (await connectionDefer.promise) as ControlledConnection
+  connection.release = connectionReleaseDefer.resolve
+
+  return connection
+}
+
+export interface ControlledConnection extends DatabaseConnection {
+  release(): void
+}

--- a/test/node/src/controlled-transaction.test.ts
+++ b/test/node/src/controlled-transaction.test.ts
@@ -1,0 +1,532 @@
+import * as sinon from 'sinon'
+import { Connection, ISOLATION_LEVEL } from 'tedious'
+import { CompiledQuery, ControlledTransaction, IsolationLevel } from '../../../'
+import {
+  DIALECTS,
+  Database,
+  TestContext,
+  clearDatabase,
+  destroyTest,
+  expect,
+  initTest,
+  insertDefaultDataSet,
+} from './test-setup.js'
+
+for (const dialect of DIALECTS) {
+  describe(`${dialect}: controlled transaction`, () => {
+    let ctx: TestContext
+    const executedQueries: CompiledQuery[] = []
+    const sandbox = sinon.createSandbox()
+    let tediousBeginTransactionSpy: sinon.SinonSpy<
+      Parameters<Connection['beginTransaction']>,
+      ReturnType<Connection['beginTransaction']>
+    >
+    let tediousCommitTransactionSpy: sinon.SinonSpy<
+      Parameters<Connection['commitTransaction']>,
+      ReturnType<Connection['commitTransaction']>
+    >
+    let tediousRollbackTransactionSpy: sinon.SinonSpy<
+      Parameters<Connection['rollbackTransaction']>,
+      ReturnType<Connection['rollbackTransaction']>
+    >
+    let tediousSaveTransactionSpy: sinon.SinonSpy<
+      Parameters<Connection['saveTransaction']>,
+      ReturnType<Connection['saveTransaction']>
+    >
+
+    before(async function () {
+      ctx = await initTest(this, dialect, (event) => {
+        if (event.level === 'query') {
+          executedQueries.push(event.query)
+        }
+      })
+    })
+
+    beforeEach(async () => {
+      await insertDefaultDataSet(ctx)
+      executedQueries.length = 0
+      tediousBeginTransactionSpy = sandbox.spy(
+        Connection.prototype,
+        'beginTransaction',
+      )
+      tediousCommitTransactionSpy = sandbox.spy(
+        Connection.prototype,
+        'commitTransaction',
+      )
+      tediousRollbackTransactionSpy = sandbox.spy(
+        Connection.prototype,
+        'rollbackTransaction',
+      )
+      tediousSaveTransactionSpy = sandbox.spy(
+        Connection.prototype,
+        'saveTransaction',
+      )
+    })
+
+    afterEach(async () => {
+      await clearDatabase(ctx)
+      sandbox.restore()
+    })
+
+    after(async () => {
+      await destroyTest(ctx)
+    })
+
+    it('should be able to start and commit a transaction', async () => {
+      const trx = await ctx.db.startTransaction().execute()
+
+      await insertSomething(trx)
+
+      await trx.commit().execute()
+
+      if (dialect == 'postgres') {
+        expect(
+          executedQueries.map((it) => ({
+            sql: it.sql,
+            parameters: it.parameters,
+          })),
+        ).to.eql([
+          {
+            sql: 'begin',
+            parameters: [],
+          },
+          {
+            sql: 'insert into "person" ("first_name", "last_name", "gender") values ($1, $2, $3)',
+            parameters: ['Foo', 'Barson', 'male'],
+          },
+          { sql: 'commit', parameters: [] },
+        ])
+      } else if (dialect === 'mysql') {
+        expect(
+          executedQueries.map((it) => ({
+            sql: it.sql,
+            parameters: it.parameters,
+          })),
+        ).to.eql([
+          {
+            sql: 'begin',
+            parameters: [],
+          },
+          {
+            sql: 'insert into `person` (`first_name`, `last_name`, `gender`) values (?, ?, ?)',
+            parameters: ['Foo', 'Barson', 'male'],
+          },
+          { sql: 'commit', parameters: [] },
+        ])
+      } else if (dialect === 'mssql') {
+        expect(tediousBeginTransactionSpy.calledOnce).to.be.true
+        expect(tediousBeginTransactionSpy.getCall(0).args[1]).to.be.undefined
+        expect(tediousBeginTransactionSpy.getCall(0).args[2]).to.be.undefined
+
+        expect(
+          executedQueries.map((it) => ({
+            sql: it.sql,
+            parameters: it.parameters,
+          })),
+        ).to.eql([
+          {
+            sql: 'insert into "person" ("first_name", "last_name", "gender") values (@1, @2, @3)',
+            parameters: ['Foo', 'Barson', 'male'],
+          },
+        ])
+
+        expect(tediousCommitTransactionSpy.calledOnce).to.be.true
+      } else {
+        expect(
+          executedQueries.map((it) => ({
+            sql: it.sql,
+            parameters: it.parameters,
+          })),
+        ).to.eql([
+          {
+            sql: 'begin',
+            parameters: [],
+          },
+          {
+            sql: 'insert into "person" ("first_name", "last_name", "gender") values (?, ?, ?)',
+            parameters: ['Foo', 'Barson', 'male'],
+          },
+          { sql: 'commit', parameters: [] },
+        ])
+      }
+    })
+
+    it('should be able to start and rollback a transaction', async () => {
+      const trx = await ctx.db.startTransaction().execute()
+
+      await insertSomething(trx)
+
+      await trx.rollback().execute()
+
+      if (dialect == 'postgres') {
+        expect(
+          executedQueries.map((it) => ({
+            sql: it.sql,
+            parameters: it.parameters,
+          })),
+        ).to.eql([
+          {
+            sql: 'begin',
+            parameters: [],
+          },
+          {
+            sql: 'insert into "person" ("first_name", "last_name", "gender") values ($1, $2, $3)',
+            parameters: ['Foo', 'Barson', 'male'],
+          },
+          { sql: 'rollback', parameters: [] },
+        ])
+      } else if (dialect === 'mysql') {
+        expect(
+          executedQueries.map((it) => ({
+            sql: it.sql,
+            parameters: it.parameters,
+          })),
+        ).to.eql([
+          {
+            sql: 'begin',
+            parameters: [],
+          },
+          {
+            sql: 'insert into `person` (`first_name`, `last_name`, `gender`) values (?, ?, ?)',
+            parameters: ['Foo', 'Barson', 'male'],
+          },
+          { sql: 'rollback', parameters: [] },
+        ])
+      } else if (dialect === 'mssql') {
+        expect(tediousBeginTransactionSpy.calledOnce).to.be.true
+        expect(tediousBeginTransactionSpy.getCall(0).args[1]).to.be.undefined
+        expect(tediousBeginTransactionSpy.getCall(0).args[2]).to.be.undefined
+
+        expect(
+          executedQueries.map((it) => ({
+            sql: it.sql,
+            parameters: it.parameters,
+          })),
+        ).to.eql([
+          {
+            sql: 'insert into "person" ("first_name", "last_name", "gender") values (@1, @2, @3)',
+            parameters: ['Foo', 'Barson', 'male'],
+          },
+        ])
+
+        expect(tediousRollbackTransactionSpy.calledOnce).to.be.true
+      } else {
+        expect(
+          executedQueries.map((it) => ({
+            sql: it.sql,
+            parameters: it.parameters,
+          })),
+        ).to.eql([
+          {
+            sql: 'begin',
+            parameters: [],
+          },
+          {
+            sql: 'insert into "person" ("first_name", "last_name", "gender") values (?, ?, ?)',
+            parameters: ['Foo', 'Barson', 'male'],
+          },
+          { sql: 'rollback', parameters: [] },
+        ])
+      }
+
+      const person = await ctx.db
+        .selectFrom('person')
+        .where('first_name', '=', 'Foo')
+        .select('first_name')
+        .executeTakeFirst()
+
+      expect(person).to.be.undefined
+    })
+
+    if (dialect === 'postgres' || dialect === 'mysql' || dialect === 'mssql') {
+      for (const isolationLevel of [
+        'read uncommitted',
+        'read committed',
+        'repeatable read',
+        'serializable',
+        ...(dialect === 'mssql' ? (['snapshot'] as const) : []),
+      ] satisfies IsolationLevel[]) {
+        it(`should set the transaction isolation level as "${isolationLevel}"`, async () => {
+          const trx = await ctx.db
+            .startTransaction()
+            .setIsolationLevel(isolationLevel)
+            .execute()
+
+          await trx
+            .insertInto('person')
+            .values({
+              first_name: 'Foo',
+              last_name: 'Barson',
+              gender: 'male',
+            })
+            .execute()
+
+          await trx.commit().execute()
+        })
+      }
+    }
+
+    it('should be able to start a transaction with a single connection', async () => {
+      const result = await ctx.db.connection().execute(async (conn) => {
+        const trx = await conn.startTransaction().execute()
+
+        const result = await insertSomething(trx)
+
+        await trx.commit().execute()
+
+        return result
+      })
+
+      expect(result.numInsertedOrUpdatedRows).to.equal(1n)
+      await ctx.db
+        .selectFrom('person')
+        .where('first_name', '=', 'Foo')
+        .select('first_name')
+        .executeTakeFirstOrThrow()
+    })
+
+    it('should be able to savepoint and rollback to savepoint', async () => {
+      const trx = await ctx.db.startTransaction().execute()
+
+      await insertSomething(trx)
+
+      const trxAfterFoo = await trx.savepoint('foo').execute()
+
+      await insertSomethingElse(trxAfterFoo)
+
+      await trxAfterFoo.rollbackToSavepoint('foo').execute()
+
+      await trxAfterFoo.commit().execute()
+
+      if (dialect == 'postgres') {
+        expect(
+          executedQueries.map((it) => ({
+            sql: it.sql,
+            parameters: it.parameters,
+          })),
+        ).to.eql([
+          { sql: 'begin', parameters: [] },
+          {
+            sql: 'insert into "person" ("first_name", "last_name", "gender") values ($1, $2, $3)',
+            parameters: ['Foo', 'Barson', 'male'],
+          },
+          { sql: 'savepoint "foo"', parameters: [] },
+          {
+            sql: 'insert into "person" ("first_name", "last_name", "gender") values ($1, $2, $3)',
+            parameters: ['Fizz', 'Buzzson', 'female'],
+          },
+          { sql: 'rollback to "foo"', parameters: [] },
+          { sql: 'commit', parameters: [] },
+        ])
+      } else if (dialect === 'mysql') {
+        expect(
+          executedQueries.map((it) => ({
+            sql: it.sql,
+            parameters: it.parameters,
+          })),
+        ).to.eql([
+          { sql: 'begin', parameters: [] },
+          {
+            sql: 'insert into `person` (`first_name`, `last_name`, `gender`) values (?, ?, ?)',
+            parameters: ['Foo', 'Barson', 'male'],
+          },
+          { sql: 'savepoint `foo`', parameters: [] },
+          {
+            sql: 'insert into `person` (`first_name`, `last_name`, `gender`) values (?, ?, ?)',
+            parameters: ['Fizz', 'Buzzson', 'female'],
+          },
+          { sql: 'rollback to `foo`', parameters: [] },
+          { sql: 'commit', parameters: [] },
+        ])
+      } else if (dialect === 'mssql') {
+        expect(tediousBeginTransactionSpy.calledOnce).to.be.true
+        expect(tediousBeginTransactionSpy.getCall(0).args[1]).to.be.undefined
+        expect(tediousBeginTransactionSpy.getCall(0).args[2]).to.be.undefined
+
+        expect(
+          executedQueries.map((it) => ({
+            sql: it.sql,
+            parameters: it.parameters,
+          })),
+        ).to.eql([
+          {
+            sql: 'insert into "person" ("first_name", "last_name", "gender") values (@1, @2, @3)',
+            parameters: ['Foo', 'Barson', 'male'],
+          },
+          {
+            sql: 'insert into "person" ("first_name", "last_name", "gender") values (@1, @2, @3)',
+            parameters: ['Fizz', 'Buzzson', 'female'],
+          },
+        ])
+
+        expect(tediousSaveTransactionSpy.calledOnce).to.be.true
+        expect(tediousSaveTransactionSpy.getCall(0).args[1]).to.equal('foo')
+
+        expect(tediousRollbackTransactionSpy.calledOnce).to.be.true
+        expect(tediousRollbackTransactionSpy.getCall(0).args[1]).to.equal('foo')
+
+        expect(tediousCommitTransactionSpy.calledOnce).to.be.true
+      } else {
+        expect(
+          executedQueries.map((it) => ({
+            sql: it.sql,
+            parameters: it.parameters,
+          })),
+        ).to.eql([
+          { sql: 'begin', parameters: [] },
+          {
+            sql: 'insert into "person" ("first_name", "last_name", "gender") values (?, ?, ?)',
+            parameters: ['Foo', 'Barson', 'male'],
+          },
+          { sql: 'savepoint "foo"', parameters: [] },
+          {
+            sql: 'insert into "person" ("first_name", "last_name", "gender") values (?, ?, ?)',
+            parameters: ['Fizz', 'Buzzson', 'female'],
+          },
+          { sql: 'rollback to "foo"', parameters: [] },
+          { sql: 'commit', parameters: [] },
+        ])
+      }
+
+      const results = await ctx.db
+        .selectFrom('person')
+        .where('first_name', 'in', ['Foo', 'Fizz'])
+        .select('first_name')
+        .execute()
+
+      expect(results).to.have.length(1)
+      expect(results[0].first_name).to.equal('Foo')
+    })
+
+    if (dialect === 'postgres' || dialect === 'mysql' || dialect === 'sqlite') {
+      it('should be able to savepoint and release savepoint', async () => {
+        const trx = await ctx.db.startTransaction().execute()
+
+        await insertSomething(trx)
+
+        const trxAfterFoo = await trx.savepoint('foo').execute()
+
+        await insertSomethingElse(trxAfterFoo)
+
+        await trxAfterFoo.releaseSavepoint('foo').execute()
+
+        await trxAfterFoo.commit().execute()
+
+        if (dialect == 'postgres') {
+          expect(
+            executedQueries.map((it) => ({
+              sql: it.sql,
+              parameters: it.parameters,
+            })),
+          ).to.eql([
+            { sql: 'begin', parameters: [] },
+            {
+              sql: 'insert into "person" ("first_name", "last_name", "gender") values ($1, $2, $3)',
+              parameters: ['Foo', 'Barson', 'male'],
+            },
+            { sql: 'savepoint "foo"', parameters: [] },
+            {
+              sql: 'insert into "person" ("first_name", "last_name", "gender") values ($1, $2, $3)',
+              parameters: ['Fizz', 'Buzzson', 'female'],
+            },
+            { sql: 'release "foo"', parameters: [] },
+            { sql: 'commit', parameters: [] },
+          ])
+        } else if (dialect === 'mysql') {
+          expect(
+            executedQueries.map((it) => ({
+              sql: it.sql,
+              parameters: it.parameters,
+            })),
+          ).to.eql([
+            { sql: 'begin', parameters: [] },
+            {
+              sql: 'insert into `person` (`first_name`, `last_name`, `gender`) values (?, ?, ?)',
+              parameters: ['Foo', 'Barson', 'male'],
+            },
+            { sql: 'savepoint `foo`', parameters: [] },
+            {
+              sql: 'insert into `person` (`first_name`, `last_name`, `gender`) values (?, ?, ?)',
+              parameters: ['Fizz', 'Buzzson', 'female'],
+            },
+            { sql: 'release savepoint `foo`', parameters: [] },
+            { sql: 'commit', parameters: [] },
+          ])
+        } else {
+          expect(
+            executedQueries.map((it) => ({
+              sql: it.sql,
+              parameters: it.parameters,
+            })),
+          ).to.eql([
+            { sql: 'begin', parameters: [] },
+            {
+              sql: 'insert into "person" ("first_name", "last_name", "gender") values (?, ?, ?)',
+              parameters: ['Foo', 'Barson', 'male'],
+            },
+            { sql: 'savepoint "foo"', parameters: [] },
+            {
+              sql: 'insert into "person" ("first_name", "last_name", "gender") values (?, ?, ?)',
+              parameters: ['Fizz', 'Buzzson', 'female'],
+            },
+            { sql: 'release "foo"', parameters: [] },
+            { sql: 'commit', parameters: [] },
+          ])
+        }
+
+        const results = await ctx.db
+          .selectFrom('person')
+          .where('first_name', 'in', ['Foo', 'Fizz'])
+          .select('first_name')
+          .orderBy('first_name')
+          .execute()
+
+        expect(results).to.have.length(2)
+        expect(results[0].first_name).to.equal('Fizz')
+        expect(results[1].first_name).to.equal('Foo')
+      })
+    }
+
+    it('should throw an error when trying to execute a query after the transaction has been committed', async () => {
+      const trx = await ctx.db.startTransaction().execute()
+
+      await insertSomething(trx)
+
+      await trx.commit().execute()
+
+      await expect(insertSomethingElse(trx)).to.be.rejected
+    })
+
+    it('should throw an error when trying to execute a query after the transaction has been rolled back', async () => {
+      const trx = await ctx.db.startTransaction().execute()
+
+      await insertSomething(trx)
+
+      await trx.rollback().execute()
+
+      await expect(insertSomethingElse(trx)).to.be.rejected
+    })
+  })
+
+  async function insertSomething(trx: ControlledTransaction<Database>) {
+    return await trx
+      .insertInto('person')
+      .values({
+        first_name: 'Foo',
+        last_name: 'Barson',
+        gender: 'male',
+      })
+      .executeTakeFirstOrThrow()
+  }
+
+  async function insertSomethingElse(trx: ControlledTransaction<Database>) {
+    return await trx
+      .insertInto('person')
+      .values({
+        first_name: 'Fizz',
+        last_name: 'Buzzson',
+        gender: 'female',
+      })
+      .executeTakeFirstOrThrow()
+  }
+}


### PR DESCRIPTION
closes #257.

This PR adds some optional savepoint-related methods to drivers - need to make sure we don't introduce a breaking change here!
A new `ControlledTransaction` that allows manual `commit`, `rollback` and savepoint-related commands.

```ts
const trx = await db.startTransaction().execute()

try {
  const moshe = await trx
    .insertInto('person')
    .values({ name: 'Moshe' })
    .returning('id')
    .executeTakeFirstOrThrow()

  const trxAfterFoo = await trx.savepoint('foo').execute()

  try {
    const bone = await trxAfterFoo
      .insertInto('toy')
      .values({ name: 'Bone', price: 1.99 })
      .returning('id')
      .executeTakeFirstOrThrow()

    await trxAfterFoo
      .insertInto('pet')
      .values({ 
        owner_id: moshe.id, 
        name: 'Lucky', 
        favorite_toy_id: bone.id 
      })
      .execute()
  } catch (error) {
    await trxAfterFoo.rollbackToSavepoint('foo').execute()
  }

  await trxAfterFoo.releaseSavepoint('foo').execute()

  await trx.insertInto('audit').values({ action: 'added Moshe' }).execute()

  await trx.commit().execute()
} catch (error) {
  await trx.rollback().execute()
}
```

Some design goals (that hopefully will be met once this is done) with `ControlledTransaction`:

- allow starting a controlled transaction in single connection scenario - it should re-use the connection, and not close/release it on commit/rollback by default.
~~- allow to release the connection on commit/rollback on demand via an option.~~
- once the controlled transaction is committed/rolled back, it should not allow executing any further queries with it.
- savepoint names are type-safe and autocompletion friendly - cannot release/rollback to a name that was not saved before. cannot save with a name that already exists.