### PR TITLE
feat: dynamic result type casting

### DIFF
--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -2327,6 +2327,10 @@ class SelectQueryBuilderImpl<DB, TB extends keyof DB, O>
     return new SelectQueryBuilderImpl(this.#props)
   }
 
+  $castUsing<T extends O, TReturn>(_: (_: T) => TReturn) {
+    return new SelectQueryBuilderImpl<DB, TB, TReturn>(this.#props);
+  }
+
   $narrowType<T>(): SelectQueryBuilder<DB, TB, NarrowPartial<O, T>> {
     return new SelectQueryBuilderImpl(this.#props)
   }

--- a/test/typings/test-d/cast-using.test-d.ts
+++ b/test/typings/test-d/cast-using.test-d.ts
@@ -1,0 +1,22 @@
+import { Kysely } from '../index'
+import { Database } from '../shared'
+import { expectType } from 'tsd'
+
+type CustomString = string & { __toString: Function };
+type ConvertToCustomString<T> = {
+  [K in keyof T]: T[K] extends string | null 
+    ? (T[K] extends string ? CustomString : CustomString | null)
+    : T[K];
+};
+
+async function testCastUsing(db: Kysely<Database>) {
+  const r1 = await db
+    .selectFrom('person')
+    .select(['first_name', 'last_name'])
+    .$castUsing((_) => {
+      return _ as unknown as ConvertToCustomString<typeof _>;
+    })
+    .executeTakeFirstOrThrow()
+
+  expectType<{ first_name: CustomString, last_name: CustomString | null }>(r1)
+}


### PR DESCRIPTION
First of all, thank you for creating this great piece of software. It is the best query builder I've used so far in 20 years.

Type casting with **$castTo**, **$narrowType** and **$assertType** is not always efficient. Using them with selectAll or with many columns create a lot of boilerplate. It is also impossible to make dynamic conversions with them. One easy solution is applying the conversion after the query, however it creates unneccessary boilerplate and make it more error prone.

**$castUsing** method solves all these problems by applying a dynamic conversion in a one-liner, without breaking the call chain. This opens up doors for flexible customizations with less boilerplate.

## Example

Convert all string types to CustomString types.

```ts
type CustomString = string & { __toString: Function };
type ConvertToCustomString<T> = {
  [K in keyof T]: T[K] extends string | null 
    ? (T[K] extends string ? CustomString : CustomString | null)
    : T[K];
};

await db
    .selectFrom('person')
    .select(['first_name', 'last_name'])
    .$castUsing((_) => {
      return _ as unknown as ConvertToCustomString<typeof _>;
    })
    .executeTakeFirstOrThrow()
// returns: { first_name: CustomString, last_name: CustomString | null }
```

Make all columns nullable without hardcoding all columns in $narrowType.

```ts
type Nullable<T> = {
  [K in keyof T]: T[K] | null;
};

const r1 = await db
    .selectFrom('person')
    .selectAll()
    .$castUsing((_) => {
      return _ as unknown as Nullable<typeof _>;
    })
    .executeTakeFirstOrThrow()
```