### PR TITLE
fix: Missing parens around insert & update CTEs in merge query

### DIFF
--- a/src/operation-node/insert-query-node.ts
+++ b/src/operation-node/insert-query-node.ts
@@ -32,6 +32,7 @@ export interface InsertQueryNode extends OperationNode {
   readonly endModifiers?: ReadonlyArray<OperationNode>
   readonly top?: TopNode
   readonly output?: OutputNode
+  readonly mergeThen?: boolean
 }
 
 /**

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -430,6 +430,7 @@ export class OperationNodeTransformer {
       defaultValues: node.defaultValues,
       top: this.transformNode(node.top, queryId),
       output: this.transformNode(node.output, queryId),
+      mergeThen: node.mergeThen,
     })
   }
 
@@ -598,6 +599,7 @@ export class OperationNodeTransformer {
       top: this.transformNode(node.top, queryId),
       output: this.transformNode(node.output, queryId),
       orderBy: this.transformNode(node.orderBy, queryId),
+      mergeThen: node.mergeThen,
     })
   }
 

--- a/src/operation-node/update-query-node.ts
+++ b/src/operation-node/update-query-node.ts
@@ -30,6 +30,7 @@ export interface UpdateQueryNode extends OperationNode {
   readonly top?: TopNode
   readonly output?: OutputNode
   readonly orderBy?: OrderByNode
+  readonly mergeThen?: boolean
 }
 
 /**
@@ -53,9 +54,10 @@ export const UpdateQueryNode = freeze({
     })
   },
 
-  createWithoutTable(): UpdateQueryNode {
+  createWithoutTable(props?: Partial<UpdateQueryNode>): UpdateQueryNode {
     return freeze({
       kind: 'UpdateQueryNode',
+      ...props,
     })
   },
 

--- a/src/query-builder/merge-query-builder.ts
+++ b/src/query-builder/merge-query-builder.ts
@@ -1069,7 +1069,7 @@ export class MatchedThenableMergeQueryBuilder<
             new UpdateQueryBuilder({
               queryId: this.#props.queryId,
               executor: NOOP_QUERY_EXECUTOR,
-              queryNode: UpdateQueryNode.createWithoutTable(),
+              queryNode: UpdateQueryNode.createWithoutTable({ mergeThen: true }),
             }) as QB,
           ),
         ),
@@ -1229,6 +1229,7 @@ export class NotMatchedThenableMergeQueryBuilder<
           InsertQueryNode.cloneWith(InsertQueryNode.createWithoutInto(), {
             columns,
             values,
+            mergeThen: true,
           }),
         ),
       ),

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -308,7 +308,7 @@ export class DefaultQueryCompiler
       this.append(' ')
     }
 
-    if (isSubQuery && !MergeQueryNode.is(rootQueryNode)) {
+    if (isSubQuery && !node.mergeThen) {
       this.append('(')
     }
 
@@ -378,7 +378,7 @@ export class DefaultQueryCompiler
       this.visitNode(node.returning)
     }
 
-    if (isSubQuery && !MergeQueryNode.is(rootQueryNode)) {
+    if (isSubQuery && !node.mergeThen) {
       this.append(')')
     }
 
@@ -798,7 +798,7 @@ export class DefaultQueryCompiler
       this.append(' ')
     }
 
-    if (isSubQuery && !MergeQueryNode.is(rootQueryNode)) {
+    if (isSubQuery && !node.mergeThen) {
       this.append('(')
     }
 
@@ -866,7 +866,7 @@ export class DefaultQueryCompiler
       this.visitNode(node.returning)
     }
 
-    if (isSubQuery && !MergeQueryNode.is(rootQueryNode)) {
+    if (isSubQuery && !node.mergeThen) {
       this.append(')')
     }
 


### PR DESCRIPTION
Fixes missing parens around insert & update CTEs in merge query - [example](https://kyse.link/#cN4IgpgJglgLg9gJwM4gFyhgTwA5jSKAW20RgAJgyBxMAOzAQEMZIyBfMgMwTkLIB0QAa0xIwAG0yCA3P1pywADxIJyUWiwSdGAYzBkAIs0YAjRmIpyyXOHCSoyAMVtIAKqfFhZta2eQOAIUZkdxNPbzY5BWVSMnVNbT0nF1DPSx84iAcaeiYWCAAeWgBXQhMGAD5va05bBxKyhgio+hjVOI0GRP0gkI99YCtM7LoGZkgi0vKEKrlI2hAAGhAAR2KGTHxGAHdGWDIIEyGAOm3YAAsACkExcUFFskvDgEoyAF4Kg5Nj27AdGEcPEI1xAtTsgmezxOZxgV0ExWwEHujxe70+h2OCIg41SYBBYKQEJ+YBg+NsyIAjAAmADMkOhFxB6kJSxRJleHy+x2ZDBgAEkNHAyeCQM9jgA3RjidZIS6UMEOak09j0jLHQgMADmYAF8BBfhZULVxSQ6k1TNoLIelwAVnB1BzPnb1Mc4LRXAh1pdVdZTuc6ABZZg6f0Qb0nWF0AxwABycFhZvDaqUf2KLG93hAbGW0Clfxg+BISBgmoQYBQyxEt026BAWFw+BgjE1SxAtEYGvw4oADMcqQAOY40rNsIA).

Merge query has two types of subqueries - CTEs and "THEN" actions. CTEs should be are always wrapped in parens when "THEN" actions should not.
To differentiate them I added `mergeThen` flag in `InsertQueryNode` and `UpdateQueryNode` which is enabled for "THEN" actions. When insert and update nodes are rendered they use this flag instead of checking if root query is merge.