### PR TITLE
chore(CI): add native typescript type checks.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -268,3 +268,22 @@ jobs:
 
       - name: Run benchmarks
         run: npm run bench:ts
+
+  typescript-native:
+    name: TypeScript Native
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci && npm i -D @typescript/native-preview
+
+      - name: Run TypeScript Native tests
+        run: tsgo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -286,4 +286,4 @@ jobs:
         run: npm ci && npm install -D @typescript/native-preview
 
       - name: Run TypeScript Native tests
-        run: npx tsgo --project ./tsconfig.json
+        run: npx tsgo --project ./tsconfig.json && npx tsgo --project ./test/node/tsconfig.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -285,5 +285,8 @@ jobs:
       - name: Install dependencies
         run: npm ci && npm install -D @typescript/native-preview
 
+      - name: Build
+        run: npm run build
+
       - name: Run TypeScript Native tests
         run: npx tsgo --project ./tsconfig.json && npx tsgo --project ./test/node/tsconfig.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -283,7 +283,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci && npm i -D @typescript/native-preview
+        run: npm ci
 
       - name: Run TypeScript Native tests
-        run: tsgo
+        run: npx tsgo --project ./tsconfig.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -283,7 +283,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci && npm install -D @typescript/native-preview
 
       - name: Run TypeScript Native tests
         run: npx tsgo --project ./tsconfig.json


### PR DESCRIPTION
Hey 👋 

This PR adds `tsgo` (TypeScript native preview) testing to CI. The Go port should have the same behavior as the "old" JavaScript implementation - but let's be safe and get a heads up if something is different.