### PR TITLE
Fix fn.any to support ColumnType references

### DIFF
--- a/src/query-builder/function-module.ts
+++ b/src/query-builder/function-module.ts
@@ -655,7 +655,7 @@ export interface FunctionModule<DB, TB extends keyof DB> {
   any<RE extends StringReference<DB, TB>>(
     expr: RE,
   ): Exclude<
-    ExtractTypeFromStringReference<DB, TB, RE>,
+    ExtractTypeFromReferenceExpression<DB, TB, RE>,
     null
   > extends ReadonlyArray<infer I>
     ? ExpressionWrapper<DB, TB, I>


### PR DESCRIPTION
Closes #1519 

## Summary
Fixes `fn.any` function to properly handle columns defined with `ColumnType<T[]>`.

Previously, using `fn.any` with `ColumnType` columns would result in:
KyselyTypeError<"any(expr) call failed: expr must be an array">

## Problem
The issue occurred because `fn.any` was using `ExtractTypeFromStringReference` which returns
the raw `ColumnType` structure, but the array type check expected the actual select type.

## Solution
Changed to use `ExtractTypeFromReferenceExpression` which properly extracts the `SelectType`
from `ColumnType`, similar to how other functions like `max`/`min` handle it.

## Example
```typescript
interface PersonTable {
  id: Generated<number>;
  ids: ColumnType<number[] | null>;
}

// This now works without type errors
const rows = await db
  .selectFrom("person")
  .select(["first_name"])
  .where((eb) => eb("id", "=", eb.fn.any("ids"))) // ✅ Fixed!
  .execute();

Changes

- Fixed: fn.any type definition in src/query-builder/function-module.ts
- Added: Comprehensive test cases for ColumnType with fn.any

Testing

- ✅ Added failing test case that reproduces the issue
- ✅ Verified tests fail before the fix
- ✅ Verified tests pass after the fix
- ✅ All existing type tests still pass
- ✅ Code formatting and linting passed