### PR TITLE
chore(CI): replace Node.js v23 with v24.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         # https://endoflife.date/nodejs
-        node-version: [20.x, 22.x, 23.x]
+        node-version: [20.x, 22.x, 24.x]
         with-transformer: [false, true]
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Hey 👋 

This PR replaces the experimental Node.js v23 with the latest v24 in our CI workflows.