### PR TITLE
feat: add the starts-with postgres comparison operator

### DIFF
--- a/src/operation-node/operator-node.ts
+++ b/src/operation-node/operator-node.ts
@@ -21,6 +21,7 @@ export const COMPARISON_OPERATORS = [
   'not ilike',
   '@>',
   '<@',
+  '^@',
   '&&',
   '?',
   '?&',


### PR DESCRIPTION
https://www.postgresql.org/docs/current/spgist-builtin-opclasses.html#SPGIST-BUILTIN-OPCLASSES-TABLE

There are a lot more operators as well that are arguably even more esoteric, not sure this can scale forever but.

see #891 and #1012. worth noting that `sql<boolean>` doesn’t currently work, but what you can do is

```ts
eb("tag", sql`^@`, ".").$castTo<boolean>()
```