### PR TITLE
Add non empty array check to insertInto

### DIFF
--- a/src/parser/insert-values-parser.ts
+++ b/src/parser/insert-values-parser.ts
@@ -33,9 +33,10 @@ export type InsertObject<DB, TB extends keyof DB> = {
     | undefined
 }
 
+type NonEmptyArray<T> = [T, ...T[]]
 export type InsertObjectOrList<DB, TB extends keyof DB> =
   | InsertObject<DB, TB>
-  | ReadonlyArray<InsertObject<DB, TB>>
+  | Readonly<NonEmptyArray<InsertObject<DB, TB>>>
 
 export type InsertObjectOrListFactory<
   DB,

--- a/test/node/src/json-traversal.test.ts
+++ b/test/node/src/json-traversal.test.ts
@@ -16,6 +16,7 @@ import {
   insertDefaultDataSet,
   testSql,
 } from './test-setup.js'
+import { getNonEmptyArray } from './utils'
 
 type TestContext = Awaited<ReturnType<typeof initJSONTest>>
 
@@ -796,42 +797,43 @@ async function insertDefaultJSONDataSet(ctx: TestContext) {
     .select(['id', 'first_name', 'last_name'])
     .execute()
 
-  await ctx.db
-    .insertInto('person_metadata')
-    .values(
-      people
-        .filter((person) => person.first_name && person.last_name)
-        .map((person, index) => ({
-          person_id: person.id,
-          website: JSON.stringify({
-            url: `https://www.${person.first_name!.toLowerCase()}${person.last_name!.toLowerCase()}.com`,
-          }),
-          nicknames: JSON.stringify([
-            `${person.first_name![0]}.${person.last_name![0]}.`,
-            `${person.first_name} the Great`,
-            `${person.last_name} the Magnificent`,
-          ]),
-          profile: JSON.stringify({
-            tags: ['awesome'],
-            auth: {
-              roles: ['contributor', 'moderator'],
-              last_login: {
-                device: 'android',
-              },
-              login_count: 12 + index,
-              is_verified: true,
+  const values = getNonEmptyArray(
+    people
+      .filter((person) => person.first_name && person.last_name)
+      .map((person, index) => ({
+        person_id: person.id,
+        website: JSON.stringify({
+          url: `https://www.${person.first_name!.toLowerCase()}${person.last_name!.toLowerCase()}.com`,
+        }),
+        nicknames: JSON.stringify([
+          `${person.first_name![0]}.${person.last_name![0]}.`,
+          `${person.first_name} the Great`,
+          `${person.last_name} the Magnificent`,
+        ]),
+        profile: JSON.stringify({
+          tags: ['awesome'],
+          auth: {
+            roles: ['contributor', 'moderator'],
+            last_login: {
+              device: 'android',
             },
-            avatar: null,
-          }),
-          experience: JSON.stringify([
-            {
-              establishment: 'The University of Life',
-            },
-          ]),
-          schedule: JSON.stringify([[[{ name: 'Gym', time: '12:15' }]]]),
-        })),
-    )
-    .execute()
+            login_count: 12 + index,
+            is_verified: true,
+          },
+          avatar: null,
+        }),
+        experience: JSON.stringify([
+          {
+            establishment: 'The University of Life',
+          },
+        ]),
+        schedule: JSON.stringify([[[{ name: 'Gym', time: '12:15' }]]]),
+      })),
+  )
+
+  if (values) {
+    await ctx.db.insertInto('person_metadata').values(values).execute()
+  }
 }
 
 async function clearJSONDatabase(ctx: TestContext) {

--- a/test/node/src/utils/getNonEmptyArray.ts
+++ b/test/node/src/utils/getNonEmptyArray.ts
@@ -1,0 +1,11 @@
+/**
+ * Returns same array if it is not empty or `undefined` otherwise
+ *
+ * @example
+ * getNonEmptyArray([]) => undefined
+ * getNonEmptyArray([1]) => [1]
+ */
+export function getNonEmptyArray<T>(arr: T[]): [T, ...T[]] | undefined {
+  if (!arr.length) return undefined
+  return arr as [T, ...T[]]
+}

--- a/test/node/src/utils/index.ts
+++ b/test/node/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './getNonEmptyArray'


### PR DESCRIPTION
This should prevent runtime error when empty array is passed to `insertInto().values()` since now TS error will pop up.

Currently no TS error is thrown and this may lead to runtime error and this is bad.

It [was said](https://github.com/kysely-org/kysely/issues/1401) that end user should handle the check but it is easy to forget about it.

Maybe we also should export a util like `getNonEmptyArray` and update the docs. It will be a little complex but I think it is better than risk of runtime errors.

What do you think?