### PR TITLE
refactor: remove redundant `queryId` args.

### DIFF
--- a/src/query-builder/delete-query-builder.ts
+++ b/src/query-builder/delete-query-builder.ts
@@ -1059,10 +1059,7 @@ export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
   async execute(): Promise<SimplifyResult<O>[]> {
     const compiledQuery = this.compile()
 
-    const result = await this.#props.executor.executeQuery<O>(
-      compiledQuery,
-      this.#props.queryId,
-    )
+    const result = await this.#props.executor.executeQuery<O>(compiledQuery)
 
     const { adapter } = this.#props.executor
     const query = compiledQuery.query as DeleteQueryNode
@@ -1115,11 +1112,7 @@ export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
   async *stream(chunkSize: number = 100): AsyncIterableIterator<O> {
     const compiledQuery = this.compile()
 
-    const stream = this.#props.executor.stream<O>(
-      compiledQuery,
-      chunkSize,
-      this.#props.queryId,
-    )
+    const stream = this.#props.executor.stream<O>(compiledQuery, chunkSize)
 
     for await (const item of stream) {
       yield* item.rows

--- a/src/query-builder/insert-query-builder.ts
+++ b/src/query-builder/insert-query-builder.ts
@@ -1292,10 +1292,7 @@ export class InsertQueryBuilder<DB, TB extends keyof DB, O>
   async execute(): Promise<SimplifyResult<O>[]> {
     const compiledQuery = this.compile()
 
-    const result = await this.#props.executor.executeQuery<O>(
-      compiledQuery,
-      this.#props.queryId,
-    )
+    const result = await this.#props.executor.executeQuery<O>(compiledQuery)
 
     const { adapter } = this.#props.executor
     const query = compiledQuery.query as InsertQueryNode
@@ -1353,11 +1350,7 @@ export class InsertQueryBuilder<DB, TB extends keyof DB, O>
   async *stream(chunkSize: number = 100): AsyncIterableIterator<O> {
     const compiledQuery = this.compile()
 
-    const stream = this.#props.executor.stream<O>(
-      compiledQuery,
-      chunkSize,
-      this.#props.queryId,
-    )
+    const stream = this.#props.executor.stream<O>(compiledQuery, chunkSize)
 
     for await (const item of stream) {
       yield* item.rows

--- a/src/query-builder/merge-query-builder.ts
+++ b/src/query-builder/merge-query-builder.ts
@@ -883,10 +883,7 @@ export class WheneableMergeQueryBuilder<
   async execute(): Promise<SimplifyResult<O>[]> {
     const compiledQuery = this.compile()
 
-    const result = await this.#props.executor.executeQuery<O>(
-      compiledQuery,
-      this.#props.queryId,
-    )
+    const result = await this.#props.executor.executeQuery<O>(compiledQuery)
 
     const { adapter } = this.#props.executor
     const query = compiledQuery.query as MergeQueryNode

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -2650,10 +2650,7 @@ class SelectQueryBuilderImpl<DB, TB extends keyof DB, O>
   async execute(): Promise<Simplify<O>[]> {
     const compiledQuery = this.compile()
 
-    const result = await this.#props.executor.executeQuery<O>(
-      compiledQuery,
-      this.#props.queryId,
-    )
+    const result = await this.#props.executor.executeQuery<O>(compiledQuery)
 
     return result.rows
   }
@@ -2684,11 +2681,7 @@ class SelectQueryBuilderImpl<DB, TB extends keyof DB, O>
   async *stream(chunkSize: number = 100): AsyncIterableIterator<O> {
     const compiledQuery = this.compile()
 
-    const stream = this.#props.executor.stream<O>(
-      compiledQuery,
-      chunkSize,
-      this.#props.queryId,
-    )
+    const stream = this.#props.executor.stream<O>(compiledQuery, chunkSize)
 
     for await (const item of stream) {
       yield* item.rows

--- a/src/query-builder/update-query-builder.ts
+++ b/src/query-builder/update-query-builder.ts
@@ -1148,10 +1148,7 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
   async execute(): Promise<SimplifyResult<O>[]> {
     const compiledQuery = this.compile()
 
-    const result = await this.#props.executor.executeQuery<O>(
-      compiledQuery,
-      this.#props.queryId,
-    )
+    const result = await this.#props.executor.executeQuery<O>(compiledQuery)
 
     const { adapter } = this.#props.executor
     const query = compiledQuery.query as UpdateQueryNode
@@ -1209,11 +1206,7 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
   async *stream(chunkSize: number = 100): AsyncIterableIterator<O> {
     const compiledQuery = this.compile()
 
-    const stream = this.#props.executor.stream<O>(
-      compiledQuery,
-      chunkSize,
-      this.#props.queryId,
-    )
+    const stream = this.#props.executor.stream<O>(compiledQuery, chunkSize)
 
     for await (const item of stream) {
       yield* item.rows

--- a/src/query-executor/query-executor-base.ts
+++ b/src/query-executor/query-executor-base.ts
@@ -60,10 +60,7 @@ export abstract class QueryExecutorBase implements QueryExecutor {
     consumer: (connection: DatabaseConnection) => Promise<T>,
   ): Promise<T>
 
-  async executeQuery<R>(
-    compiledQuery: CompiledQuery,
-    queryId: QueryId,
-  ): Promise<QueryResult<R>> {
+  async executeQuery<R>(compiledQuery: CompiledQuery): Promise<QueryResult<R>> {
     return await this.provideConnection(async (connection) => {
       const result = await connection.executeQuery(compiledQuery)
 
@@ -73,14 +70,13 @@ export abstract class QueryExecutorBase implements QueryExecutor {
         )
       }
 
-      return await this.#transformResult(result, queryId)
+      return await this.#transformResult(result, compiledQuery.queryId)
     })
   }
 
   async *stream<R>(
     compiledQuery: CompiledQuery,
     chunkSize: number,
-    queryId: QueryId,
   ): AsyncIterableIterator<QueryResult<R>> {
     const { connection, release } = await provideControlledConnection(this)
 
@@ -89,7 +85,7 @@ export abstract class QueryExecutorBase implements QueryExecutor {
         compiledQuery,
         chunkSize,
       )) {
-        yield await this.#transformResult(result, queryId)
+        yield await this.#transformResult(result, compiledQuery.queryId)
       }
     } finally {
       release()

--- a/src/query-executor/query-executor.ts
+++ b/src/query-executor/query-executor.ts
@@ -44,10 +44,7 @@ export interface QueryExecutor extends ConnectionProvider {
    * Executes a compiled query and runs the result through all plugins'
    * `transformResult` method.
    */
-  executeQuery<R>(
-    compiledQuery: CompiledQuery<R>,
-    queryId: QueryId,
-  ): Promise<QueryResult<R>>
+  executeQuery<R>(compiledQuery: CompiledQuery<R>): Promise<QueryResult<R>>
 
   /**
    * Executes a compiled query and runs the result through all plugins'
@@ -61,7 +58,6 @@ export interface QueryExecutor extends ConnectionProvider {
      * only by the postgres driver.
      */
     chunkSize: number,
-    queryId: QueryId,
   ): AsyncIterableIterator<QueryResult<R>>
 
   /**

--- a/src/raw-builder/raw-builder.ts
+++ b/src/raw-builder/raw-builder.ts
@@ -190,10 +190,7 @@ class RawBuilderImpl<O> implements RawBuilder<O> {
   ): Promise<QueryResult<O>> {
     const executor = this.#getExecutor(executorProvider)
 
-    return executor.executeQuery<O>(
-      this.#compile(executor),
-      this.#props.queryId,
-    )
+    return executor.executeQuery<O>(this.#compile(executor))
   }
 
   #getExecutor(executorProvider?: QueryExecutorProvider): QueryExecutor {

--- a/src/schema/alter-table-add-foreign-key-constraint-builder.ts
+++ b/src/schema/alter-table-add-foreign-key-constraint-builder.ts
@@ -97,7 +97,7 @@ export class AlterTableAddForeignKeyConstraintBuilder
   }
 
   async execute(): Promise<void> {
-    await this.#props.executor.executeQuery(this.compile(), this.#props.queryId)
+    await this.#props.executor.executeQuery(this.compile())
   }
 }
 

--- a/src/schema/alter-table-add-index-builder.ts
+++ b/src/schema/alter-table-add-index-builder.ts
@@ -214,7 +214,7 @@ export class AlterTableAddIndexBuilder
   }
 
   async execute(): Promise<void> {
-    await this.#props.executor.executeQuery(this.compile(), this.#props.queryId)
+    await this.#props.executor.executeQuery(this.compile())
   }
 }
 

--- a/src/schema/alter-table-builder.ts
+++ b/src/schema/alter-table-builder.ts
@@ -504,7 +504,7 @@ export class AlterTableColumnAlteringBuilder
   }
 
   async execute(): Promise<void> {
-    await this.#props.executor.executeQuery(this.compile(), this.#props.queryId)
+    await this.#props.executor.executeQuery(this.compile())
   }
 }
 

--- a/src/schema/alter-table-drop-constraint-builder.ts
+++ b/src/schema/alter-table-drop-constraint-builder.ts
@@ -81,7 +81,7 @@ export class AlterTableDropConstraintBuilder
   }
 
   async execute(): Promise<void> {
-    await this.#props.executor.executeQuery(this.compile(), this.#props.queryId)
+    await this.#props.executor.executeQuery(this.compile())
   }
 }
 

--- a/src/schema/alter-table-executor.ts
+++ b/src/schema/alter-table-executor.ts
@@ -28,7 +28,7 @@ export class AlterTableExecutor implements OperationNodeSource, Compilable {
   }
 
   async execute(): Promise<void> {
-    await this.#props.executor.executeQuery(this.compile(), this.#props.queryId)
+    await this.#props.executor.executeQuery(this.compile())
   }
 }
 

--- a/src/schema/create-index-builder.ts
+++ b/src/schema/create-index-builder.ts
@@ -301,7 +301,7 @@ export class CreateIndexBuilder<C = never>
   }
 
   async execute(): Promise<void> {
-    await this.#props.executor.executeQuery(this.compile(), this.#props.queryId)
+    await this.#props.executor.executeQuery(this.compile())
   }
 }
 

--- a/src/schema/create-schema-builder.ts
+++ b/src/schema/create-schema-builder.ts
@@ -43,7 +43,7 @@ export class CreateSchemaBuilder implements OperationNodeSource, Compilable {
   }
 
   async execute(): Promise<void> {
-    await this.#props.executor.executeQuery(this.compile(), this.#props.queryId)
+    await this.#props.executor.executeQuery(this.compile())
   }
 }
 

--- a/src/schema/create-table-builder.ts
+++ b/src/schema/create-table-builder.ts
@@ -530,7 +530,7 @@ export class CreateTableBuilder<TB extends string, C extends string = never>
   }
 
   async execute(): Promise<void> {
-    await this.#props.executor.executeQuery(this.compile(), this.#props.queryId)
+    await this.#props.executor.executeQuery(this.compile())
   }
 }
 

--- a/src/schema/create-type-builder.ts
+++ b/src/schema/create-type-builder.ts
@@ -52,7 +52,7 @@ export class CreateTypeBuilder implements OperationNodeSource, Compilable {
   }
 
   async execute(): Promise<void> {
-    await this.#props.executor.executeQuery(this.compile(), this.#props.queryId)
+    await this.#props.executor.executeQuery(this.compile())
   }
 }
 

--- a/src/schema/create-view-builder.ts
+++ b/src/schema/create-view-builder.ts
@@ -117,7 +117,7 @@ export class CreateViewBuilder implements OperationNodeSource, Compilable {
   }
 
   async execute(): Promise<void> {
-    await this.#props.executor.executeQuery(this.compile(), this.#props.queryId)
+    await this.#props.executor.executeQuery(this.compile())
   }
 }
 

--- a/src/schema/drop-index-builder.ts
+++ b/src/schema/drop-index-builder.ts
@@ -68,7 +68,7 @@ export class DropIndexBuilder implements OperationNodeSource, Compilable {
   }
 
   async execute(): Promise<void> {
-    await this.#props.executor.executeQuery(this.compile(), this.#props.queryId)
+    await this.#props.executor.executeQuery(this.compile())
   }
 }
 

--- a/src/schema/drop-schema-builder.ts
+++ b/src/schema/drop-schema-builder.ts
@@ -54,7 +54,7 @@ export class DropSchemaBuilder implements OperationNodeSource, Compilable {
   }
 
   async execute(): Promise<void> {
-    await this.#props.executor.executeQuery(this.compile(), this.#props.queryId)
+    await this.#props.executor.executeQuery(this.compile())
   }
 }
 

--- a/src/schema/drop-table-builder.ts
+++ b/src/schema/drop-table-builder.ts
@@ -54,7 +54,7 @@ export class DropTableBuilder implements OperationNodeSource, Compilable {
   }
 
   async execute(): Promise<void> {
-    await this.#props.executor.executeQuery(this.compile(), this.#props.queryId)
+    await this.#props.executor.executeQuery(this.compile())
   }
 }
 

--- a/src/schema/drop-type-builder.ts
+++ b/src/schema/drop-type-builder.ts
@@ -45,7 +45,7 @@ export class DropTypeBuilder implements OperationNodeSource, Compilable {
   }
 
   async execute(): Promise<void> {
-    await this.#props.executor.executeQuery(this.compile(), this.#props.queryId)
+    await this.#props.executor.executeQuery(this.compile())
   }
 }
 

--- a/src/schema/drop-view-builder.ts
+++ b/src/schema/drop-view-builder.ts
@@ -63,7 +63,7 @@ export class DropViewBuilder implements OperationNodeSource, Compilable {
   }
 
   async execute(): Promise<void> {
-    await this.#props.executor.executeQuery(this.compile(), this.#props.queryId)
+    await this.#props.executor.executeQuery(this.compile())
   }
 }
 

--- a/src/schema/refresh-materialized-view-builder.ts
+++ b/src/schema/refresh-materialized-view-builder.ts
@@ -88,7 +88,7 @@ export class RefreshMaterializedViewBuilder
   }
 
   async execute(): Promise<void> {
-    await this.#props.executor.executeQuery(this.compile(), this.#props.queryId)
+    await this.#props.executor.executeQuery(this.compile())
   }
 }
 


### PR DESCRIPTION
Hey :wave:

This PR does some cleanup. `queryId` has been recently added to `CompiledQuery`, but a bunch of places still accept both a `CompiledQuery` and a `queryId` which is redundant.

There's only 1 user-facing place this occurs, and instead of removing the arg, we keep it as optional and log a deprecation message.