### PR TITLE
fix: filter schemas the current user does not have access to in postres introspector

### DIFF
--- a/src/dialect/postgres/postgres-introspector.ts
+++ b/src/dialect/postgres/postgres-introspector.ts
@@ -75,6 +75,8 @@ export class PostgresIntrospector implements DatabaseIntrospector {
       .where('ns.nspname', '!=', 'information_schema')
       // Filter out internal cockroachdb schema
       .where('ns.nspname', '!=', 'crdb_internal')
+      // Only schemas where we are allowed access
+      .where(sql<boolean>`has_schema_privilege(ns.nspname, 'USAGE')`)
       // No system columns
       .where('a.attnum', '>=', 0)
       .where('a.attisdropped', '!=', true)


### PR DESCRIPTION
Fixes #1537.
The issue was that the current `PostgresIntrospector` tries to query information from all tables from all schemas except for `pg_*` schemas, `information_shema` and `crdb_internal` schema for CockroachDB.

This adds a check to filter out any schemas that the current user/connection does not have access to.