### PR TITLE
move `preventAwait` to `alter-column-builder`.ts.

### DIFF
--- a/src/schema/alter-column-builder.ts
+++ b/src/schema/alter-column-builder.ts
@@ -8,6 +8,7 @@ import {
   DefaultValueExpression,
   parseDefaultValueExpression,
 } from '../parser/default-value-parser.js'
+import { preventAwait } from '../util/prevent-await.js'
 
 export class AlterColumnBuilder {
   readonly #column: string
@@ -63,6 +64,8 @@ export class AlterColumnBuilder {
   }
 }
 
+preventAwait(AlterColumnBuilder, "don't await AlterColumnBuilder instances")
+
 /**
  * Allows us to force consumers to do exactly one alteration to a column.
  *
@@ -93,3 +96,5 @@ export class AlteredColumnBuilder implements OperationNodeSource {
 export type AlterColumnBuilderCallback = (
   builder: AlterColumnBuilder,
 ) => AlteredColumnBuilder
+
+preventAwait(AlteredColumnBuilder, "don't await AlteredColumnBuilder instances")

--- a/src/schema/alter-table-builder.ts
+++ b/src/schema/alter-table-builder.ts
@@ -323,6 +323,8 @@ export interface AlterTableBuilderProps {
   readonly node: AlterTableNode
 }
 
+preventAwait(AlterTableBuilder, "don't await AlterTableBuilder instances")
+
 export interface ColumnAlteringInterface {
   alterColumn(
     column: string,
@@ -468,9 +470,6 @@ export class AlterTableColumnAlteringBuilder
 
 export interface AlterTableColumnAlteringBuilderProps
   extends AlterTableBuilderProps {}
-
-preventAwait(AlterTableBuilder, "don't await AlterTableBuilder instances")
-preventAwait(AlterColumnBuilder, "don't await AlterColumnBuilder instances")
 
 preventAwait(
   AlterTableColumnAlteringBuilder,


### PR DESCRIPTION
Hey 👋 

I've checked the reproduction repository provided at https://github.com/kysely-org/kysely-ctl/issues/26, and it appears to be that `preventAwait`ing `AlterColumnBuilder` outside of its own file was causing this issue in the given CommonJS setup.

I believe the `preventAwait` being in the wrong file was caused by an incomplete extraction refactor, and should be in `AlterColumnBuilder`'s file anyway.