### PR TITLE
[WIP] Add more options to CamelCasePlugin

### DIFF
--- a/test/node/src/camel-case-plugin.test.ts
+++ b/test/node/src/camel-case-plugin.test.ts
@@ -1,0 +1,119 @@
+import {
+  CamelCasePlugin,
+  CamelCasePluginOptions,
+  createQueryId,
+  CreateTableNode,
+} from '../../..'
+import { expect } from './test-setup'
+
+describe('CamelCasePlugin', () => {
+  type TestCaseWithOptions = {
+    name: string
+    options?: CamelCasePluginOptions
+    schema: [source: string, expected: string][]
+    result: [source: string, expected: string][]
+  }
+  const testCaseWithOptions: TestCaseWithOptions[] = [
+    {
+      name: 'undefined',
+      options: undefined,
+      schema: [
+        ['asis', 'asis'],
+        ['fooBar', 'foo_bar'],
+        ['aFOOBar', 'a_foobar'],
+        ['_fooBar', '_foo_bar'],
+      ],
+      result: [
+        ['asis', 'asis'],
+        ['foo_bar', 'fooBar'],
+        ['a_f_o_o_bar', 'aFOOBar'],
+        ['_id', '_Id'],
+      ],
+    },
+    {
+      name: 'upperCase',
+      options: { upperCase: true },
+      schema: [
+        ['foo', 'FOO'],
+        ['fooBar', 'FOO_BAR'],
+      ],
+      result: [
+        ['asis', 'asis'],
+        ['FOO', 'foo'],
+        ['foo_bar', 'fooBar'],
+        ['FOO_BAR', 'fooBar'],
+      ],
+    },
+    {
+      name: 'underscoreBetweenUppercaseLetters',
+      options: { underscoreBetweenUppercaseLetters: true },
+      schema: [
+        ['asis', 'asis'],
+        ['fooBar', 'foo_bar'],
+        ['aFOOBar', 'a_f_o_o_bar'],
+        ['_fooBar', '_foo_bar'],
+      ],
+      result: [
+        ['asis', 'asis'],
+        ['foo_bar', 'fooBar'],
+        ['a_f_o_o_bar', 'aFOOBar'],
+      ],
+    },
+    {
+      name: 'underscoreBeforeDigits',
+      options: { underscoreBeforeDigits: true },
+      schema: [
+        ['asis', 'asis'],
+        ['fooBar', 'foo_bar'],
+        ['foo12Bar', 'foo_12_bar'],
+      ],
+      result: [
+        ['asis', 'asis'],
+        ['foo_bar', 'fooBar'],
+        ['a_f_o_o_bar', 'aFOOBar'],
+      ],
+    },
+  ]
+
+  for (const {
+    name,
+    options,
+    schema: schemaTestCases,
+    result: resultTestCases,
+  } of testCaseWithOptions) {
+    describe(`with "${name}" options`, () => {
+      const plugin = new CamelCasePlugin(options)
+
+      for (const [source, expected] of schemaTestCases) {
+        it(`should convert schema "${source}"`, () => {
+          const result = plugin.transformQuery({
+            queryId: createQueryId(),
+            node: {
+              kind: 'CreateTableNode',
+              table: {
+                kind: 'TableNode',
+                table: {
+                  kind: 'SchemableIdentifierNode',
+                  identifier: { kind: 'IdentifierNode', name: source },
+                },
+              },
+              columns: [],
+            },
+          }) as CreateTableNode
+          expect(result.table.table.identifier.name).to.equal(expected)
+        })
+      }
+
+      for (const [source, expected] of resultTestCases) {
+        it(`should convert result "${source}"`, async () => {
+          const { rows } = await plugin.transformResult({
+            queryId: createQueryId(),
+            result: { rows: [{ [source]: 123456789 }] },
+          })
+          expect(rows[0]).has.key(expected)
+          expect(rows[0][expected]).to.equal(123456789)
+        })
+      }
+    })
+  }
+})


### PR DESCRIPTION
This PR will add more properties to `CamelCasePluginOptions`:

| property | description |
| --- | --- |
| `ignoreSurroundingUnderscores?: boolean` | Ignore leading/trailing underscores, add as-is after conversion |
| `removeSurroudingUnderscores?: boolean` | Remove leading/trailing underscores before conversion |
| `customMapping?: Record<string,string>` | Provide custom conversion rule |

In case of #1627, I think `_id` -> `_Id` conversion is a bug. So What's the correct one? `_id` or `id`? When I tested a bunch of snake_case to camelCase implementations, the golden rule was to remove leading underscores(`_id` -> `id`). But it would be great if there are more options to control some opinioned behavior, since there is no standard.

Closes #1627

#### WIP

First of all, I added a test file to test CamelCasePlugin independently.
Since the maintainer might reject this approach, I haven't implemented anything yet and also haven't declared all the test cases.

