### PR TITLE
fix: change `Updateable` to `Updatable`

### DIFF
--- a/example/src/authentication/refresh-token.repository.ts
+++ b/example/src/authentication/refresh-token.repository.ts
@@ -2,7 +2,7 @@ import { Kysely } from 'kysely'
 import { Database } from '../database'
 import {
   RefreshTokenRow,
-  UpdateableRefreshTokenRow,
+  UpdatableRefreshTokenRow,
 } from './refresh-token.table'
 
 export async function insertRefreshToken(
@@ -40,7 +40,7 @@ export async function findRefreshToken(
 export async function updateRefreshToken(
   db: Kysely<Database>,
   refreshTokenId: string,
-  patch: Pick<UpdateableRefreshTokenRow, 'last_refreshed_at'>
+  patch: Pick<UpdatableRefreshTokenRow, 'last_refreshed_at'>
 ): Promise<void> {
   await db
     .updateTable('refresh_token')

--- a/example/src/authentication/refresh-token.table.ts
+++ b/example/src/authentication/refresh-token.table.ts
@@ -1,4 +1,4 @@
-import { Generated, Insertable, Selectable, Updateable } from 'kysely'
+import { Generated, Insertable, Selectable, Updatable } from 'kysely'
 
 export interface RefreshTokenTable {
   refresh_token_id: Generated<string>
@@ -9,4 +9,4 @@ export interface RefreshTokenTable {
 
 export type RefreshTokenRow = Selectable<RefreshTokenTable>
 export type InsertableRefreshTokenRow = Insertable<RefreshTokenTable>
-export type UpdateableRefreshTokenRow = Updateable<RefreshTokenTable>
+export type UpdatableRefreshTokenRow = Updatable<RefreshTokenTable>

--- a/example/src/user/sign-in-method/password-sign-in-method.table.ts
+++ b/example/src/user/sign-in-method/password-sign-in-method.table.ts
@@ -1,4 +1,4 @@
-import { Insertable, Selectable, Updateable } from 'kysely'
+import { Insertable, Selectable, Updatable } from 'kysely'
 
 export interface PasswordSignInMethodTable {
   user_id: string
@@ -10,5 +10,5 @@ export type PasswordSignInMethodRow = Selectable<PasswordSignInMethodTable>
 export type InsertablePasswordSignInMethodRow =
   Insertable<PasswordSignInMethodTable>
 
-export type UpdateablePasswordSignInMethodRow =
-  Updateable<PasswordSignInMethodTable>
+export type UpdatablePasswordSignInMethodRow =
+  Updatable<PasswordSignInMethodTable>

--- a/example/src/user/sign-in-method/sign-in-method.table.ts
+++ b/example/src/user/sign-in-method/sign-in-method.table.ts
@@ -1,4 +1,4 @@
-import { Insertable, Selectable, Updateable } from 'kysely'
+import { Insertable, Selectable, Updatable } from 'kysely'
 
 export interface SignInMethodTable {
   user_id: string
@@ -7,4 +7,4 @@ export interface SignInMethodTable {
 
 export type SignInMethodRow = Selectable<SignInMethodTable>
 export type InsertableSignInMethodRow = Insertable<SignInMethodTable>
-export type UpdateableSignInMethodRow = Updateable<SignInMethodTable>
+export type UpdatableSignInMethodRow = Updatable<SignInMethodTable>

--- a/example/src/user/user.table.ts
+++ b/example/src/user/user.table.ts
@@ -1,4 +1,4 @@
-import { Generated, Insertable, Selectable, Updateable } from 'kysely'
+import { Generated, Insertable, Selectable, Updatable } from 'kysely'
 
 export interface UserTable {
   user_id: Generated<string>
@@ -10,4 +10,4 @@ export interface UserTable {
 
 export type UserRow = Selectable<UserTable>
 export type InsertableUserRow = Insertable<UserTable>
-export type UpdateableUserRow = Updateable<UserTable>
+export type UpdatableUserRow = Updatable<UserTable>

--- a/site/docs/getting-started/_types.mdx
+++ b/site/docs/getting-started/_types.mdx
@@ -12,7 +12,7 @@ import {
   Insertable,
   JSONColumnType,
   Selectable,
-  Updateable,
+  Updatable
 } from 'kysely'
 
 export interface Database {
@@ -59,14 +59,14 @@ export interface PersonTable {
 }
 
 // You should not use the table schema interfaces directly. Instead, you should
-// use the `Selectable`, `Insertable` and `Updateable` wrappers. These wrappers
+// use the `Selectable`, `Insertable` and `Updatable` wrappers. These wrappers
 // make sure that the correct types are used in each operation.
 //
 // Most of the time you should trust the type inference and not use explicit
 // types at all. These types can be useful when typing function arguments.
 export type Person = Selectable<PersonTable>
 export type NewPerson = Insertable<PersonTable>
-export type PersonUpdate = Updateable<PersonTable>
+export type PersonUpdate = Updatable<PersonTable>
 
 export interface PetTable {
   id: Generated<number>
@@ -77,7 +77,7 @@ export interface PetTable {
 
 export type Pet = Selectable<PetTable>
 export type NewPet = Insertable<PetTable>
-export type PetUpdate = Updateable<PetTable>
+export type PetUpdate = Updatable<PetTable>
 ```
 
 :::tip[Codegen]

--- a/src/query-builder/merge-query-builder.ts
+++ b/src/query-builder/merge-query-builder.ts
@@ -718,7 +718,7 @@ export class WheneableMergeQueryBuilder<
    * ### Examples
    *
    * ```ts
-   * async function updatePerson(id: number, updates: UpdateablePerson, returnLastName: boolean) {
+   * async function updatePerson(id: number, updates: UpdatablePerson, returnLastName: boolean) {
    *   return await db
    *     .updateTable('person')
    *     .set(updates)

--- a/src/query-builder/on-conflict-builder.ts
+++ b/src/query-builder/on-conflict-builder.ts
@@ -15,7 +15,7 @@ import {
   UpdateObjectExpression,
   parseUpdateObjectExpression,
 } from '../parser/update-set-parser.js'
-import { Updateable } from '../util/column-type.js'
+import { Updatable } from '../util/column-type.js'
 import { freeze } from '../util/object-utils.js'
 import { preventAwait } from '../util/prevent-await.js'
 import { AnyColumn, SqlBool } from '../util/type-utils.js'
@@ -254,7 +254,7 @@ export interface OnConflictBuilderProps {
 preventAwait(OnConflictBuilder, "don't await OnConflictBuilder instances.")
 
 export type OnConflictDatabase<DB, TB extends keyof DB> = {
-  [K in keyof DB | 'excluded']: Updateable<K extends keyof DB ? DB[K] : DB[TB]>
+  [K in keyof DB | 'excluded']: Updatable<K extends keyof DB ? DB[K] : DB[TB]>
 }
 
 export type OnConflictTables<TB> = TB | 'excluded'

--- a/src/query-builder/update-query-builder.ts
+++ b/src/query-builder/update-query-builder.ts
@@ -848,7 +848,7 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
    * ### Examples
    *
    * ```ts
-   * async function updatePerson(id: number, updates: UpdateablePerson, returnLastName: boolean) {
+   * async function updatePerson(id: number, updates: UpdatablePerson, returnLastName: boolean) {
    *   return await db
    *     .updateTable('person')
    *     .set(updates)

--- a/src/util/column-type.ts
+++ b/src/util/column-type.ts
@@ -197,13 +197,35 @@ export type Insertable<R> = DrainOuterGeneric<
  *   modified_at: ColumnType<Date, string, never>
  * }
  *
- * type UpdateablePerson = Updateable<PersonTable>
+ * type UpdatablePerson = Updatable<PersonTable>
  * // {
  * //   id?: number,
  * //   first_name?: string
  * // }
  * ```
  */
-export type Updateable<R> = DrainOuterGeneric<{
+export type Updatable<R> = DrainOuterGeneric<{
   [K in UpdateKeys<R>]?: UpdateType<R[K]>
 }>
+
+/**
+ * Given a table interface, extracts the update type from all
+ * {@link ColumnType} types.
+ *
+ * ### Examples
+ *
+ * ```ts
+ * interface PersonTable {
+ *   id: Generated<number>
+ *   first_name: string
+ *   modified_at: ColumnType<Date, string, never>
+ * }
+ *
+ * type UpdatablePerson = Updatable<PersonTable>
+ * // {
+ * //   id?: number,
+ * //   first_name?: string
+ * // }
+ * ```
+ */
+export type Updateable<R> = Updatable<R>

--- a/test/node/src/sanitize-identifiers.test.ts
+++ b/test/node/src/sanitize-identifiers.test.ts
@@ -1,4 +1,4 @@
-import { Updateable } from '../../../dist/cjs'
+import { Updatable } from '../../../dist/cjs'
 
 import {
   destroyTest,
@@ -28,7 +28,7 @@ for (const dialect of DIALECTS) {
         'last_name"`': 'bar',
       }
 
-      const person = obj as unknown as Updateable<Person>
+      const person = obj as unknown as Updatable<Person>
       const query = ctx.db.updateTable('person').set(person)
 
       testSql(query, dialect, {
@@ -57,7 +57,7 @@ for (const dialect of DIALECTS) {
         'last_name""``': 'bar',
       }
 
-      const person = obj as unknown as Updateable<Person>
+      const person = obj as unknown as Updatable<Person>
       const query = ctx.db.updateTable('person').set(person)
 
       testSql(query, dialect, {


### PR DESCRIPTION
The prominently used form is `updatable` (without the "e"), however, for backwards-compatibility, both is now supported (see the changes in `src/util/column-type.ts`). Also see: https://english.stackexchange.com/questions/56431