### PR TITLE
feat: escape single quotes in string literals.

### DIFF
--- a/test/node/src/sql-injection.test.ts
+++ b/test/node/src/sql-injection.test.ts
@@ -1,0 +1,66 @@
+import { expect } from 'chai'
+import { sql } from '../../../'
+import { destroyTest, DIALECTS, initTest, TestContext } from './test-setup'
+
+for (const dialect of DIALECTS) {
+  describe(`${dialect}: select`, () => {
+    let ctx: TestContext
+    const identifierWrapper = dialect === 'mysql' ? '`' : '"'
+
+    before(async function () {
+      ctx = await initTest(this, dialect)
+    })
+
+    after(async () => {
+      await destroyTest(ctx)
+    })
+
+    it('should not allow SQL injection in table names', async () => {
+      const query = sql`select * from ${sql.table(
+        `person${identifierWrapper}; drop table person --`,
+      )}`.compile(ctx.db)
+
+      expect(query.sql).to.equal(
+        `select * from ${identifierWrapper}person${identifierWrapper}${identifierWrapper}; drop table person --${identifierWrapper}`,
+      )
+
+      await expect(ctx.db.executeQuery(query)).to.eventually.be.rejected
+      await assertDidNotDropTable(ctx, 'person')
+    })
+
+    it('should not allow SQL injection in column refs', async () => {
+      const query =
+        sql`select ${sql.ref(`first_name${identifierWrapper}; drop table person --`)} from person`.compile(
+          ctx.db,
+        )
+
+      expect(query.sql).to.equal(
+        `select ${identifierWrapper}first_name${identifierWrapper}${identifierWrapper}; drop table person --${identifierWrapper} from person`,
+      )
+
+      await expect(ctx.db.executeQuery(query)).to.eventually.be.rejected
+      await assertDidNotDropTable(ctx, 'person')
+    })
+
+    it('should not allow SQL injection in literals', async () => {
+      const query = ctx.db
+        .selectFrom('person')
+        .where('first_name', '=', sql.lit(`Sylvester'; drop table person --`))
+        .selectAll()
+
+      expect(query.compile().sql).to.equal(
+        `select * from ${identifierWrapper}person${identifierWrapper} where ${identifierWrapper}first_name${identifierWrapper} = 'Sylvester''; drop table person --'`,
+      )
+
+      const results = await ctx.db.executeQuery(query)
+      expect(results.rows).to.have.length(0)
+      await assertDidNotDropTable(ctx, 'person')
+    })
+  })
+}
+
+async function assertDidNotDropTable(ctx: TestContext, tableName: string) {
+  const tables = await ctx.db.introspection.getTables()
+
+  expect(tables.some((table) => table.name === tableName)).to.be.true
+}


### PR DESCRIPTION
Hey :wave:

closes #1124.

This PR introduces some string literal SQL injection denial in the form of escaping `'` to deny the most common string literal attacks:

```sql
-- when sql.lit(`'; drop table users --`)
where column = ''; drop table users --'
-- when sql.lit(`' or 1=1 --`)
where column = '' or 1=1 --'
```

and make them:

```sql
-- when sql.lit(`'; drop table users --`)
where column = '''; drop table users --'
-- when sql.lit(`' or 1=1 --`)
where column = ''' or 1=1 --'
```

If you find any additional measures we could take, please submit an issue OR swing by the Discord.
Some things are out of bounds, like SQL parsing, semantic checks, etc.