### PR TITLE
Add additional config options to MSSQL dialect

### DIFF
--- a/src/dialect/mssql/mssql-dialect-config.ts
+++ b/src/dialect/mssql/mssql-dialect-config.ts
@@ -55,9 +55,9 @@ export interface Tedious {
   Request: TediousRequestClass
   TYPES: TediousTypes
   /**
-   * This controls weather the dialect calls the underlying tedious connection's
-   * [`reset` method](https://github.com/tediousjs/tedious/blob/master/src/connection.ts/#L3190)
-   * when a connection is released back to the pool.
+   * Controls whether connections are reset to their initial states when released back to the pool. Resetting a connection performs additional requests to the database.
+   * See {@link https://tediousjs.github.io/tedious/api-connection.html#function_reset | connection.reset}.
+   *
    * Defaults to `true`.
    */
   resetConnectionOnRelease?: boolean
@@ -152,9 +152,9 @@ export interface Tarn {
    */
   options: Omit<TarnPoolOptions<any>, 'create' | 'destroy' | 'validate'> & {
     /**
-     * Controls if tarn will validate connections before acquiring them from the pool.
-     * Connections are validated by executing the query `SELECT 1` on the connection.
-     * Defaults to `true`
+     * Controls whether connections are validated before being acquired from the pool. Connection validation performs additional requests to the database.
+     *
+     * Defaults to `true`.
      */
     validateConnections?: boolean
   }
@@ -199,7 +199,7 @@ export interface TarnPoolOptions<R> {
   min: number
   propagateCreateError?: boolean
   reapIntervalMillis?: number
-  validate(resource: R): boolean
+  validate?: (resource: R) => boolean
 }
 
 export interface TarnPendingRequest<R> {

--- a/src/dialect/mssql/mssql-dialect-config.ts
+++ b/src/dialect/mssql/mssql-dialect-config.ts
@@ -1,5 +1,3 @@
-import type { MssqlConnection } from './mssql-driver.js'
-
 export interface MssqlDialectConfig {
   /**
    * This dialect uses the `tarn` package to manage the connection pool to your

--- a/src/dialect/mssql/mssql-dialect-config.ts
+++ b/src/dialect/mssql/mssql-dialect-config.ts
@@ -199,7 +199,7 @@ export interface TarnPoolOptions<R> {
   min: number
   propagateCreateError?: boolean
   reapIntervalMillis?: number
-  validate?: (resource: R) => boolean
+  validate?(resource: R): boolean
 }
 
 export interface TarnPendingRequest<R> {

--- a/src/dialect/mssql/mssql-dialect-config.ts
+++ b/src/dialect/mssql/mssql-dialect-config.ts
@@ -1,4 +1,4 @@
-import { MssqlConnection } from './mssql-driver'
+import type { MssqlConnection } from './mssql-driver.js'
 
 export interface MssqlDialectConfig {
   /**

--- a/src/dialect/mssql/mssql-dialect-config.ts
+++ b/src/dialect/mssql/mssql-dialect-config.ts
@@ -1,9 +1,12 @@
+import { MssqlConnection } from './mssql-driver'
+
 export interface MssqlDialectConfig {
   /**
    * This dialect uses the `tarn` package to manage the connection pool to your
    * database. To use it as a peer dependency and not bundle it with Kysely's code,
    * you need to pass the `tarn` package itself. You also need to pass some pool options
-   * (excluding `create`, `destroy` and `validate` functions which are controlled by this dialect),
+   * (excluding `create` and `destroy` functions which are controlled by this dialect whereas `validate`
+   * may be provided, otherwise it is also controlled by the dialect),
    * `min` & `max` connections at the very least.
    *
    * Example:
@@ -47,6 +50,13 @@ export interface MssqlDialectConfig {
    * ```
    */
   tedious: Tedious
+
+  /**
+   * This controls weather the dialect calls the underlying tedious connection's
+   * [`reset` method](https://github.com/tediousjs/tedious/blob/master/src/connection.ts/#L3190)
+   * when a connection is released back to the pool. Defaults to `true`.
+   */
+  resetOnRelease?: boolean
 }
 
 export interface Tedious {
@@ -143,7 +153,9 @@ export interface Tarn {
    * Tarn.js' pool options, excluding `create`, `destroy` and `validate` functions,
    * which must be implemented by this dialect.
    */
-  options: Omit<TarnPoolOptions<any>, 'create' | 'destroy' | 'validate'>
+  options: Omit<TarnPoolOptions<any>, 'create' | 'destroy' | 'validate'> & {
+    validate?: (connection: MssqlConnection) => Promise<boolean> | boolean
+  }
 
   /**
    * Tarn.js' Pool class.

--- a/src/dialect/mssql/mssql-dialect-config.ts
+++ b/src/dialect/mssql/mssql-dialect-config.ts
@@ -50,13 +50,6 @@ export interface MssqlDialectConfig {
    * ```
    */
   tedious: Tedious
-
-  /**
-   * This controls weather the dialect calls the underlying tedious connection's
-   * [`reset` method](https://github.com/tediousjs/tedious/blob/master/src/connection.ts/#L3190)
-   * when a connection is released back to the pool. Defaults to `true`.
-   */
-  resetOnRelease?: boolean
 }
 
 export interface Tedious {
@@ -64,6 +57,13 @@ export interface Tedious {
   ISOLATION_LEVEL: TediousIsolationLevel
   Request: TediousRequestClass
   TYPES: TediousTypes
+  /**
+   * This controls weather the dialect calls the underlying tedious connection's
+   * [`reset` method](https://github.com/tediousjs/tedious/blob/master/src/connection.ts/#L3190)
+   * when a connection is released back to the pool.
+   * Defaults to `true`.
+   */
+  resetConnectionOnRelease?: boolean
 }
 
 export interface TediousConnection {
@@ -154,7 +154,12 @@ export interface Tarn {
    * which must be implemented by this dialect.
    */
   options: Omit<TarnPoolOptions<any>, 'create' | 'destroy' | 'validate'> & {
-    validate?: (connection: MssqlConnection) => Promise<boolean> | boolean
+    /**
+     * Controls if tarn will validate connections before acquiring them from the pool.
+     * Connections are validated by executing the query `SELECT 1` on the connection.
+     * Defaults to `true`
+     */
+    validateConnections?: boolean
   }
 
   /**

--- a/src/dialect/mssql/mssql-dialect-config.ts
+++ b/src/dialect/mssql/mssql-dialect-config.ts
@@ -3,8 +3,7 @@ export interface MssqlDialectConfig {
    * This dialect uses the `tarn` package to manage the connection pool to your
    * database. To use it as a peer dependency and not bundle it with Kysely's code,
    * you need to pass the `tarn` package itself. You also need to pass some pool options
-   * (excluding `create` and `destroy` functions which are controlled by this dialect whereas `validate`
-   * may be provided, otherwise it is also controlled by the dialect),
+   * (excluding `create`, `destroy` and `validate` functions which are controlled by this dialect),
    * `min` & `max` connections at the very least.
    *
    * Example:

--- a/src/dialect/mssql/mssql-driver.ts
+++ b/src/dialect/mssql/mssql-driver.ts
@@ -58,7 +58,7 @@ export class MssqlDriver implements Driver {
       // the types are not aligned and it type errors.
       validate:
         this.#config.tarn.options.validateConnections === false
-          ? () => true
+          ? undefined
           : (connection) => connection.validate(),
     })
   }
@@ -87,9 +87,7 @@ export class MssqlDriver implements Driver {
   }
 
   async releaseConnection(connection: MssqlConnection): Promise<void> {
-    if (this.#config.tedious.resetConnectionOnRelease !== false) {
-      await connection[PRIVATE_RELEASE_METHOD]()
-    }
+    await connection[PRIVATE_RELEASE_METHOD]()
     this.#pool.release(connection)
   }
 
@@ -277,6 +275,9 @@ class MssqlConnection implements DatabaseConnection {
   }
 
   [PRIVATE_RELEASE_METHOD](): Promise<void> {
+    if (this.#tedious.resetConnectionOnRelease === false) {
+      return Promise.resolve(undefined)
+    }
     return new Promise((resolve, reject) => {
       this.#connection.reset((error) => {
         if (error) reject(error)

--- a/src/dialect/mssql/mssql-driver.ts
+++ b/src/dialect/mssql/mssql-driver.ts
@@ -41,15 +41,15 @@ export class MssqlDriver implements Driver {
   constructor(config: MssqlDialectConfig) {
     this.#config = freeze({ ...config })
 
-    this.#pool = new this.#config.tarn.Pool({
-      ...this.#config.tarn.options,
-      create: async () => {
-        const connection = await this.#config.tedious.connectionFactory()
+    const { tarn, tedious } = this.#config
+    const { validateConnections, ...poolOptions } = tarn.options
 
-        return await new MssqlConnection(
-          connection,
-          this.#config.tedious,
-        ).connect()
+    this.#pool = new tarn.Pool({
+      ...poolOptions,
+      create: async () => {
+        const connection = await tedious.connectionFactory()
+
+        return await new MssqlConnection(connection, tedious).connect()
       },
       destroy: async (connection) => {
         await connection[PRIVATE_DESTROY_METHOD]()
@@ -57,7 +57,7 @@ export class MssqlDriver implements Driver {
       // @ts-ignore `tarn` accepts a function that returns a promise here, but
       // the types are not aligned and it type errors.
       validate:
-        this.#config.tarn.options.validateConnections === false
+        validateConnections === false
           ? undefined
           : (connection) => connection.validate(),
     })
@@ -274,16 +274,16 @@ class MssqlConnection implements DatabaseConnection {
     })
   }
 
-  [PRIVATE_RELEASE_METHOD](): Promise<void> {
-    if (this.#tedious.resetConnectionOnRelease === false) {
-      return Promise.resolve(undefined)
-    }
-    return new Promise((resolve, reject) => {
-      this.#connection.reset((error) => {
-        if (error) reject(error)
-        else resolve(undefined)
+  async [PRIVATE_RELEASE_METHOD](): Promise<void> {
+    // TODO: flip this to `if (!this.#tedious.resetConnectionOnRelease) {}` in a future PR.
+    if (this.#tedious.resetConnectionOnRelease !== false) {
+      await new Promise((resolve, reject) => {
+        this.#connection.reset((error) => {
+          if (error) reject(error)
+          else resolve(undefined)
+        })
       })
-    })
+    }
   }
 
   [PRIVATE_DESTROY_METHOD](): Promise<void> {

--- a/src/dialect/mssql/mssql-driver.ts
+++ b/src/dialect/mssql/mssql-driver.ts
@@ -275,7 +275,6 @@ export class MssqlConnection implements DatabaseConnection {
   }
 
   [PRIVATE_RELEASE_METHOD](): Promise<void> {
-    console.log('realeseing')
     return new Promise((resolve, reject) => {
       this.#connection.reset((error) => {
         if (error) reject(error)

--- a/src/dialect/mssql/mssql-driver.ts
+++ b/src/dialect/mssql/mssql-driver.ts
@@ -98,7 +98,7 @@ export class MssqlDriver implements Driver {
   }
 }
 
-export class MssqlConnection implements DatabaseConnection {
+class MssqlConnection implements DatabaseConnection {
   readonly #connection: TediousConnection
   readonly #tedious: Tedious
 

--- a/src/dialect/mssql/mssql-driver.ts
+++ b/src/dialect/mssql/mssql-driver.ts
@@ -104,6 +104,7 @@ export class MssqlConnection implements DatabaseConnection {
   constructor(connection: TediousConnection, tedious: Tedious) {
     this.#connection = connection
     this.#tedious = tedious
+
     this.#connection.on('error', console.error)
     this.#connection.once('end', () => {
       this.#connection.off('error', console.error)

--- a/test/node/src/test-setup.ts
+++ b/test/node/src/test-setup.ts
@@ -188,12 +188,14 @@ export const DB_CONFIGS: PerDialect<KyselyConfig> = {
         options: {
           max: POOL_SIZE,
           min: 0,
+          validateConnections: false,
         },
         ...Tarn,
       },
       tedious: {
         ...Tedious,
         connectionFactory: () => new Tedious.Connection(DIALECT_CONFIGS.mssql),
+        resetConnectionOnRelease: false,
       },
     }),
     plugins: PLUGINS,


### PR DESCRIPTION
This PR is part of https://github.com/kysely-org/kysely/issues/1061.

Adds a new optional `resetConnectionOnRelease` config option to `config.tedious` that controls if the underlying tedious `reset` function is called when a connection is released back to the connection pool. The value defaults to true to maintain current behavior.

Adds new optional `validateConnections` argument to `config.tarn` that controls if tarn will execute a query to validate a connection before it is acquired. Defaults to `true` to maintain current behavior.

This is non-breaking change that will require no action for those currently using the MSSQL dialect, as it maintains current behavior. 