### PR TITLE
fix(docs): Fixed closing backtick in Migrator JSDoc

### DIFF
--- a/src/migration/migrator.ts
+++ b/src/migration/migrator.ts
@@ -805,7 +805,7 @@ export interface MigratorProps {
    *
    * When false, migrations must be run in their exact alpha-numeric order.
    * This is checked against the migrations already run in the database
-   * (`migrationTableName'). This ensures your migrations are always run in
+   * (`migrationTableName`). This ensures your migrations are always run in
    * the same order and is the safest option.
    *
    * When true, migrations are still run in alpha-numeric order, but


### PR DESCRIPTION
I noticed an incredibly minor typo in a JSDoc comment for the `Migrator` class when scaffolding out a new project, had to fix it real quick.

![image](https://github.com/user-attachments/assets/73432306-8e4c-40e1-8b9b-2a5dbe003391)