### PR TITLE
feat: add addIndex to CreateTableBuilder

### DIFF
--- a/src/operation-node/add-index-table-node.ts
+++ b/src/operation-node/add-index-table-node.ts
@@ -1,0 +1,39 @@
+import { freeze } from '../util/object-utils.js'
+import { ColumnNode } from './column-node.js'
+import { IdentifierNode } from './identifier-node.js'
+import { OperationNode } from './operation-node.js'
+
+export interface AddIndexTableNode extends OperationNode {
+  readonly kind: 'AddIndexTableNode'
+  readonly columns: ReadonlyArray<ColumnNode>
+  readonly name?: IdentifierNode
+}
+
+export type AddIndexTableNodeProps = Omit<Partial<AddIndexTableNode>, 'kind'>
+
+/**
+ * @internal
+ */
+export const AddIndexTableNode = freeze({
+  is(node: OperationNode): node is AddIndexTableNode {
+    return node.kind === 'AddIndexTableNode'
+  },
+
+  create(columns: string[], indexName?: string): AddIndexTableNode {
+    return freeze({
+      kind: 'AddIndexTableNode',
+      columns: freeze(columns.map(ColumnNode.create)),
+      name: indexName ? IdentifierNode.create(indexName) : undefined,
+    })
+  },
+
+  cloneWith(
+    node: AddIndexTableNode,
+    props: AddIndexTableNodeProps,
+  ): AddIndexTableNode {
+    return freeze({
+      ...node,
+      ...props,
+    })
+  },
+})

--- a/src/operation-node/create-table-node.ts
+++ b/src/operation-node/create-table-node.ts
@@ -4,6 +4,7 @@ import { TableNode } from './table-node.js'
 import { ConstraintNode } from './constraint-node.js'
 import { ColumnDefinitionNode } from './column-definition-node.js'
 import { ArrayItemType } from '../util/type-utils.js'
+import { AddIndexTableNode } from './add-index-table-node.js'
 
 export const ON_COMMIT_ACTIONS = ['preserve rows', 'delete rows', 'drop']
 export type OnCommitAction = ArrayItemType<typeof ON_COMMIT_ACTIONS>
@@ -23,6 +24,7 @@ export interface CreateTableNode extends OperationNode {
   readonly table: TableNode
   readonly columns: ReadonlyArray<ColumnDefinitionNode>
   readonly constraints?: ReadonlyArray<ConstraintNode>
+  readonly addIndexTable?: ReadonlyArray<AddIndexTableNode>
   readonly temporary?: boolean
   readonly ifNotExists?: boolean
   readonly onCommit?: OnCommitAction
@@ -90,6 +92,18 @@ export const CreateTableNode = freeze({
       endModifiers: createTable.endModifiers
         ? freeze([...createTable.endModifiers, modifier])
         : freeze([modifier]),
+    })
+  },
+
+  cloneWithAddIndexTable(
+    createTable: CreateTableNode,
+    addIndexTable: AddIndexTableNode,
+  ): CreateTableNode {
+    return freeze({
+      ...createTable,
+      addIndexTable: createTable.addIndexTable
+        ? freeze([...createTable.addIndexTable, addIndexTable])
+        : freeze([addIndexTable]),
     })
   },
 

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -94,6 +94,7 @@ import { CastNode } from './cast-node.js'
 import { FetchNode } from './fetch-node.js'
 import { TopNode } from './top-node.js'
 import { OutputNode } from './output-node.js'
+import { AddIndexTableNode } from './add-index-table-node.js'
 
 /**
  * Transforms an operation node tree into another one.
@@ -228,6 +229,7 @@ export class OperationNodeTransformer {
     FetchNode: this.transformFetch.bind(this),
     TopNode: this.transformTop.bind(this),
     OutputNode: this.transformOutput.bind(this),
+    AddIndexTableNode: this.transformOutput.bind(this),
   })
 
   transformNode<T extends OperationNode | undefined>(node: T): T {
@@ -441,6 +443,7 @@ export class OperationNodeTransformer {
       frontModifiers: this.transformNodeList(node.frontModifiers),
       endModifiers: this.transformNodeList(node.endModifiers),
       selectQuery: this.transformNode(node.selectQuery),
+      addIndexTable: this.transformNodeList(node.addIndexTable),
     })
   }
 
@@ -624,6 +627,14 @@ export class OperationNodeTransformer {
       columns: this.transformNodeList(node.columns),
       name: this.transformNode(node.name),
       nullsNotDistinct: node.nullsNotDistinct,
+    })
+  }
+
+  protected transformAddIndexTable(node: AddIndexTableNode): AddIndexTableNode {
+    return requireAllProps<AddIndexTableNode>({
+      kind: 'AddIndexTableNode',
+      columns: this.transformNodeList(node.columns),
+      name: this.transformNode(node.name),
     })
   }
 

--- a/src/operation-node/operation-node-visitor.ts
+++ b/src/operation-node/operation-node-visitor.ts
@@ -96,6 +96,7 @@ import { CastNode } from './cast-node.js'
 import { FetchNode } from './fetch-node.js'
 import { TopNode } from './top-node.js'
 import { OutputNode } from './output-node.js'
+import { AddIndexTableNode } from './add-index-table-node.js'
 
 export abstract class OperationNodeVisitor {
   protected readonly nodeStack: OperationNode[] = []
@@ -199,6 +200,7 @@ export abstract class OperationNodeVisitor {
     FetchNode: this.visitFetch.bind(this),
     TopNode: this.visitTop.bind(this),
     OutputNode: this.visitOutput.bind(this),
+    AddIndexTableNode: this.visitAddIndexTable.bind(this),
   })
 
   protected readonly visitNode = (node: OperationNode): void => {
@@ -245,6 +247,7 @@ export abstract class OperationNodeVisitor {
     node: PrimaryKeyConstraintNode,
   ): void
   protected abstract visitUniqueConstraint(node: UniqueConstraintNode): void
+  protected abstract visitAddIndexTable(node: AddIndexTableNode): void
   protected abstract visitReferences(node: ReferencesNode): void
   protected abstract visitCheckConstraint(node: CheckConstraintNode): void
   protected abstract visitWith(node: WithNode): void

--- a/src/operation-node/operation-node.ts
+++ b/src/operation-node/operation-node.ts
@@ -92,6 +92,7 @@ export type OperationNodeKind =
   | 'FetchNode'
   | 'TopNode'
   | 'OutputNode'
+  | 'AddIndexTableNode'
 
 export interface OperationNode {
   readonly kind: OperationNodeKind

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -1092,6 +1092,116 @@ for (const dialect of DIALECTS) {
 
           await builder.execute()
         })
+
+        it('should create a table with index on nickname named nickname_key', async () => {
+          const builder = ctx.db.schema
+            .createTable('test')
+            .addColumn('id', 'integer', (col) => col.notNull())
+            .addColumn('nickname', 'varchar(64)', (col) => col.notNull())
+            .addColumn('country', 'varchar(2)', (col) => col.notNull())
+            .addIndex(['nickname'], 'nickname_key')
+
+          testSql(builder, dialect, {
+            postgres: NOT_SUPPORTED,
+            mysql: {
+              sql: [
+                'create table `test`',
+                '(`id` integer not null,',
+                '`nickname` varchar(64) not null,',
+                '`country` varchar(2) not null,',
+                'index `nickname_key`  (`nickname`))',
+              ],
+              parameters: [],
+            },
+            mssql: NOT_SUPPORTED,
+            sqlite: NOT_SUPPORTED,
+          })
+
+          await builder.execute()
+        })
+
+        it('should create a table with indexes on nickname named nickname_key, and country names country_key', async () => {
+          const builder = ctx.db.schema
+            .createTable('test')
+            .addColumn('id', 'integer', (col) => col.notNull())
+            .addColumn('nickname', 'varchar(64)', (col) => col.notNull())
+            .addColumn('country', 'varchar(2)', (col) => col.notNull())
+            .addIndex(['nickname'], 'nickname_key')
+            .addIndex(['country'], 'country_key')
+
+          testSql(builder, dialect, {
+            postgres: NOT_SUPPORTED,
+            mysql: {
+              sql: [
+                'create table `test`',
+                '(`id` integer not null,',
+                '`nickname` varchar(64) not null,',
+                '`country` varchar(2) not null,',
+                'index `nickname_key`  (`nickname`),',
+                'index `country_key`  (`country`))',
+              ],
+              parameters: [],
+            },
+            mssql: NOT_SUPPORTED,
+            sqlite: NOT_SUPPORTED,
+          })
+
+          await builder.execute()
+        })
+
+        it('should create a table with composite index on nickname and country without setting name', async () => {
+          const builder = ctx.db.schema
+            .createTable('test')
+            .addColumn('id', 'integer', (col) => col.notNull())
+            .addColumn('nickname', 'varchar(64)', (col) => col.notNull())
+            .addColumn('country', 'varchar(2)', (col) => col.notNull())
+            .addIndex(['nickname', 'country'])
+
+          testSql(builder, dialect, {
+            postgres: NOT_SUPPORTED,
+            mysql: {
+              sql: [
+                'create table `test`',
+                '(`id` integer not null,',
+                '`nickname` varchar(64) not null,',
+                '`country` varchar(2) not null,',
+                'index (`nickname`, `country`))',
+              ],
+              parameters: [],
+            },
+            mssql: NOT_SUPPORTED,
+            sqlite: NOT_SUPPORTED,
+          })
+
+          await builder.execute()
+        })
+
+        it('should create a table with index on nickname without setting name', async () => {
+          const builder = ctx.db.schema
+            .createTable('test')
+            .addColumn('id', 'integer', (col) => col.notNull())
+            .addColumn('nickname', 'varchar(64)', (col) => col.notNull())
+            .addColumn('country', 'varchar(2)', (col) => col.notNull())
+            .addIndex(['nickname'])
+
+          testSql(builder, dialect, {
+            postgres: NOT_SUPPORTED,
+            mysql: {
+              sql: [
+                'create table `test`',
+                '(`id` integer not null,',
+                '`nickname` varchar(64) not null,',
+                '`country` varchar(2) not null,',
+                'index (`nickname`))',
+              ],
+              parameters: [],
+            },
+            mssql: NOT_SUPPORTED,
+            sqlite: NOT_SUPPORTED,
+          })
+
+          await builder.execute()
+        })
       }
 
       if (dialect === 'sqlite') {


### PR DESCRIPTION
This PR adds addIndex to CreateTableBuilder. Now is possible to create index inside create table (for dialects like mysql).

Closes:
#509

PS: If you could suggest me a better name for new node, review this 😉 .