### PR TITLE
`InferResult` should output plural.

### DIFF
--- a/src/query-builder/merge-query-builder.ts
+++ b/src/query-builder/merge-query-builder.ts
@@ -703,7 +703,7 @@ export class WheneableMergeQueryBuilder<
     )
   }
 
-  compile(): CompiledQuery<never> {
+  compile(): CompiledQuery<O> {
     return this.#props.executor.compileQuery(
       this.toOperationNode(),
       this.#props.queryId,

--- a/src/util/infer-result.ts
+++ b/src/util/infer-result.ts
@@ -56,5 +56,5 @@ type ResolveResult<O> = O extends
   | UpdateResult
   | DeleteResult
   | MergeResult
-  ? O
+  ? O[]
   : Simplify<O>[]

--- a/test/typings/test-d/infer-result.test-d.ts
+++ b/test/typings/test-d/infer-result.test-d.ts
@@ -47,7 +47,7 @@ function testInferResultInsertQuery(db: Kysely<Database>) {
   })
   const compiledQuery0 = query0.compile()
 
-  type Expected0 = InsertResult
+  type Expected0 = InsertResult[]
   expectType<Equals<Expected0, InferResult<typeof query0>>>(true)
   expectType<Equals<Expected0, InferResult<typeof compiledQuery0>>>(true)
 
@@ -74,7 +74,7 @@ function testInferResultUpdateQuery(db: Kysely<Database>) {
     .where('pet.id', '=', '1')
   const compiledQuery0 = query0.compile()
 
-  type Expected0 = UpdateResult
+  type Expected0 = UpdateResult[]
   expectType<Equals<Expected0, InferResult<typeof query0>>>(true)
   expectType<Equals<Expected0, InferResult<typeof compiledQuery0>>>(true)
 
@@ -111,7 +111,7 @@ function testInferResultDeleteQuery(db: Kysely<Database>) {
   const query0 = db.deleteFrom('pet').where('id', '=', '1')
   const compiledQuery0 = query0.compile()
 
-  type Expected0 = DeleteResult
+  type Expected0 = DeleteResult[]
   expectType<Equals<Expected0, InferResult<typeof query0>>>(true)
   expectType<Equals<Expected0, InferResult<typeof compiledQuery0>>>(true)
 
@@ -138,7 +138,7 @@ function testInferResultMergeQuery(db: Kysely<Database>) {
     .thenDelete()
   const compiledQuery0 = query0.compile()
 
-  type Expected0 = MergeResult
+  type Expected0 = MergeResult[]
   expectType<Equals<Expected0, InferResult<typeof query0>>>(true)
   expectType<Equals<Expected0, InferResult<typeof compiledQuery0>>>(true)
 }

--- a/test/typings/test-d/infer-result.test-d.ts
+++ b/test/typings/test-d/infer-result.test-d.ts
@@ -6,6 +6,7 @@ import {
   InferResult,
   InsertResult,
   Kysely,
+  MergeResult,
   Selectable,
   UpdateResult,
 } from '..'
@@ -127,4 +128,17 @@ function testInferResultDeleteQuery(db: Kysely<Database>) {
   type Expected2 = { id: string }[]
   expectType<Equals<Expected2, InferResult<typeof query2>>>(true)
   expectType<Equals<Expected2, InferResult<typeof compiledQuery2>>>(true)
+}
+
+function testInferResultMergeQuery(db: Kysely<Database>) {
+  const query0 = db
+    .mergeInto('person')
+    .using('pet', 'pet.owner_id', 'person.id')
+    .whenMatched()
+    .thenDelete()
+  const compiledQuery0 = query0.compile()
+
+  type Expected0 = MergeResult
+  expectType<Equals<Expected0, InferResult<typeof query0>>>(true)
+  expectType<Equals<Expected0, InferResult<typeof compiledQuery0>>>(true)
 }


### PR DESCRIPTION
Hey :wave:

Right now, `InferResult` wrongfully outputs a singular type, despite queries actually having a plural result type when executed.

This PR makes it plural instead.

This will enable simpler types for when we implement batch execution.