### PR TITLE
Docs: fix typo

### DIFF
--- a/site/docs/examples/insert/0040-complex-values.js
+++ b/site/docs/examples/insert/0040-complex-values.js
@@ -7,7 +7,7 @@ const result = await db
   .insertInto('person')
   .values(({ ref, selectFrom, fn }) => ({
     first_name: 'Jennifer',
-    last_name: sql<string>\`>concat(\${ani}, \${ston})\`,
+    last_name: sql<string>\`concat(\${ani}, \${ston})\`,
     middle_name: ref('first_name'),
     age: selectFrom('person')
       .select(fn.avg<number>('age').as('avg_age')),

--- a/src/query-builder/insert-query-builder.ts
+++ b/src/query-builder/insert-query-builder.ts
@@ -202,7 +202,7 @@ export class InsertQueryBuilder<DB, TB extends keyof DB, O>
    *   .insertInto('person')
    *   .values(({ ref, selectFrom, fn }) => ({
    *     first_name: 'Jennifer',
-   *     last_name: sql<string>`>concat(${ani}, ${ston})`,
+   *     last_name: sql<string>`concat(${ani}, ${ston})`,
    *     middle_name: ref('first_name'),
    *     age: selectFrom('person')
    *       .select(fn.avg<number>('age').as('avg_age')),


### PR DESCRIPTION
Removed the unnecessary `>` before `concat`.