### PR TITLE
fix(ExpressionBuilder): improper custom operator support in `eb()`.

### DIFF
--- a/src/expression/expression-builder.ts
+++ b/src/expression/expression-builder.ts
@@ -183,7 +183,11 @@ export interface ExpressionBuilder<DB, TB extends keyof DB> {
     TB,
     OP extends ComparisonOperator
       ? SqlBool
-      : ExtractTypeFromReferenceExpression<DB, TB, RE>
+      : OP extends Expression<infer T>
+        ? unknown extends T
+          ? SqlBool
+          : T
+        : ExtractTypeFromReferenceExpression<DB, TB, RE>
   >
 
   /**
@@ -1164,7 +1168,11 @@ export function createExpressionBuilder<DB, TB extends keyof DB>(
     TB,
     OP extends ComparisonOperator
       ? SqlBool
-      : ExtractTypeFromReferenceExpression<DB, TB, RE>
+      : OP extends Expression<infer T>
+        ? unknown extends T
+          ? SqlBool
+          : T
+        : ExtractTypeFromReferenceExpression<DB, TB, RE>
   > {
     return new ExpressionWrapper(parseValueBinaryOperation(lhs, op, rhs))
   }

--- a/test/typings/test-d/expression.test-d.ts
+++ b/test/typings/test-d/expression.test-d.ts
@@ -12,6 +12,7 @@ import {
   Kysely,
   SqlBool,
   expressionBuilder,
+  sql,
 } from '..'
 import { KyselyTypeError } from '../../../dist/cjs/util/type-error'
 import { Database } from '../shared'
@@ -38,6 +39,11 @@ async function testExpressionBuilder(
 ) {
   // Binary expression
   expectAssignable<Expression<number>>(eb('age', '+', 1))
+  expectAssignable<Expression<SqlBool>>(eb('age', '=', 1))
+  expectAssignable<Expression<SqlBool>>(eb('age', sql`OP`, 1))
+  expectAssignable<Expression<SqlBool>>(eb('age', sql<SqlBool>`OP`, 1))
+  expectAssignable<Expression<number>>(eb('age', sql<number>`OP`, 1))
+  expectAssignable<Expression<string>>(eb('age', sql<string>`OP`, 1))
 
   // `not` expression
   expectAssignable<Expression<SqlBool>>(eb.not(eb('age', '>', 10)))


### PR DESCRIPTION
Hey :wave:

closes #891.

This PR makes it so that the following is assignable to `Expression<SqlBool>`:

```ts
eb('age', sql`OP`, 1)
```

Where before it would inherit the type from the first argument, and fail when it was not assignable to `SqlBool` in common contexts.

This was also true when explicitly providing the custom operator a return type.

So now, as an experiment, we'll allow you to dictate the binary expression's return type:

```ts
expectAssignable<Expression<SqlBool>>(eb('age', sql<SqlBool>`OP`, 1)) 
expectAssignable<Expression<number>>(eb('age', sql<number>`OP`, 1))
expectAssignable<Expression<string>>(eb('age', sql<string>`OP`, 1))
```