### PR TITLE
fix: auto rollback only if transaction begun.

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,9 +10,6 @@ ignoredBuiltDependencies:
 
 minimumReleaseAge: 1440 # install package versions that are at least 1 day old (in minutes).
 
-minimumReleaseAgeExclude:
-  - '@types/node'
-
 # `postinstall` allow list
 onlyBuiltDependencies:
   - better-sqlite3

--- a/src/driver/driver.ts
+++ b/src/driver/driver.ts
@@ -34,15 +34,6 @@ export interface Driver {
   commitTransaction(connection: DatabaseConnection): Promise<void>
 
   /**
-   * Tells {@link TransactionBuilder} whether a transaction has begun in the database
-   * for the given connection.
-   *
-   * This is only useful if {@link beginTransaction} can fail after beginning a
-   * transaction. In such cases we still need to try and rollback the transaction.
-   */
-  hasBegunTransaction?(connection: DatabaseConnection): boolean
-
-  /**
    * Rolls back a transaction.
    */
   rollbackTransaction(connection: DatabaseConnection): Promise<void>

--- a/src/driver/driver.ts
+++ b/src/driver/driver.ts
@@ -34,6 +34,15 @@ export interface Driver {
   commitTransaction(connection: DatabaseConnection): Promise<void>
 
   /**
+   * Tells {@link TransactionBuilder} whether a transaction has begun in the database
+   * for the given connection.
+   *
+   * This is only useful if {@link beginTransaction} can fail after beginning a
+   * transaction. In such cases we still need to try and rollback the transaction.
+   */
+  hasBegunTransaction?(connection: DatabaseConnection): boolean
+
+  /**
    * Rolls back a transaction.
    */
   rollbackTransaction(connection: DatabaseConnection): Promise<void>

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -769,7 +769,10 @@ export class TransactionBuilder<DB> {
 
         return result
       } catch (error) {
-        if (transactionBegun) {
+        if (
+          transactionBegun ||
+          this.#props.driver.hasBegunTransaction?.(connection)
+        ) {
           await this.#props.driver.rollbackTransaction(connection)
         }
 

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -769,10 +769,7 @@ export class TransactionBuilder<DB> {
 
         return result
       } catch (error) {
-        if (
-          transactionBegun ||
-          this.#props.driver.hasBegunTransaction?.(connection)
-        ) {
+        if (transactionBegun) {
           await this.#props.driver.rollbackTransaction(connection)
         }
 

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -758,14 +758,21 @@ export class TransactionBuilder<DB> {
         executor,
       })
 
+      let transactionBegun = false
       try {
         await this.#props.driver.beginTransaction(connection, settings)
+        transactionBegun = true
+
         const result = await callback(transaction)
+
         await this.#props.driver.commitTransaction(connection)
 
         return result
       } catch (error) {
-        await this.#props.driver.rollbackTransaction(connection)
+        if (transactionBegun) {
+          await this.#props.driver.rollbackTransaction(connection)
+        }
+
         throw error
       }
     })


### PR DESCRIPTION
Hey :wave:

closes #952.

This PR ensures `rollbackTransaction` is only called if `beginTransaction` was successful with a simple flag.