### PR TITLE
feat: expands limit in select accepting null value

### DIFF
--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -1124,6 +1124,9 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
   /**
    * Adds a limit clause to the query.
    *
+   * Passing a `null` value is only supported by some dialects like PostgreSQL,
+   * and will result in a no-op limit clause.
+   *
    * ### Examples
    *
    * Select the first 10 rows of the result:

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -1160,7 +1160,7 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    * ```
    */
   limit(
-    limit: ValueExpression<DB, TB, number | bigint>,
+    limit: ValueExpression<DB, TB, number | bigint | null>,
   ): SelectQueryBuilder<DB, TB, O>
 
   /**
@@ -2417,7 +2417,7 @@ class SelectQueryBuilderImpl<DB, TB extends keyof DB, O>
   }
 
   limit(
-    limit: ValueExpression<DB, TB, number | bigint>,
+    limit: ValueExpression<DB, TB, number | bigint | null>,
   ): SelectQueryBuilder<DB, TB, O> {
     return new SelectQueryBuilderImpl({
       ...this.#props,

--- a/test/node/src/select.test.ts
+++ b/test/node/src/select.test.ts
@@ -1123,6 +1123,28 @@ for (const dialect of DIALECTS) {
       })
     }
 
+    if (dialect === 'postgres') {
+      it('should create a select query with limit null', async () => {
+        const query = ctx.db
+          .selectFrom('person')
+          .select('first_name')
+          .limit(null)
+
+        testSql(query, dialect, {
+          postgres: {
+            sql: `select "first_name" from "person" limit $1`,
+            parameters: [null],
+          },
+          mysql: NOT_SUPPORTED,
+          mssql: NOT_SUPPORTED,
+          sqlite: NOT_SUPPORTED,
+        })
+
+        const result = await query.execute()
+        expect(result).to.have.length(3)
+      })
+    }
+
     it('should create a select statement without a `from` clause', async () => {
       const query = ctx.db.selectNoFrom((eb) => [
         eb
@@ -1235,26 +1257,6 @@ for (const dialect of DIALECTS) {
         })
 
         await query.execute()
-      })
-
-      it('should create a select query with limit null', async () => {
-        const query = ctx.db
-          .selectFrom('person')
-          .select('first_name')
-          .limit(null)
-
-        testSql(query, dialect, {
-          postgres: {
-            sql: `select "first_name" from "person" limit $1`,
-            parameters: [null],
-          },
-          mysql: NOT_SUPPORTED,
-          mssql: NOT_SUPPORTED,
-          sqlite: NOT_SUPPORTED,
-        })
-
-        const result = await query.execute()
-        expect(result).to.have.length(3)
       })
     }
 

--- a/test/node/src/select.test.ts
+++ b/test/node/src/select.test.ts
@@ -1236,6 +1236,26 @@ for (const dialect of DIALECTS) {
 
         await query.execute()
       })
+
+      it('should create a select query with limit null', async () => {
+        const query = ctx.db
+          .selectFrom('person')
+          .select('first_name')
+          .limit(null)
+
+        testSql(query, dialect, {
+          postgres: {
+            sql: `select "first_name" from "person" limit $1`,
+            parameters: [null],
+          },
+          mysql: NOT_SUPPORTED,
+          mssql: NOT_SUPPORTED,
+          sqlite: NOT_SUPPORTED,
+        })
+
+        const result = await query.execute()
+        expect(result).to.have.length(3)
+      })
     }
 
     if (dialect === 'mssql') {


### PR DESCRIPTION
Expands limit in select accepting null value. This PR includes tests.

This PR doesn't add _limit ALL_ : https://github.com/brianc/node-postgres/issues/2673

Closes:
#1345

