### PR TITLE
Go up prototype chain when checking isPlainObject

### DIFF
--- a/src/util/object-utils.ts
+++ b/src/util/object-utils.ts
@@ -64,7 +64,8 @@ export function isPlainObject(obj: unknown): obj is Record<string, unknown> {
     !Array.isArray(obj) &&
     !isDate(obj) &&
     !isBuffer(obj) &&
-    !isArrayBufferOrView(obj)
+    !isArrayBufferOrView(obj) &&
+    hasPlainObjectPrototype(obj)
   )
 }
 
@@ -168,4 +169,18 @@ function compareGenericObjects(
   }
 
   return true
+}
+
+function hasPlainObjectPrototype(obj: unknown): boolean {
+  if (Object.getPrototypeOf(obj) === null) {
+    return true
+  }
+
+  let proto = obj
+
+  while (Object.getPrototypeOf(proto) !== null) {
+    proto = Object.getPrototypeOf(proto)
+  }
+
+  return Object.getPrototypeOf(obj) === proto
 }


### PR DESCRIPTION
Implement a more robust version of `isPlainObject` that checks the prototype chain, [inspired by Lodash's `isPlainObject`](https://github.com/lodash/lodash/blob/a67a085cc0612f5b83d78024e507427dab25ca2c/src/isPlainObject.ts).

Fixes https://github.com/kysely-org/kysely/issues/1036.

Sorry for not writing a test, I'm a first-time contributor and the idea of adding a test for my particular use case--complex objects returned from `PG.types.setTypeMapParser`--was daunting. However, all tests pass on my machine.