### PR TITLE
fix: `Buffer` breaking `ShallowDehydrateValue` in non-Node.js TypeScript environments.

### DIFF
--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -250,7 +250,12 @@ export type ShallowDehydrateValue<T> = T extends null | undefined
             ? never
             : string)
 
-export type StringsWhenDataTypeNotAvailable = Date | Buffer | ArrayBuffer
+export type StringsWhenDataTypeNotAvailable =
+  | Date
+  // Many Node.js drivers return `Buffer` by default for some column data types.
+  // Buffer is a subclass of `Uint8Array`. `Buffer` doesn't exist in non-Node TypeScript
+  // environments - and results in `any` or a compilation error if used.
+  | Uint8Array
 
 export type NumbersWhenDataTypeNotAvailable = bigint | NumericString
 

--- a/test/typings/test-d/postgres-json.test-d.ts
+++ b/test/typings/test-d/postgres-json.test-d.ts
@@ -46,6 +46,7 @@ async function testPostgresJsonSelects(db: Kysely<Database>) {
         modified_at: eb.ref('modified_at'),
         people_with_same_name_by_2050: sql<bigint>`custom_function(first_name)`,
         people_with_same_name_by_2050_str: sql<NumericString>`custom_function(first_name)::text`,
+        binary_thing: sql<Buffer>`another_custom_function()`,
       }).as('name'),
 
     // Nest other people with same first name.
@@ -90,6 +91,7 @@ async function testPostgresJsonSelects(db: Kysely<Database>) {
         modified_at: string
         people_with_same_name_by_2050: number
         people_with_same_name_by_2050_str: number
+        binary_thing: string
       }
       people_same_first_name: {
         id: number


### PR DESCRIPTION
Hey :wave:

Spotted in Discord, with a Bun project. Usage of `Buffer` was breaking types and causing results of JSON helpers to infer all `any` or `string` JSON prop types.

`Buffer` is a Node.js thing. It doesn't exist in the Bun types by default.

`Buffer` is returned by many Node.js database drivers for binary columns. It becomes a `string` when referenced in JSON result columns.

Luckily, `Buffer` is a subclass of `Uint8Array`, which is JavaScript-native. We can use it instead of `Buffer` to represent it and translate `Buffer` to `string`.