### PR TITLE
docs: add prerequisites section in "getting started".

### DIFF
--- a/site/docs/getting-started.mdx
+++ b/site/docs/getting-started.mdx
@@ -4,6 +4,7 @@ title: 'Getting started'
 ---
 
 import BrowserOnly from '@docusaurus/BrowserOnly'
+import Prerequisites from './getting-started/_prerequisites.mdx'
 import { Installation } from './getting-started/Installation'
 import Types from './getting-started/_types.mdx'
 import { Dialects } from './getting-started/Dialects'
@@ -12,6 +13,10 @@ import { Querying } from './getting-started/Querying'
 import { Summary } from './getting-started/Summary'
 
 # Getting started
+
+## Prerequisites
+
+<Prerequisites />
 
 ## Installation
 

--- a/site/docs/getting-started/_prerequisites.mdx
+++ b/site/docs/getting-started/_prerequisites.mdx
@@ -1,0 +1,15 @@
+- [TypeScript](https://www.typescriptlang.org/) version 4.6 or later.
+
+- You must enable `strict` mode in your `tsconfig.json` file's `compilerOptions`.
+
+  ```ts title="tsconfig.json"
+  {
+    // ...
+    "compilerOptions": {
+      // ...
+      "strict": true
+      // ...
+    }
+    // ...
+  }
+  ```


### PR DESCRIPTION
Hey :wave:

This PR adds a prerequisites section to the "getting started" page in the docs site.
TypeScript 4.6+ and `strict: true` are the current requirements.