### PR TITLE
Add a reference to `ref` in `table`'s docstring

### DIFF
--- a/src/expression/expression-builder.ts
+++ b/src/expression/expression-builder.ts
@@ -565,6 +565,8 @@ export interface ExpressionBuilder<DB, TB extends keyof DB> {
    * inner join "pet" on "pet"."owner_id" = "person"."id"
    * group by "person"."id"
    * ```
+   *
+   * If you need a column reference, use {@link ref}.
    */
   table<T extends TB & string>(
     table: T,


### PR DESCRIPTION
There's a `.table()` fn, but there's no `.col()` fn. Thought it would be nice to include a reference to `ref` to make discoverability easier.