### PR TITLE
feat: create create type as enum values argument readonly.

### DIFF
--- a/src/operation-node/create-type-node.ts
+++ b/src/operation-node/create-type-node.ts
@@ -27,12 +27,13 @@ export const CreateTypeNode = freeze({
     })
   },
 
-  cloneWithEnum(createType: CreateTypeNode, values: string[]): CreateTypeNode {
+  cloneWithEnum(
+    createType: CreateTypeNode,
+    values: readonly string[],
+  ): CreateTypeNode {
     return freeze({
       ...createType,
-      enum: ValueListNode.create(
-        values.map((value) => ValueNode.createImmediate(value)),
-      ),
+      enum: ValueListNode.create(values.map(ValueNode.createImmediate)),
     })
   },
 })

--- a/src/schema/create-type-builder.ts
+++ b/src/schema/create-type-builder.ts
@@ -29,7 +29,7 @@ export class CreateTypeBuilder implements OperationNodeSource, Compilable {
    * db.schema.createType('species').asEnum(['cat', 'dog', 'frog'])
    * ```
    */
-  asEnum(values: string[]): CreateTypeBuilder {
+  asEnum(values: readonly string[]): CreateTypeBuilder {
     return new CreateTypeBuilder({
       ...this.#props,
       node: CreateTypeNode.cloneWithEnum(this.#props.node, values),


### PR DESCRIPTION
Hey :wave:

closes #1118.

This PR makes the `values` argument in `asEnum` a readonly list.