### PR TITLE
feat(docs): applying google fonts optimization.

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -57,11 +57,7 @@ export default {
     ],
     [
       'vercel-analytics',
-      {
-        debug: true,
-        id: 'vercel-analytics',
-        mode: 'auto',
-      } satisfies VercelAnalyticsPluginOptions,
+      { debug: true, mode: 'auto' } satisfies VercelAnalyticsPluginOptions,
     ],
   ],
   presets: [

--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -57,7 +57,11 @@ export default {
     ],
     [
       'vercel-analytics',
-      { debug: true, mode: 'auto' } satisfies VercelAnalyticsPluginOptions,
+      {
+        debug: true,
+        id: 'vercel-analytics',
+        mode: 'auto',
+      } satisfies VercelAnalyticsPluginOptions,
     ],
   ],
   presets: [
@@ -174,6 +178,32 @@ export default {
       ],
       style: 'dark',
     },
+    headTags: [
+      {
+        attributes: {
+          href: 'https://fonts.googleapis.com',
+          rel: 'preconnect',
+        },
+        tagName: 'link',
+      },
+      {
+        attributes: {
+          crossOrigin: 'anonymous',
+          href: 'https://fonts.gstatic.com',
+          rel: 'preconnect',
+        },
+        tagName: 'link',
+      },
+      {
+        attributes: {
+          as: 'style',
+          onLoad: "this.onload=null;this.rel='stylesheet'",
+          href: 'https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;1,100;1,200;1,300;1,400;1,500;1,600;1,700&display=swap',
+          rel: 'preload',
+        },
+        tagName: 'link',
+      },
+    ],
     mermaid: {
       options: {
         sequence: {

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;1,100;1,200;1,300;1,400;1,500;1,600;1,700&display=swap');
-
 /**
  * Any CSS included here will be global. The classic template
  * bundles Infima by default. Infima is a CSS framework designed to


### PR DESCRIPTION
Hey 👋 

This is what co-pilot understood:

This pull request updates how the Poppins font is loaded in the Docusaurus site. Instead of importing the font directly in the CSS, the font is now preloaded and preconnected via `headTags` in the Docusaurus config for improved performance and better loading practices.

**Font loading improvements:**

* Added `headTags` in `site/docusaurus.config.ts` to preconnect to Google Fonts and preload the Poppins stylesheet, optimizing font loading and performance.
* Removed the direct `@import` of the Poppins font from `site/src/css/custom.css`, as font loading is now handled via the config.