### PR TITLE
fix: no logging in streams.

### DIFF
--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -8,6 +8,7 @@ export type LogLevel = ArrayItemType<typeof LOG_LEVELS>
 
 export interface QueryLogEvent {
   readonly level: 'query'
+  readonly isStream?: boolean
   readonly query: CompiledQuery
   readonly queryDurationMillis: number
 }
@@ -64,10 +65,9 @@ export class Log {
 
 function defaultLogger(event: LogEvent): void {
   if (event.level === 'query') {
-    console.log(`kysely:query: ${event.query.sql}`)
-    console.log(
-      `kysely:query: duration: ${event.queryDurationMillis.toFixed(1)}ms`,
-    )
+    const prefix = `kysely:query:${event.isStream ? 'stream:' : ''}`
+    console.log(`${prefix} ${event.query.sql}`)
+    console.log(`${prefix} duration: ${event.queryDurationMillis.toFixed(1)}ms`)
   } else if (event.level === 'error') {
     if (event.error instanceof Error) {
       console.error(`kysely:error: ${event.error.stack ?? event.error.message}`)


### PR DESCRIPTION
Hey :wave:

closes #1380.

Looks like we forgot to also monkey patch streams with logging.
Add an optional (for backwards compatibility) `isStream` log event property.
Went ahead and added differentiation in the logs between regular queries and streamed queries in the default logger.