### PR TITLE
Docs: Fix typo

### DIFF
--- a/site/src/components/SectionFeatures/index.tsx
+++ b/site/src/components/SectionFeatures/index.tsx
@@ -46,7 +46,7 @@ const FeatureList: FeatureItem[] = [
     description: (
       <>
         PostgreSQL, MySQL, or SQLite? We've got you covered. There's also a
-        growing ecosystem of third-party dialects, including PlanetScale, D3,
+        growing ecosystem of third-party dialects, including PlanetScale, D1,
         SurrealDB, and more. <a href="/docs/dialects">Learn more.</a>
       </>
     ),


### PR DESCRIPTION
[Dialects list](https://kysely.dev/docs/dialects) mentions only D1, so I guess this might be a typo.

