### PR TITLE
`await using kysely = new Kysely()` support.

### DIFF
--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -42,6 +42,9 @@ import {
   provideControlledConnection,
 } from './util/provide-controlled-connection.js'
 
+// @ts-ignore
+Symbol.asyncDispose ??= Symbol('Symbol.asyncDispose')
+
 /**
  * The main Kysely class.
  *

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -87,7 +87,7 @@ import {
  */
 export class Kysely<DB>
   extends QueryCreator<DB>
-  implements QueryExecutorProvider
+  implements QueryExecutorProvider, AsyncDisposable
 {
   readonly #props: KyselyProps
 
@@ -508,6 +508,10 @@ export class Kysely<DB>
     const compiledQuery = isCompilable(query) ? query.compile() : query
 
     return this.getExecutor().executeQuery<R>(compiledQuery, queryId)
+  }
+
+  async [Symbol.asyncDispose]() {
+    await this.destroy()
   }
 }
 

--- a/test/node/src/async-dispose.test.ts
+++ b/test/node/src/async-dispose.test.ts
@@ -1,52 +1,65 @@
 import {
   CompiledQuery,
+  DatabaseConnection,
   DummyDriver,
   Kysely,
   PostgresAdapter,
   PostgresIntrospector,
   PostgresQueryCompiler,
+  QueryResult,
   RootOperationNode,
   sql,
 } from '../../..'
 import { expect } from './test-setup'
 
 describe('async dispose', function () {
-  it.only('should call destroy ', async () => {
-    const steps: string[] = [];
+  it('should call destroy ', async () => {
+    const steps: string[] = []
 
-    async function runScope() {
-        await using db = new Kysely({
-          dialect: {
-            createAdapter: () => new PostgresAdapter(),
-            createDriver: () => new (class SpiedOnDummyDriver extends DummyDriver {
-                async destroy(): Promise<void> {
-                    await new Promise((resolve) => setTimeout(resolve, 100))
-                    steps.push('destroyed')
-                }
+    {
+      await using db = new Kysely({
+        dialect: {
+          createAdapter: () => new PostgresAdapter(),
+          createDriver: () =>
+            new (class extends DummyDriver {
+              async acquireConnection() {
+                return new (class implements DatabaseConnection {
+                  async executeQuery<R>(): Promise<QueryResult<R>> {
+                    steps.push('executed')
+                    return { rows: [] }
+                  }
+                  streamQuery<R>(): AsyncIterableIterator<QueryResult<R>> {
+                    throw new Error('Method not implemented.')
+                  }
+                })()
+              }
+              async destroy(): Promise<void> {
+                steps.push('destroyed')
+              }
             })(),
-            createIntrospector: (db) => new PostgresIntrospector(db),
-            createQueryCompiler: () => new (class SpiedOnPostgresQueryCompiler extends PostgresQueryCompiler {
-                compileQuery(node: RootOperationNode): CompiledQuery<unknown> {
-                    const compiled = super.compileQuery(node)
-                    steps.push('compiled')
-                    return compiled
-                }
+          createIntrospector: (db) => new PostgresIntrospector(db),
+          createQueryCompiler: () =>
+            new (class extends PostgresQueryCompiler {
+              compileQuery(node: RootOperationNode): CompiledQuery<unknown> {
+                const compiled = super.compileQuery(node)
+                steps.push('compiled')
+                return compiled
+              }
             })(),
-          },
-        })
+        },
+      })
 
-        sql`select 1`.compile(db);
+      await sql`select 1`.execute(db)
     }
-
-    await runScope()
 
     steps.push('after runScope')
 
     expect(steps).to.length.to.be.greaterThan(1)
     expect(steps).to.deep.equal([
-        'compiled',
-        'destroyed',
-        'after runScope',
+      'compiled',
+      'executed',
+      'destroyed',
+      'after runScope',
     ])
   })
 })

--- a/test/node/src/async-dispose.test.ts
+++ b/test/node/src/async-dispose.test.ts
@@ -1,0 +1,52 @@
+import {
+  CompiledQuery,
+  DummyDriver,
+  Kysely,
+  PostgresAdapter,
+  PostgresIntrospector,
+  PostgresQueryCompiler,
+  RootOperationNode,
+  sql,
+} from '../../..'
+import { expect } from './test-setup'
+
+describe('async dispose', function () {
+  it.only('should call destroy ', async () => {
+    const steps: string[] = [];
+
+    async function runScope() {
+        await using db = new Kysely({
+          dialect: {
+            createAdapter: () => new PostgresAdapter(),
+            createDriver: () => new (class SpiedOnDummyDriver extends DummyDriver {
+                async destroy(): Promise<void> {
+                    await new Promise((resolve) => setTimeout(resolve, 100))
+                    steps.push('destroyed')
+                }
+            })(),
+            createIntrospector: (db) => new PostgresIntrospector(db),
+            createQueryCompiler: () => new (class SpiedOnPostgresQueryCompiler extends PostgresQueryCompiler {
+                compileQuery(node: RootOperationNode): CompiledQuery<unknown> {
+                    const compiled = super.compileQuery(node)
+                    steps.push('compiled')
+                    return compiled
+                }
+            })(),
+          },
+        })
+
+        sql`select 1`.compile(db);
+    }
+
+    await runScope()
+
+    steps.push('after runScope')
+
+    expect(steps).to.length.to.be.greaterThan(1)
+    expect(steps).to.deep.equal([
+        'compiled',
+        'destroyed',
+        'after runScope',
+    ])
+  })
+})

--- a/test/node/tsconfig.json
+++ b/test/node/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../../tsconfig-base.json",
   "include": ["src/**/*"],
   "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ESNext"],
     "module": "CommonJS",
     "outDir": "dist"
   }

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "moduleResolution": "Node",
-    "target": "ESNext",
+    "target": "ES2022",
     "lib": ["ESNext"],
     "declaration": true,
     "strict": true,

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "moduleResolution": "Node",
     "target": "ESNext",
+    "lib": ["ESNext"],
     "declaration": true,
     "strict": true,
     "noImplicitAny": true

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
     "moduleResolution": "Node",
-    "target": "ES2022",
-    "lib": ["ESNext"],
+    "target": "ESNext",
     "declaration": true,
     "strict": true,
     "noImplicitAny": true


### PR DESCRIPTION
Hey 👋 

This PR introduces `await using db = new Kysely(...)` support. Under the hood, it calls the `destroy` function when the scope in which `using` was used is exited.

`using` is part of TypeScript since version 5.2 was released in August 2023 (more than a year ago).

According to `npm` stats:

`typescript` has 59,208,821 weekly downloads.

`typescript`@5.6.2 has 10,367,140 weekly downloads.
`typescript`@5.5.4 has 5,269,636 weekly downloads.
`typescript`@5.5.3 has 1,986,815 weekly downloads.
`typescript`@5.5.2 has 793,512 weekly downloads.
`typescript`@5.4.5 has 4,832,241 weekly downloads.
`typescript`@5.4.4 has 272,520 weekly downloads.
`typescript`@5.4.3 has 551,093 weekly downloads.
`typescript`@5.4.2 has 1,258,707 weekly downloads.
`typescript`@5.3.3 has 4,330,332 weekly downloads.
`typescript`@5.3.2 has 429,380 weekly downloads.
`typescript`@5.2.2 has 8,388,969 weekly downloads.

total of 38,480,345 (64.99%)