### PR TITLE
chore: bye bye node 18.

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: 'npm'
-          node-version: 22.x
+          node-version: lts/*
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: tests
+name: test
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         with-transformer: [false, true]
     runs-on: ubuntu-latest
 
-    name: Node.js${{ matrix.with-transformer ? ' /w transformer' : '' }}
+    name: Node.js${{ matrix.with-transformer && ' /w transformer' || '' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -58,8 +58,8 @@ jobs:
       - name: Run docker compose
         run: docker compose up -d
 
-      - name: Run node tests${{ matrix.with-transformer ? ' with transformer' : '' }}
-        run: ${{ matrix.with-transformer ? 'TEST_TRANSFORMER=1 ' : '' }}npm test
+      - name: Run node tests
+        run: ${{ matrix.with-transformer && 'TEST_TRANSFORMER=1 ' || '' }}npm test
 
       - name: Run esbuild test
         run: npm run test:esbuild

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         with-transformer: [false, true]
     runs-on: ubuntu-latest
 
-    name: Node.js ${{ matrix.with-transformer && '/w transformer ' || '' }}${{ matrix.node-version }}
+    name: Node.js ${{ matrix.node-version }}${{ matrix.with-transformer && ' /w transformer' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
         run: docker compose up -d
 
       - name: Run node tests
-        run: ${{ matrix.with-transformer && 'TEST_TRANSFORMER=1 ' || '' }}npm test
+        run: ${{ matrix.with-transformer && 'TEST_TRANSFORMER=1 ' }}npm test
 
       - name: Run esbuild test
         run: npm run test:esbuild

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         with-transformer: [false, true]
     runs-on: ubuntu-latest
 
-    name: Node.js ${{ matrix.node-version }}${{ matrix.with-transformer && ' /w transformer' || '' }}
+    name: Node.js (${{ matrix.node-version }})${{ matrix.with-transformer && ' /w transformer' || '' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,13 +33,15 @@ on:
 
 jobs:
   node:
-    name: Node.js
-    runs-on: ubuntu-latest
-
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x, 23.x]
+        # https://endoflife.date/nodejs
+        node-version: [20.x, 22.x, 23.x]
+        with-transformer: [false, true]
+    runs-on: ubuntu-latest
+
+    name: Node.js${{ matrix.with-transformer ? ' /w transformer' : '' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -56,38 +58,11 @@ jobs:
       - name: Run docker compose
         run: docker compose up -d
 
-      - name: Run node tests
-        run: npm test
+      - name: Run node tests${{ matrix.with-transformer ? ' with transformer' : '' }}
+        run: ${{ matrix.with-transformer ? 'TEST_TRANSFORMER=1 ' : '' }}npm test
 
       - name: Run esbuild test
         run: npm run test:esbuild
-
-  node-with-transformer:
-    name: Node.js /w transformer
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [18.x, 20.x, 22.x, 23.x]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run docker compose
-        run: docker compose up -d
-
-      - name: Run node tests with transformer
-        run: TEST_TRANSFORMER=1 npm test
 
   deno:
     name: Deno
@@ -96,7 +71,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deno-version: [1.x.x, 2.0.x]
+        # https://endoflife.date/deno
+        deno-version: [2.1.x, 2.2.x, 2.3.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -104,7 +80,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: lts/*
           cache: 'npm'
 
       - name: Use Deno ${{ matrix.deno-version }}
@@ -131,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bun-version: [1.1.26]
+        bun-version: [1.1, 1.2]
 
     steps:
       - uses: actions/checkout@v4
@@ -139,7 +115,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: lts/*
           cache: 'npm'
 
       - name: Install dependencies
@@ -166,7 +142,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: lts/*
           cache: 'npm'
 
       - name: Install dependencies
@@ -188,7 +164,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: lts/*
           cache: 'npm'
 
       - name: Install dependencies
@@ -224,7 +200,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
           cache: 'npm'
 
       - name: Install dependencies
@@ -256,13 +232,13 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: lts/*
           cache: 'npm'
 
       - name: Use Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: 2.0.x
+          deno-version: 2.x
 
       - name: Install dependencies
         run: npm ci
@@ -283,7 +259,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: lts/*
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         with-transformer: [false, true]
     runs-on: ubuntu-latest
 
-    name: Node.js${{ matrix.with-transformer && ' /w transformer' || '' }}
+    name: Node.js ${{ matrix.with-transformer && '/w transformer ' || '' }}${{ matrix.node-version }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,7 @@ jobs:
         run: ${{ matrix.with-transformer && 'TEST_TRANSFORMER=1 ' || '' }}npm test
 
       - name: Run esbuild test
+        if: ${{ !matrix.with-transformer }}
         run: npm run test:esbuild
 
   deno:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         with-transformer: [false, true]
     runs-on: ubuntu-latest
 
-    name: Node.js ${{ matrix.node-version }}${{ matrix.with-transformer && ' /w transformer' }}
+    name: Node.js ${{ matrix.node-version }}${{ matrix.with-transformer && ' /w transformer' || '' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
         run: docker compose up -d
 
       - name: Run node tests
-        run: ${{ matrix.with-transformer && 'TEST_TRANSFORMER=1 ' }}npm test
+        run: ${{ matrix.with-transformer && 'TEST_TRANSFORMER=1 ' || '' }}npm test
 
       - name: Run esbuild test
         run: npm run test:esbuild

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/kysely-org/kysely.git"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Hey :wave:

Node v18 has reached End of Life on [30.4.2025](https://endoflife.date/nodejs).
This PR removes it from CI and bumps the minimum Node.js engine in `package.json`.

Users should bump Node.js to a version that is still getting security updates. 
Users still on Node v18 can keep using Kysely, but we don't test for them anymore. Last version that was tested for Node v18 is 0.28.2.