### PR TITLE
docs: updated outdated links

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -19,4 +19,4 @@ npm install
 npm test
 ```
 
-You need to have postgres running in the default port `5432` and the default postgres user `postgres` should exist with no password. You can modify the [test configuration](https://github.com/koskimas/kysely/blob/master/example/test/test-config.ts) if you want to use different settings.
+You need to have postgres running in the default port `5432` and the default postgres user `postgres` should exist with no password. You can modify the [test configuration](https://github.com/kysely-org/kysely/blob/master/example/test/test-config.ts) if you want to use different settings.

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -372,7 +372,7 @@ export class Kysely<DB>
   /**
    * Executes a given compiled query or query builder.
    *
-   * See {@link https://github.com/koskimas/kysely/blob/master/site/docs/recipes/splitting-build-compile-and-execute-code.md#execute-compiled-queries splitting build, compile and execute code recipe} for more information.
+   * See {@link https://github.com/kysely-org/kysely/blob/master/site/docs/recipes/0004-splitting-query-building-and-execution.md#execute-compiled-queries splitting build, compile and execute code recipe} for more information.
    */
   executeQuery<R>(
     query: CompiledQuery<R> | Compilable<R>,

--- a/src/plugin/deduplicate-joins/deduplicate-joins-plugin.ts
+++ b/src/plugin/deduplicate-joins/deduplicate-joins-plugin.ts
@@ -11,7 +11,7 @@ import { DeduplicateJoinsTransformer } from './deduplicate-joins-transformer.js'
 /**
  * Plugin that removes duplicate joins from queries.
  *
- * See [this recipe](https://github.com/koskimas/kysely/tree/master/site/docs/recipes/deduplicate-joins.md)
+ * See [this recipe](https://github.com/kysely-org/kysely/blob/master/site/docs/recipes/0008-deduplicate-joins.md)
  */
 export class DeduplicateJoinsPlugin implements KyselyPlugin {
   readonly #transformer = new DeduplicateJoinsTransformer()

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -1570,7 +1570,7 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    * method called inside the callback add optional fields to the result type. This is
    * because we can't know if those selections were actually made before running the code.
    *
-   * Also see [this recipe](https://github.com/koskimas/kysely/tree/master/site/docs/recipes/conditional-selects.md)
+   * Also see [this recipe](https://github.com/kysely-org/kysely/blob/master/site/docs/recipes/0005-conditional-selects.md)
    *
    * ### Examples
    *

--- a/src/query-creator.ts
+++ b/src/query-creator.ts
@@ -738,7 +738,7 @@ export class QueryCreator<DB> {
    * This only affects the query created through the builder returned from
    * this method and doesn't modify the `db` instance.
    *
-   * See [this recipe](https://github.com/koskimas/kysely/tree/master/site/docs/recipes/schemas.md)
+   * See [this recipe](https://github.com/kysely-org/kysely/blob/master/site/docs/recipes/0007-schemas.md)
    * for a more detailed explanation.
    *
    * ### Examples


### PR DESCRIPTION
some links were pointing to what I'm assuming is the previous repository for kysely