### PR TITLE
fix: allow empty array for sql.join

### DIFF
--- a/src/raw-builder/sql.ts
+++ b/src/raw-builder/sql.ts
@@ -462,7 +462,7 @@ export const sql: Sql = Object.assign(
       array: readonly unknown[],
       separator: RawBuilder<any> = sql`, `,
     ): RawBuilder<unknown> {
-      const nodes = new Array<OperationNode>(2 * array.length - 1)
+      const nodes = new Array<OperationNode>(Math.max(2 * array.length - 1, 0))
       const sep = separator.toOperationNode()
 
       for (let i = 0; i < array.length; ++i) {


### PR DESCRIPTION
We are trying to support using ANY() with empty arrays such as in this code:
```ts
if (filter.excludedOperatorIds) {
    query = query.where(sqlKy`NOT operator_id = ANY(ARRAY[${sqlKy.join(filter.excludedOperatorIds)}])`);
}

if (filter.includedOperatorIds) {
    query = query.where(sqlKy`operator_id = ANY(ARRAY[${sqlKy.join(filter.includedOperatorIds)}])`);
}
```

While this code works for any non-empty array, it crashes as the join fails calling a new Array(-1).

This change should maintain the current behavior while supporting empty arrays. If this PR is valid, I can add a test for it.