### PR TITLE
fix(dialect/mysql): compatibility with mysql2@3.14.5

### DIFF
--- a/src/dialect/mysql/mysql-dialect-config.ts
+++ b/src/dialect/mysql/mysql-dialect-config.ts
@@ -56,7 +56,7 @@ export interface MysqlPoolConnection {
 
 export interface MysqlStreamOptions {
   highWaterMark?: number
-  objectMode?: boolean
+  objectMode?: true
 }
 
 export interface MysqlStream<T> {


### PR DESCRIPTION
mysql2 have updated their types, which causes types issues: https://github.com/sidorares/node-mysql2/pull/3784


For searchability:

```
src/dialect.ts(7,5): error TS2322: Type 'Pool' is not assignable to type 'MysqlPool | (() => Promise<MysqlPool>)'.
  Type 'Pool' is not assignable to type 'MysqlPool'.
    Types of property 'getConnection' are incompatible.
      Type '(callback: (err: ErrnoException | null, connection: PoolConnection) => any) => void' is not assignable to type '(callback: (error: unknown, connection: MysqlPoolConnection) => void) => void'.
        Types of parameters 'callback' and 'callback' are incompatible.
          Types of parameters 'connection' and 'connection' are incompatible.
            Type 'PoolConnection' is not assignable to type 'MysqlPoolConnection'.
              Types of property 'query' are incompatible.
                Type '{ <T extends QueryResult>(sql: string, callback?: ((err: QueryError | null, result: T, fields: FieldPacket[]) => any) | undefined): Query; <T extends QueryResult>(sql: string, values: any, callback?: ((err: QueryError | null, result: T, fields: FieldPacket[]) => any) | undefined): Query; <T extends QueryResult>(opti...' is not assignable to type '{ (sql: string, parameters: readonly unknown[]): { stream: <T>(options: MysqlStreamOptions) => MysqlStream<T>; }; (sql: string, parameters: readonly unknown[], callback: (error: unknown, result: MysqlQueryResult) => void): void; }'.
                  Types of parameters 'callback' and 'parameters' are incompatible.
                    Type 'readonly unknown[]' is not assignable to type '(err: QueryError | null, result: any, fields: FieldPacket[]) => any'.
                      Type 'readonly unknown[]' provides no match for the signature '(err: QueryError | null, result: any, fields: FieldPacket[]): any'.
```