### PR TITLE
pg introspector - Wrap schema.table in double quotes for case handling

### DIFF
--- a/src/dialect/postgres/postgres-introspector.ts
+++ b/src/dialect/postgres/postgres-introspector.ts
@@ -62,7 +62,7 @@ export class PostgresIntrospector implements DatabaseIntrospector {
         ),
         sql<
           string | null
-        >`pg_get_serial_sequence(ns.nspname || '.' || c.relname, a.attname)`.as(
+        >`pg_get_serial_sequence(quote_ident(ns.nspname) || '.' || quote_ident(c.relname), a.attname)`.as(
           'auto_incrementing',
         ),
       ])

--- a/test/node/src/introspect.test.ts
+++ b/test/node/src/introspect.test.ts
@@ -257,6 +257,22 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              name: 'MixedCaseTable',
+              isView: false,
+              schema: 'some_schema',
+              columns: [
+                {
+                  name: 'some_column',
+                  dataType: 'int4',
+                  dataTypeSchema: 'pg_catalog',
+                  isNullable: false,
+                  isAutoIncrementing: true,
+                  hasDefaultValue: true,
+                  comment: undefined,
+                },
+              ],
+            },
+            {
               name: 'pet',
               isView: false,
               schema: 'some_schema',
@@ -879,6 +895,11 @@ for (const dialect of DIALECTS) {
           .execute()
 
         await ctx.db.schema
+          .createTable('some_schema.MixedCaseTable')
+          .addColumn('some_column', 'serial', (col) => col.primaryKey())
+          .execute()
+
+        await ctx.db.schema
           .createTable('some_schema.pet')
           .addColumn('some_column', 'serial', (col) => col.primaryKey())
           .addColumn('spcies', sql`dtype_schema.species`)
@@ -908,6 +929,10 @@ for (const dialect of DIALECTS) {
 
     async function dropSchema() {
       await ctx.db.schema.dropTable('some_schema.pet').ifExists().execute()
+      await ctx.db.schema
+        .dropTable('some_schema.MixedCaseTable')
+        .ifExists()
+        .execute()
       await ctx.db.schema
         .dropTable('some_schema.pet_partition')
         .ifExists()


### PR DESCRIPTION
Fixes https://github.com/kysely-org/kysely/issues/1425

Does so by wrapping the namespace and relname with the builtin `quote_ident` function to match the behavior of  `pg_get_serial_sequence` lowercasing by default.

Adds a test assertion to the introspector for a `some_table.MixedCaseTable` that I confirmed fails without the fix.