### PR TITLE
fix(helpers): JSON helpers' return types incorrectly have `Date`s and other JS/Node-native instances that require data type metadata.

### DIFF
--- a/src/helpers/mysql.ts
+++ b/src/helpers/mysql.ts
@@ -4,7 +4,11 @@ import { SelectQueryBuilderExpression } from '../query-builder/select-query-buil
 import { RawBuilder } from '../raw-builder/raw-builder.js'
 import { sql } from '../raw-builder/sql.js'
 import { getJsonObjectArgs } from '../util/json-object-args.js'
-import { Simplify } from '../util/type-utils.js'
+import {
+  ShallowDehydrateObject,
+  ShallowDehydrateValue,
+  Simplify,
+} from '../util/type-utils.js'
 
 /**
  * A MySQL helper for aggregating a subquery into a JSON array.
@@ -56,7 +60,7 @@ import { Simplify } from '../util/type-utils.js'
  */
 export function jsonArrayFrom<O>(
   expr: SelectQueryBuilderExpression<O>,
-): RawBuilder<Simplify<O>[]> {
+): RawBuilder<Simplify<ShallowDehydrateObject<O>>[]> {
   return sql`(select cast(coalesce(json_arrayagg(json_object(${sql.join(
     getMysqlJsonObjectArgs(expr.toOperationNode(), 'agg'),
   )})), '[]') as json) from ${expr} as agg)`
@@ -114,7 +118,7 @@ export function jsonArrayFrom<O>(
  */
 export function jsonObjectFrom<O>(
   expr: SelectQueryBuilderExpression<O>,
-): RawBuilder<Simplify<O> | null> {
+): RawBuilder<Simplify<ShallowDehydrateObject<O>> | null> {
   return sql`(select json_object(${sql.join(
     getMysqlJsonObjectArgs(expr.toOperationNode(), 'obj'),
   )}) from ${expr} as obj)`
@@ -164,7 +168,9 @@ export function jsonBuildObject<O extends Record<string, Expression<unknown>>>(
   obj: O,
 ): RawBuilder<
   Simplify<{
-    [K in keyof O]: O[K] extends Expression<infer V> ? V : never
+    [K in keyof O]: O[K] extends Expression<infer V>
+      ? ShallowDehydrateValue<V>
+      : never
   }>
 > {
   return sql`json_object(${sql.join(

--- a/src/helpers/postgres.ts
+++ b/src/helpers/postgres.ts
@@ -1,7 +1,11 @@
 import { Expression } from '../expression/expression.js'
 import { RawBuilder } from '../raw-builder/raw-builder.js'
 import { sql } from '../raw-builder/sql.js'
-import { Simplify } from '../util/type-utils.js'
+import {
+  ShallowDehydrateValue,
+  ShallowDehydrateObject,
+  Simplify,
+} from '../util/type-utils.js'
 
 /**
  * A postgres helper for aggregating a subquery (or other expression) into a JSONB array.
@@ -54,7 +58,7 @@ import { Simplify } from '../util/type-utils.js'
  */
 export function jsonArrayFrom<O>(
   expr: Expression<O>,
-): RawBuilder<Simplify<O>[]> {
+): RawBuilder<Simplify<ShallowDehydrateObject<O>>[]> {
   return sql`(select coalesce(json_agg(agg), '[]') from ${expr} as agg)`
 }
 
@@ -111,7 +115,7 @@ export function jsonArrayFrom<O>(
  */
 export function jsonObjectFrom<O>(
   expr: Expression<O>,
-): RawBuilder<Simplify<O> | null> {
+): RawBuilder<Simplify<ShallowDehydrateObject<O>> | null> {
   return sql`(select to_json(obj) from ${expr} as obj)`
 }
 
@@ -162,7 +166,9 @@ export function jsonBuildObject<O extends Record<string, Expression<unknown>>>(
   obj: O,
 ): RawBuilder<
   Simplify<{
-    [K in keyof O]: O[K] extends Expression<infer V> ? V : never
+    [K in keyof O]: O[K] extends Expression<infer V>
+      ? ShallowDehydrateValue<V>
+      : never
   }>
 > {
   return sql`json_build_object(${sql.join(

--- a/src/helpers/sqlite.ts
+++ b/src/helpers/sqlite.ts
@@ -4,7 +4,11 @@ import { SelectQueryBuilderExpression } from '../query-builder/select-query-buil
 import { RawBuilder } from '../raw-builder/raw-builder.js'
 import { sql } from '../raw-builder/sql.js'
 import { getJsonObjectArgs } from '../util/json-object-args.js'
-import { Simplify } from '../util/type-utils.js'
+import {
+  ShallowDehydrateObject,
+  ShallowDehydrateValue,
+  Simplify,
+} from '../util/type-utils.js'
 
 /**
  * A SQLite helper for aggregating a subquery into a JSON array.
@@ -69,7 +73,7 @@ import { Simplify } from '../util/type-utils.js'
  */
 export function jsonArrayFrom<O>(
   expr: SelectQueryBuilderExpression<O>,
-): RawBuilder<Simplify<O>[]> {
+): RawBuilder<Simplify<ShallowDehydrateObject<O>>[]> {
   return sql`(select coalesce(json_group_array(json_object(${sql.join(
     getSqliteJsonObjectArgs(expr.toOperationNode(), 'agg'),
   )})), '[]') from ${expr} as agg)`
@@ -140,7 +144,7 @@ export function jsonArrayFrom<O>(
  */
 export function jsonObjectFrom<O>(
   expr: SelectQueryBuilderExpression<O>,
-): RawBuilder<Simplify<O> | null> {
+): RawBuilder<Simplify<ShallowDehydrateObject<O>> | null> {
   return sql`(select json_object(${sql.join(
     getSqliteJsonObjectArgs(expr.toOperationNode(), 'obj'),
   )}) from ${expr} as obj)`
@@ -206,7 +210,9 @@ export function jsonBuildObject<O extends Record<string, Expression<unknown>>>(
   obj: O,
 ): RawBuilder<
   Simplify<{
-    [K in keyof O]: O[K] extends Expression<infer V> ? V : never
+    [K in keyof O]: O[K] extends Expression<infer V>
+      ? ShallowDehydrateValue<V>
+      : never
   }>
 > {
   return sql`json_object(${sql.join(

--- a/src/index.ts
+++ b/src/index.ts
@@ -236,6 +236,9 @@ export {
   SqlBool,
   Nullable,
   NotNull,
+  ShallowDehydrateObject,
+  ShallowDehydrateValue,
+  StringsWhenDataTypeNotAvailable,
 } from './util/type-utils.js'
 export * from './util/infer-result.js'
 export { logOnce } from './util/log-once.js'

--- a/src/query-builder/function-module.ts
+++ b/src/query-builder/function-module.ts
@@ -18,7 +18,11 @@ import {
 } from '../parser/reference-parser.js'
 import { parseSelectAll } from '../parser/select-parser.js'
 import { KyselyTypeError } from '../util/type-error.js'
-import { IsNever } from '../util/type-utils.js'
+import {
+  IsNever,
+  ShallowDehydrateObject,
+  ShallowDehydrateValue,
+} from '../util/type-utils.js'
 import { AggregateFunctionBuilder } from './aggregate-function-builder.js'
 import { SelectQueryBuilderExpression } from '../query-builder/select-query-builder-expression.js'
 import { isString } from '../util/object-utils.js'
@@ -716,9 +720,9 @@ export interface FunctionModule<DB, TB extends keyof DB> {
     DB,
     TB,
     T extends TB
-      ? Selectable<DB[T]>[]
+      ? ShallowDehydrateObject<Selectable<DB[T]>>[]
       : T extends Expression<infer O>
-        ? O[]
+        ? ShallowDehydrateObject<O>[]
         : never
   >
 
@@ -727,7 +731,7 @@ export interface FunctionModule<DB, TB extends keyof DB> {
   ): AggregateFunctionBuilder<
     DB,
     TB,
-    ExtractTypeFromStringReference<DB, TB, RE>[] | null
+    ShallowDehydrateValue<ExtractTypeFromStringReference<DB, TB, RE>>[] | null
   >
 
   /**
@@ -755,7 +759,11 @@ export interface FunctionModule<DB, TB extends keyof DB> {
   ): ExpressionWrapper<
     DB,
     TB,
-    T extends TB ? Selectable<DB[T]> : T extends Expression<infer O> ? O : never
+    T extends TB
+      ? ShallowDehydrateObject<Selectable<DB[T]>>
+      : T extends Expression<infer O>
+        ? ShallowDehydrateObject<O>
+        : never
   >
 }
 

--- a/src/query-builder/function-module.ts
+++ b/src/query-builder/function-module.ts
@@ -28,7 +28,7 @@ import { AggregateFunctionBuilder } from './aggregate-function-builder.js'
 import { SelectQueryBuilderExpression } from '../query-builder/select-query-builder-expression.js'
 import { isString } from '../util/object-utils.js'
 import { parseTable } from '../parser/table-parser.js'
-import { Selectable } from '../util/column-type.js'
+import { Selectable, SelectType } from '../util/column-type.js'
 
 /**
  * Helpers for type safe SQL function calls.
@@ -732,7 +732,10 @@ export interface FunctionModule<DB, TB extends keyof DB> {
   ): AggregateFunctionBuilder<
     DB,
     TB,
-    ShallowDehydrateValue<ExtractTypeFromStringReference<DB, TB, RE>>[] | null
+    | ShallowDehydrateValue<
+        SelectType<ExtractTypeFromStringReference<DB, TB, RE>>
+      >[]
+    | null
   >
 
   /**

--- a/src/query-builder/function-module.ts
+++ b/src/query-builder/function-module.ts
@@ -22,6 +22,7 @@ import {
   IsNever,
   ShallowDehydrateObject,
   ShallowDehydrateValue,
+  Simplify,
 } from '../util/type-utils.js'
 import { AggregateFunctionBuilder } from './aggregate-function-builder.js'
 import { SelectQueryBuilderExpression } from '../query-builder/select-query-builder-expression.js'
@@ -720,9 +721,9 @@ export interface FunctionModule<DB, TB extends keyof DB> {
     DB,
     TB,
     T extends TB
-      ? ShallowDehydrateObject<Selectable<DB[T]>>[]
+      ? Simplify<ShallowDehydrateObject<Selectable<DB[T]>>>[]
       : T extends Expression<infer O>
-        ? ShallowDehydrateObject<O>[]
+        ? Simplify<ShallowDehydrateObject<O>>[]
         : never
   >
 
@@ -760,9 +761,9 @@ export interface FunctionModule<DB, TB extends keyof DB> {
     DB,
     TB,
     T extends TB
-      ? ShallowDehydrateObject<Selectable<DB[T]>>
+      ? Simplify<ShallowDehydrateObject<Selectable<DB[T]>>>
       : T extends Expression<infer O>
-        ? ShallowDehydrateObject<O>
+        ? Simplify<ShallowDehydrateObject<O>>
         : never
   >
 }

--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -218,3 +218,28 @@ export type DrainOuterGeneric<T> = [T] extends [unknown] ? T : never
 export type ShallowRecord<K extends keyof any, T> = DrainOuterGeneric<{
   [P in K]: T
 }>
+
+/**
+ * Dehydrates any root properties of an object that are not valid JSON types.
+ *
+ * For now, we catch anything in {@link StringsWhenDataTypeNotAvailable} and convert it to `string`.
+ */
+export type ShallowDehydrateObject<O> = {
+  [K in keyof O]: ShallowDehydrateValue<O[K]>
+}
+
+/**
+ * Dehydrates a value when it is not a valid JSON type.
+ *
+ * For now, we catch anything in {@link StringsWhenDataTypeNotAvailable} and convert it to `string`.
+ */
+export type ShallowDehydrateValue<T> =
+  T extends Exclude<T, StringsWhenDataTypeNotAvailable>
+    ? T
+    : string | Exclude<T, StringsWhenDataTypeNotAvailable>
+
+export type StringsWhenDataTypeNotAvailable =
+  | ArrayBuffer
+  | bigint
+  | Buffer
+  | Date

--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -233,8 +233,9 @@ export type ShallowDehydrateObject<O> = {
  *
  * For now, we catch anything in {@link StringsWhenDataTypeNotAvailable} and convert it to `string`.
  */
-export type ShallowDehydrateValue<T> =
-  T extends Exclude<T, StringsWhenDataTypeNotAvailable>
+export type ShallowDehydrateValue<T> = T extends (infer U)[] | null | undefined
+  ? ShallowDehydrateValue<U>[] | Extract<T, null | undefined>
+  : T extends Exclude<T, StringsWhenDataTypeNotAvailable>
     ? T
     : string | Exclude<T, StringsWhenDataTypeNotAvailable>
 

--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -233,8 +233,10 @@ export type ShallowDehydrateObject<O> = {
  *
  * For now, we catch anything in {@link StringsWhenDataTypeNotAvailable} and convert it to `string`.
  */
-export type ShallowDehydrateValue<T> = T extends (infer U)[] | null | undefined
-  ? ShallowDehydrateValue<U>[] | Extract<T, null | undefined>
+export type ShallowDehydrateValue<T> = [T] extends [
+  (infer U)[] | null | undefined,
+]
+  ? Array<ShallowDehydrateValue<U>> | Extract<T, null | undefined>
   : T extends Exclude<T, StringsWhenDataTypeNotAvailable>
     ? T
     : string | Exclude<T, StringsWhenDataTypeNotAvailable>

--- a/test/typings/test-d/postgres-json.test-d.ts
+++ b/test/typings/test-d/postgres-json.test-d.ts
@@ -155,7 +155,7 @@ async function testPostgresJsonAgg(db: Kysely<Database>) {
               }),
             )
             .filterWhere('transaction.id', 'is not', null),
-          sql`'[]'`,
+          sql<[]>`'[]'`,
         )
         .as('transactions'),
     ])


### PR DESCRIPTION
Hey :wave:

closes #482.

We're going for a shallow approach - no recursion:

1. Recursion would be very expensive at compile time.

1. JSON results of nested JSON helpers should already be covered by their return type calculation.

1. If you have JSON columns, you should have already defined them properly - no JS/Node native, JSON invalid, types in their `SelectType`.

1. PostgreSQL arrays are in the scope of this change. e.g. a `timestamp[]` column would be `string[]`, not `Date[]`.

Typings test seems to be running for same amount of time. 😬 

Will add some more cases tomorrow.