### PR TITLE
fix: `ImmediateValueTransformer` not handling `PrimitiveValueListNode`s.

### DIFF
--- a/src/plugin/immediate-value/immediate-value-transformer.ts
+++ b/src/plugin/immediate-value/immediate-value-transformer.ts
@@ -10,6 +10,10 @@ import { ValueNode } from '../../operation-node/value-node.js'
  * @internal
  */
 export class ImmediateValueTransformer extends OperationNodeTransformer {
+  override transformPrimitiveValueList(node: PrimitiveValueListNode): PrimitiveValueListNode {
+    return ValueListNode.create(node.values.map(ValueNode.createImmediate)) as any;
+  }
+  
   override transformValue(node: ValueNode): ValueNode {
     return {
       ...super.transformValue(node),


### PR DESCRIPTION
Hey 👋 

PrimitiveValueListNode values end up in the parameters array right now.

Start this in the browser, will come back to it with testing.