### PR TITLE
remove docker-compose file version.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   # credit to Knex.js team for the following mssql setup here:
   mssql:


### PR DESCRIPTION
> The top-level version property is defined by the Compose Specification for backward compatibility. It is only informative and you'll receive a warning message that it is obsolete if used.
https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete