### PR TITLE
add `returning` support in `MERGE` queries.

### DIFF
--- a/deno.check.d.ts
+++ b/deno.check.d.ts
@@ -12,6 +12,7 @@ import type {
 export interface Database {
   audit: AuditTable
   person: PersonTable
+  person_backup: PersonTable
   pet: PetTable
   toy: ToyTable
   wine: WineTable

--- a/src/helpers/postgres.ts
+++ b/src/helpers/postgres.ts
@@ -189,15 +189,17 @@ export type MergeAction = 'INSERT' | 'UPDATE' | 'DELETE'
  *   .using('person_backup as pb', 'p.id', 'pb.id')
  *   .whenMatched()
  *   .thenUpdateSet(({ ref }) => ({
- *     nickname: ref('pb.nickname'),
- *     updated_at: ref('pb.updated_at')
+ *     first_name: ref('pb.first_name'),
+ *     updated_at: ref('pb.updated_at').$castTo<string | null>(),
  *   }))
  *   .whenNotMatched()
  *   .thenInsertValues(({ ref}) => ({
- *     nickname: ref('pb.nickname'),
- *     created_at: ref('pb.updated_at')
+ *     id: ref('pb.id'),
+ *     first_name: ref('pb.first_name'),
+ *     created_at: ref('pb.updated_at'),
+ *     updated_at: ref('pb.updated_at').$castTo<string | null>(),
  *   }))
- *   .returning([mergeAction().as('action'), 'p.id', 'p.nickname'])
+ *   .returning([mergeAction().as('action'), 'p.id', 'p.updated_at'])
  *   .execute()
  *
  * result[0].action
@@ -208,9 +210,12 @@ export type MergeAction = 'INSERT' | 'UPDATE' | 'DELETE'
  * ```sql
  * merge into "person" as "p"
  * using "person_backup" as "pb" on "p"."id" = "pb"."id"
- * when matched then update set "nickname" = "pb"."nickname", "updated_at" = "pb"."updated_at"
- * when not matched then insert ("nickname", "created_at") values ("pb"."nickname", "pb"."updated_at")
- * returning merge_action() as "action", "p"."id", "p"."nickname"
+ * when matched then update set
+ *   "first_name" = "pb"."first_name",
+ *   "updated_at" = "pb"."updated_at"::text
+ * when not matched then insert values ("id", "first_name", "created_at", "updated_at")
+ * values ("pb"."id", "pb"."first_name", "pb"."updated_at", "pb"."updated_at")
+ * returning merge_action() as "action", "p"."id", "p"."updated_at"
  * ```
  */
 export function mergeAction(): RawBuilder<MergeAction> {

--- a/src/helpers/postgres.ts
+++ b/src/helpers/postgres.ts
@@ -169,3 +169,50 @@ export function jsonBuildObject<O extends Record<string, Expression<unknown>>>(
     Object.keys(obj).flatMap((k) => [sql.lit(k), obj[k]]),
   )})`
 }
+
+export type MergeAction = 'INSERT' | 'UPDATE' | 'DELETE'
+
+/**
+ * The PostgreSQL `merge_action` function.
+ *
+ * This function can be used in a `returning` clause to get the action that was
+ * performed in a `mergeInto` query. The function returns one of the following
+ * strings: `'INSERT'`, `'UPDATE'`, or `'DELETE'`.
+ *
+ * ### Examples
+ *
+ * ```ts
+ * import { mergeAction } from 'kysely/helpers/postgres'
+ *
+ * const result = await db
+ *   .mergeInto('person as p')
+ *   .using('person_backup as pb', 'p.id', 'pb.id')
+ *   .whenMatched()
+ *   .thenUpdateSet(({ ref }) => ({
+ *     nickname: ref('pb.nickname'),
+ *     updated_at: ref('pb.updated_at')
+ *   }))
+ *   .whenNotMatched()
+ *   .thenInsertValues(({ ref}) => ({
+ *     nickname: ref('pb.nickname'),
+ *     created_at: ref('pb.updated_at')
+ *   }))
+ *   .returning([mergeAction().as('action'), 'p.id', 'p.nickname'])
+ *   .execute()
+ *
+ * result[0].action
+ * ```
+ *
+ * The generated SQL (PostgreSQL):
+ *
+ * ```sql
+ * merge into "person" as "p"
+ * using "person_backup" as "pb" on "p"."id" = "pb"."id"
+ * when matched then update set "nickname" = "pb"."nickname", "updated_at" = "pb"."updated_at"
+ * when not matched then insert ("nickname", "created_at") values ("pb"."nickname", "pb"."updated_at")
+ * returning merge_action() as "action", "p"."id", "p"."nickname"
+ * ```
+ */
+export function mergeAction(): RawBuilder<MergeAction> {
+  return sql`merge_action()`
+}

--- a/src/operation-node/merge-query-node.ts
+++ b/src/operation-node/merge-query-node.ts
@@ -3,6 +3,7 @@ import { AliasNode } from './alias-node.js'
 import { JoinNode } from './join-node.js'
 import { OperationNode } from './operation-node.js'
 import { OutputNode } from './output-node.js'
+import { ReturningNode } from './returning-node.js'
 import { TableNode } from './table-node.js'
 import { TopNode } from './top-node.js'
 import { WhenNode } from './when-node.js'
@@ -15,6 +16,7 @@ export interface MergeQueryNode extends OperationNode {
   readonly whens?: ReadonlyArray<WhenNode>
   readonly with?: WithNode
   readonly top?: TopNode
+  readonly returning?: ReturningNode
   readonly output?: OutputNode
   readonly endModifiers?: ReadonlyArray<OperationNode>
 }

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -1039,6 +1039,7 @@ export class OperationNodeTransformer {
       top: this.transformNode(node.top),
       endModifiers: this.transformNodeList(node.endModifiers),
       output: this.transformNode(node.output),
+      returning: this.transformNode(node.returning),
     })
   }
 

--- a/src/query-builder/delete-query-builder.ts
+++ b/src/query-builder/delete-query-builder.ts
@@ -41,7 +41,7 @@ import { QueryId } from '../util/query-id.js'
 import { freeze } from '../util/object-utils.js'
 import { KyselyPlugin } from '../plugin/kysely-plugin.js'
 import { WhereInterface } from './where-interface.js'
-import { ReturningInterface } from './returning-interface.js'
+import { MultiTableReturningInterface } from './returning-interface.js'
 import {
   isNoResultErrorConstructor,
   NoResultError,
@@ -82,7 +82,7 @@ import {
 export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
   implements
     WhereInterface<DB, TB>,
-    ReturningInterface<DB, TB, O>,
+    MultiTableReturningInterface<DB, TB, O>,
     OutputInterface<DB, TB, O, 'deleted'>,
     OperationNodeSource,
     Compilable<O>,

--- a/src/query-builder/returning-interface.ts
+++ b/src/query-builder/returning-interface.ts
@@ -1,4 +1,5 @@
 import {
+  ReturningAllRow,
   ReturningCallbackRow,
   ReturningRow,
 } from '../parser/returning-parser.js'
@@ -10,7 +11,7 @@ export interface ReturningInterface<DB, TB extends keyof DB, O> {
    * Allows you to return data from modified rows.
    *
    * On supported databases like PostgreSQL, this method can be chained to
-   * `insert`, `update` and `delete` queries to return data.
+   * `insert`, `update`, `delete` and `merge` queries to return data.
    *
    * Note that on SQLite you need to give aliases for the expressions to avoid
    * [this bug](https://sqlite.org/forum/forumpost/033daf0b32) in SQLite.
@@ -78,10 +79,29 @@ export interface ReturningInterface<DB, TB extends keyof DB, O> {
   ): ReturningInterface<DB, TB, ReturningRow<DB, TB, O, SE>>
 
   /**
-   * Adds a `returning *` to an insert/update/delete query on databases
+   * Adds a `returning *` to an insert/update/delete/merge query on databases
    * that support `returning` such as PostgreSQL.
    *
    * Also see the {@link returning} method.
    */
+  returningAll(): ReturningInterface<DB, TB, Selectable<DB[TB]>>
+}
+
+export interface MultiTableReturningInterface<DB, TB extends keyof DB, O>
+  extends ReturningInterface<DB, TB, O> {
+  /**
+   * Adds a `returning *` or `returning table.*` to an insert/update/delete/merge
+   * query on databases that support `returning` such as PostgreSQL.
+   *
+   * Also see the {@link returning} method.
+   */
+  returningAll<T extends TB>(
+    tables: ReadonlyArray<T>,
+  ): MultiTableReturningInterface<DB, TB, ReturningAllRow<DB, T, O>>
+
+  returningAll<T extends TB>(
+    table: T,
+  ): MultiTableReturningInterface<DB, TB, ReturningAllRow<DB, T, O>>
+
   returningAll(): ReturningInterface<DB, TB, Selectable<DB[TB]>>
 }

--- a/src/query-builder/update-query-builder.ts
+++ b/src/query-builder/update-query-builder.ts
@@ -48,7 +48,7 @@ import { freeze } from '../util/object-utils.js'
 import { UpdateResult } from './update-result.js'
 import { KyselyPlugin } from '../plugin/kysely-plugin.js'
 import { WhereInterface } from './where-interface.js'
-import { ReturningInterface } from './returning-interface.js'
+import { MultiTableReturningInterface } from './returning-interface.js'
 import {
   isNoResultErrorConstructor,
   NoResultError,
@@ -83,7 +83,7 @@ import {
 export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
   implements
     WhereInterface<DB, TB>,
-    ReturningInterface<DB, TB, O>,
+    MultiTableReturningInterface<DB, TB, O>,
     OutputInterface<DB, TB, O>,
     OperationNodeSource,
     Compilable<O>,

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -1585,6 +1585,11 @@ export class DefaultQueryCompiler
       this.compileList(node.whens, ' ')
     }
 
+    if (node.returning) {
+      this.append(' ')
+      this.visitNode(node.returning)
+    }
+
     if (node.output) {
       this.append(' ')
       this.visitNode(node.output)


### PR DESCRIPTION
Hey 👋 

closes #1169.

As of PostgreSQL 17, `MERGE` queries now have `returning` clause support.

- [x] add `returning`/`returningAll` to `MERGE`.
- [x] add `MultiTableReturningInterface`, enforce it across `DeleteQueryBuilder`, `UpdateQueryBuilder` and `MERGE` builders. Why? the existing `ReturningInterface` doesn't have the `returningAll(tables)` methods, and `INSERT` queries are the only ones that don't support `returning table.*`.
- [x] add a way to return `merge_action()` in a type-safe and aliasable way - a PostgreSQL helper function was found to be the lightest solution. Expanding the `ExpressionBuilder` locally (only for `returning`) with `eb.mergeAction()` was also tested, but was adding way more changes. I think that with documentation we could nullify the worse discoverability.
- [x] unit tests.
- [x] typings tests.