### PR TITLE
Updated TraversedJSONPathBuilder.$castTo and .$notNull to support chaining with .as()

### DIFF
--- a/src/query-builder/json-path-builder.ts
+++ b/src/query-builder/json-path-builder.ts
@@ -246,12 +246,12 @@ export class TraversedJSONPathBuilder<S, O>
    * This method call doesn't change the SQL in any way. This methods simply
    * returns a copy of this `JSONPathBuilder` with a new output type.
    */
-  $castTo<C>(): JSONPathBuilder<C> {
-    return new JSONPathBuilder(this.#node)
+  $castTo<O2>(): TraversedJSONPathBuilder<S, O2> {
+    return new TraversedJSONPathBuilder(this.#node)
   }
 
-  $notNull(): JSONPathBuilder<Exclude<O, null>> {
-    return new JSONPathBuilder(this.#node)
+  $notNull(): TraversedJSONPathBuilder<S, Exclude<O, null>> {
+    return new TraversedJSONPathBuilder(this.#node)
   }
 
   toOperationNode(): OperationNode {

--- a/test/typings/test-d/json-traversal.test-d.ts
+++ b/test/typings/test-d/json-traversal.test-d.ts
@@ -87,6 +87,28 @@ async function testJSONReference(db: Kysely<Database>) {
 
   expectType<{ whenever: string | null }>(r10)
 
+  // `.$castTo()` should support chaining with `.as(...)` #1139
+  const [r11] = await db
+    .selectFrom('person_metadata')
+    .select((eb) =>
+      eb
+        .ref('array', '->')
+        .at(0)
+        .$castTo<string & { _brand: 'whenever' } | null>()
+        .as('whenever'),
+    )
+    .execute()
+
+  expectType<{ whenever: (string & { _brand: 'whenever' }) | null }>(r11)
+
+  // `.$notNull()` should support chaining with `.as(...)` #1139
+  const [r12] = await db
+    .selectFrom('person_metadata')
+    .select((eb) => eb.ref('array', '->').at(0).$notNull().as('whenever'))
+    .execute()
+
+  expectType<{ whenever: string }>(r12)
+
   // missing operator
 
   expectError(


### PR DESCRIPTION
closes #1138

i hope :)

## TODO

- [x] add test