### PR TITLE
fix typings: remove conflicts from intersecting selects 

### DIFF
--- a/src/parser/select-parser.ts
+++ b/src/parser/select-parser.ts
@@ -77,7 +77,7 @@ type FlattenSelectExpression<SE> = SE extends DynamicReferenceBuilder<infer RA>
   ? { [R in RA]: DynamicReferenceBuilder<R> }[RA]
   : SE
 
-type ExtractAliasFromSelectExpression<SE> = SE extends string
+export type ExtractAliasFromSelectExpression<SE> = SE extends string
   ? ExtractAliasFromStringSelectExpression<SE>
   : SE extends AliasedExpression<any, infer EA>
     ? EA

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -366,7 +366,11 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
 
   select<CB extends SelectCallback<DB, TB>>(
     callback: CB,
-  ): SelectQueryBuilder<DB, TB, O & CallbackSelection<DB, TB, CB>>
+  ): SelectQueryBuilder<
+    DB,
+    TB,
+    Omit<O, keyof CallbackSelection<DB, TB, CB>> & CallbackSelection<DB, TB, CB>
+  >
 
   select<SE extends SelectExpression<DB, TB>>(
     selection: SE,

--- a/test/typings/test-d/select.test-d.ts
+++ b/test/typings/test-d/select.test-d.ts
@@ -1,3 +1,4 @@
+import {expectError, expectType} from 'tsd'
 import {
   ColumnType,
   Expression,
@@ -9,8 +10,7 @@ import {
   Simplify,
   sql,
 } from '..'
-import { Database, Person, PersonMetadata } from '../shared'
-import { expectType, expectError } from 'tsd'
+import {Database, Person, PersonMetadata} from '../shared'
 
 async function testSelectSingle(db: Kysely<Database>) {
   const qb = db.selectFrom('person')
@@ -484,8 +484,16 @@ async function testSelectConflicts(db: Kysely<PGGenDatabase>) {
   expectType<{
     experience: {
       establishment: string
-    }[]
-  }>(r1)
+    }[]}>(r1)
+
+  const r2 = await db
+    .selectFrom('person_metadata')
+    .select(() => sql<number>`1`.as('answer'))
+    .select(sql<string>`foo`.as('answer'))
+    .select([sql<boolean>`true`.as('answer')])
+    .executeTakeFirstOrThrow()
+
+  expectType<{answer: boolean}>(r2)
 }
 
 export function jsonArrayFrom<O>(


### PR DESCRIPTION
When 2 select statements use the same alias, the DB will return 2 discrete columns, but the _driver_ will merge those into an object using a conflict strategy of last write wins.

For example, `SELECT 1 as ans, true as ans` will return `{ans: 1, ans: true}`, but the driver will return this value as `{ans: true}` (I believe ALL database drivers do this, please correct me if I'm wrong!)

Currently, kysely intersects these types instead of picking the value of the last one, e.g. `{ans: number & boolean}`, which becomes `{ans: never}`.

This PR selects the type of the most recently selected alias. This is useful in real world scenarios, e.g. using `to_json` to overwrite a column that that was captured in a `selectAll()`.