### PR TITLE
React Native should use CJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,26 +20,31 @@
   },
   "exports": {
     ".": {
+      "react-native": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "default": "./dist/cjs/index.js"
     },
     "./helpers/postgres": {
+      "react-native": "./dist/cjs/helpers/postgres.js",
       "import": "./dist/esm/helpers/postgres.js",
       "require": "./dist/cjs/helpers/postgres.js",
       "default": "./dist/cjs/helpers/postgres.js"
     },
     "./helpers/mysql": {
+      "react-native": "./dist/cjs/helpers/mysql.js",
       "import": "./dist/esm/helpers/mysql.js",
       "require": "./dist/cjs/helpers/mysql.js",
       "default": "./dist/cjs/helpers/mysql.js"
     },
     "./helpers/mssql": {
+      "react-native": "./dist/cjs/helpers/mssql.js",
       "import": "./dist/esm/helpers/mssql.js",
       "require": "./dist/cjs/helpers/mssql.js",
       "default": "./dist/cjs/helpers/mssql.js"
     },
     "./helpers/sqlite": {
+      "react-native": "./dist/cjs/helpers/sqlite.js",
       "import": "./dist/esm/helpers/sqlite.js",
       "require": "./dist/cjs/helpers/sqlite.js",
       "default": "./dist/cjs/helpers/sqlite.js"


### PR DESCRIPTION
Without this, builds in Expo 53 break (expo/expo#36544) because the `package.json:exports` field is now enabled by default in Metro bundler.

This causes the ESM version of Kysely to get imported, which is an issue because Metro can't do dynamic imports yet (facebook/metro#52) which is used in the `FileMigrationProvider`: https://github.com/kysely-org/kysely/blob/master/src/migration/file-migration-provider.ts#L38-L43

This is a quick fix, but IMO the `FileMigrationProvider` should get its own sub path in `package.json:exports` so that RN can use the ESM version as well. If that's more acceptable even though it would be a breaking change, let me know and I can update the PR.