### PR TITLE
feat: Add disableTransactions option to Migrator

### DIFF
--- a/src/migration/migrator.ts
+++ b/src/migration/migrator.ts
@@ -824,7 +824,14 @@ export interface MigratorProps {
   readonly nameComparator?: (name0: string, name1: string) => number
 
   /**
-   *
+   * Whether to skip running the migration in a transaction. Only relevant to databases
+   * that support a transactional DDL (i.e. postgres and mssql).
+   * 
+   * When true, migrations will not be run in a transaction, even if the dialect 
+   * supports transactions in their DDL.
+   * 
+   * When false, migrations will be run in a transaction if that is supported by
+   * the dialect.
    */
   readonly disableTransactions?: boolean
 }

--- a/src/migration/migrator.ts
+++ b/src/migration/migrator.ts
@@ -523,7 +523,7 @@ export class Migrator {
       }
     }
 
-    if (adapter.supportsTransactionalDdl) {
+    if (adapter.supportsTransactionalDdl && !this.#props.disableTransactions) {
       return this.#props.db.transaction().execute(run)
     } else {
       return this.#props.db.connection().execute(run)
@@ -822,6 +822,11 @@ export interface MigratorProps {
    * Default is `name0.localeCompare(name1)`.
    */
   readonly nameComparator?: (name0: string, name1: string) => number
+
+  /**
+   *
+   */
+  readonly disableTransactions?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary 

Adds `disableTransactions` option to the Migrator.

This flag controls whether the migrator will run a migration in a transaction or not, for dialects that support a transactional DDL. 
   
When true, migrations will not be run in a transaction, even if the dialect supports transactions in their DDL.

When false, migrations will be run in a transaction if that is supported by the dialect.

## Testing

- Added unit tests to `test/node`.
- Tested manually by creating a postgres migration to `CREATE INDEX CONCURRENTLY` on a big table. This succeeded when `disableTransactions` was true, and failed (as expected) when `disableTransactions` was false.

Closes #352 

