### PR TITLE
fix: SQLite's introspector is printing deprecation errors for `orderBy(array)`.

### DIFF
--- a/src/dialect/sqlite/sqlite-introspector.ts
+++ b/src/dialect/sqlite/sqlite-introspector.ts
@@ -102,7 +102,8 @@ export class SqliteIntrospector implements DatabaseIntrospector {
         'p.dflt_value',
         'p.pk',
       ])
-      .orderBy(['tl.name', 'p.cid'])
+      .orderBy('tl.name')
+      .orderBy('p.cid')
       .execute()
 
     const columnsByTable: Record<string, typeof tableMetadata> = {}

--- a/src/query-builder/order-by-interface.ts
+++ b/src/query-builder/order-by-interface.ts
@@ -45,24 +45,6 @@ export interface OrderByInterface<DB, TB extends keyof DB, O> {
    * order by "id", "fn" desc
    * ```
    *
-   * Multiple columns/expressions per call:
-   *
-   * ```ts
-   * await db
-   *   .selectFrom('person')
-   *   .select('person.first_name as fn')
-   *   .orderBy(['id', 'fn'])
-   *   .execute()
-   * ```
-   *
-   * The generated SQL (PostgreSQL):
-   *
-   * ```sql
-   * select "person"."first_name" as "fn"
-   * from "person"
-   * order by "id", "fn"
-   * ```
-   *
    * Building advanced modifiers:
    *
    * ```ts


### PR DESCRIPTION
Hey :wave:

closes #1424

Sorry about that. Annoying.