### PR TITLE
Add Oracle dialect to dialects.md

### DIFF
--- a/site/docs/dialects.md
+++ b/site/docs/dialects.md
@@ -38,3 +38,4 @@ A dialect is the glue between Kysely and the underlying database engine. Check t
 | BigQuery                      | https://github.com/maktouch/kysely-bigquery                                 |
 | Clickhouse                    | https://github.com/founderpathcom/kysely-clickhouse                         |
 | PGLite                        | https://github.com/czeidler/kysely-pglite-dialect                           |
+| Oracle                        | https://github.com/griffiths-waite/kysely-oracledb                          |


### PR DESCRIPTION
Hi there! I've built an Oracle dialect and type generator for Kysely. It doesn't support every feature at the moment, but it has most of the basic functionality to enable type safety for querying Oracle Databases. We're using this in our tech stack at Griffiths Waite, and hope to add improvements in the future.

Repository: https://github.com/griffiths-waite/kysely-oracledb