### PR TITLE
chore(ci): pr comment typescript benchmark results.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -273,6 +273,8 @@ jobs:
 
   typescript-benchmarks:
     name: TypeScript Benchmarks
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:
@@ -291,7 +293,32 @@ jobs:
         run: pnpm install
 
       - name: Run benchmarks
-        run: pnpm bench:ts
+        id: bench
+        run: |
+          echo "summary<<EOF" >> $GITHUB_OUTPUT
+          pnpm bench:ts | grep -v "> " | sed '/./,$!d' | tee -a $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Calculate output hash
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
+        id: hash
+        env:
+          SUMMARY_OUTPUT: ${{ steps.bench.outputs.summary }}
+        run: echo "sha=$(echo -n "$SUMMARY_OUTPUT" | shasum -a 256 | awk '{print $1}')" >> $GITHUB_OUTPUT
+
+      - name: PR comment
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # 3.0.1
+        with:
+          comment-tag: ${{ steps.hash.outputs.sha }}
+          message: |
+            <details>
+            <summary>⏱️ TypeScript Benchmarks</summary>
+
+            ```
+            ${{ steps.bench.outputs.summary }}
+            ```
+            </details>
 
   typescript-native:
     name: TypeScript Native

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -303,10 +303,11 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # 3.0.1
         with:
+          # edits the existing pr comment if exists. github ui allows checking edit history.
           comment-tag: typescript-benchmarks
           message: |
             <details>
-            <summary>⏱️ TypeScript Benchmarks</summary>
+            <summary>⏱️ TypeScript Benchmarks following ${{ github.event.pull_request.head.sha }}</summary>
 
             ```
             ${{ steps.bench.outputs.summary }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -299,18 +299,11 @@ jobs:
           pnpm bench:ts | grep -v "> " | sed '/./,$!d' | tee -a $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Calculate output hash
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
-        id: hash
-        env:
-          SUMMARY_OUTPUT: ${{ steps.bench.outputs.summary }}
-        run: echo "sha=$(echo -n "$SUMMARY_OUTPUT" | shasum -a 256 | awk '{print $1}')" >> $GITHUB_OUTPUT
-
       - name: PR comment
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # 3.0.1
         with:
-          comment-tag: ${{ steps.hash.outputs.sha }}
+          comment-tag: typescript-benchmarks
           message: |
             <details>
             <summary>⏱️ TypeScript Benchmarks</summary>

--- a/test/ts-benchmarks/order-by.bench.ts
+++ b/test/ts-benchmarks/order-by.bench.ts
@@ -37,7 +37,7 @@ bench('kysely..orderBy(column)', () =>
 bench('kysely..orderBy(~column)', () =>
   // @ts-expect-error
   query.orderBy('col_164b7896ec8e770207febe0812c5f052_'),
-).types([365, 'instantiations'])
+).types([364, 'instantiations'])
 
 bench('kysely..orderBy(O)', () => query.orderBy('e862ca')).types([
   118,
@@ -51,7 +51,7 @@ bench('kysely..orderBy(column, asc)', () =>
 bench('kysely..orderBy(~column, asc)', () =>
   // @ts-expect-error
   query.orderBy('col_164b7896ec8e770207febe0812c5f052_', 'asc'),
-).types([183, 'instantiations'])
+).types([182, 'instantiations'])
 
 bench('kysely..orderBy(column, ~asc)', () =>
   // @ts-expect-error
@@ -70,7 +70,7 @@ bench('kysely..orderBy(column, ob)', async () =>
 
 bench('kysely..orderBy(sql)', () =>
   query.orderBy(sql`col_164b7896ec8e770207febe0812c5f052 asc nulls first`),
-).types([146, 'instantiations'])
+).types([145, 'instantiations'])
 
 bench('kysely..orderBy(select)', () =>
   query.orderBy(
@@ -92,15 +92,15 @@ bench('kysely..orderBy(eb => select)', () =>
       )
       .limit(1),
   ),
-).types([882, 'instantiations'])
+).types([890, 'instantiations'])
 
 bench('deprecated - kysely..orderBy(column desc)', () =>
   query.orderBy('col_164b7896ec8e770207febe0812c5f052 desc'),
-).types([346, 'instantiations'])
+).types([345, 'instantiations'])
 
 bench('deprecated - kysely..orderBy([column])', () =>
   query.orderBy(['col_164b7896ec8e770207febe0812c5f052']),
-).types([307, 'instantiations'])
+).types([306, 'instantiations'])
 
 bench('kysely..orderBy(column).orderBy(column)', () =>
   query
@@ -113,7 +113,7 @@ bench('deprecated - kysely..orderBy([column, column])', () =>
     'col_164b7896ec8e770207febe0812c5f052',
     'col_6f7a0a5f582c69dd4c6be0a819e862cb',
   ]),
-).types([307, 'instantiations'])
+).types([306, 'instantiations'])
 
 bench('kysely..orderBy(column).orderBy(column, desc)', () =>
   query
@@ -126,7 +126,7 @@ bench('deprecated - kysely..orderBy([column, column desc])', () =>
     'col_6f7a0a5f582c69dd4c6be0a819e862cb',
     'col_164b7896ec8e770207febe0812c5f052 desc',
   ]),
-).types([307, 'instantiations'])
+).types([306, 'instantiations'])
 
 bench('kysely..orderBy(column).orderBy(column).orderBy(column)', () =>
   query
@@ -141,7 +141,7 @@ bench('deprecated - kysely..orderBy([column, column, column])', () =>
     'col_6f7a0a5f582c69dd4c6be0a819e862cb',
     'col_af4e225b70a9bbd83cc3bc0e7ef24cfa',
   ]),
-).types([307, 'instantiations'])
+).types([306, 'instantiations'])
 
 //
 
@@ -183,7 +183,7 @@ bench('kyselyAny..orderBy(column, ob)', async () =>
 
 bench('kyselyAny..orderBy(sql)', () =>
   queryAny.orderBy(sql`col_164b7896ec8e770207febe0812c5f052 asc nulls first`),
-).types([146, 'instantiations'])
+).types([145, 'instantiations'])
 
 bench('kyselyAny..orderBy(select)', () =>
   queryAny.orderBy(
@@ -203,4 +203,4 @@ bench('kyselyAny..orderBy(eb => select)', () =>
       .select('col_164b7896ec8e770207febe0812c5f052')
       .limit(1),
   ),
-).types([538, 'instantiations'])
+).types([537, 'instantiations'])


### PR DESCRIPTION
Hey 👋 

This PR adds some CI steps to TypeScript benchmarks job, to PR comment the results. This only works when the changes are pushed from this repository, not from a fork.