### PR TITLE
speed up assigning Transaction to a Kysely

### DIFF
--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -660,10 +660,6 @@ export type Transaction<DB> = TransactionMethods<DB> & Kysely<DB>
 
 /**
  * The methods a {@link Transaction} has on top of the {@link Kysely} ones.
- *
- * These are the members that make a transaction a transaction: the ones that
- * return another transaction rather than a plain `Kysely` instance, and the
- * ones a transaction doesn't support.
  */
 export interface TransactionMethods<DB> {
   /**

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -642,7 +642,113 @@ export class Kysely<DB>
   }
 }
 
-export class Transaction<DB> extends Kysely<DB> {
+/**
+ * A {@link Kysely} instance that runs all its queries inside a transaction.
+ *
+ * You get one from {@link Kysely.transaction} or {@link Kysely.startTransaction}.
+ *
+ * A `Transaction<DB>` can be used anywhere a `Kysely<DB>` is expected. The
+ * opposite is not true - a plain `Kysely` instance is not a transaction.
+ *
+ * This is an intersection of {@link TransactionMethods} and {@link Kysely}
+ * rather than a subclass of `Kysely` for type check performance reasons.
+ *
+ * `Transaction` is still a class at runtime, so `db instanceof Transaction`
+ * works.
+ */
+export type Transaction<DB> = TransactionMethods<DB> & Kysely<DB>
+
+/**
+ * The methods a {@link Transaction} has on top of the {@link Kysely} ones.
+ *
+ * These are the members that make a transaction a transaction: the ones that
+ * return another transaction rather than a plain `Kysely` instance, and the
+ * ones a transaction doesn't support.
+ */
+export interface TransactionMethods<DB> {
+  /**
+   * Always `true` for a transaction.
+   *
+   * The type is `true` instead of `boolean` to make `Kysely<DB>` unassignable
+   * to `Transaction<DB>` while allowing assignment the other way around.
+   */
+  readonly isTransaction: true
+
+  /**
+   * @deprecated calling the transaction method for a Transaction is not supported
+   */
+  transaction(): never
+
+  /**
+   * @deprecated calling the controlled transaction method for a Transaction is not supported
+   */
+  startTransaction(): never
+
+  /**
+   * @deprecated calling the connection method for a Transaction is not supported
+   */
+  connection(): never
+
+  /**
+   * @deprecated calling the destroy method for a Transaction is not supported
+   */
+  destroy(): never
+
+  /**
+   * Similar to {@link Kysely.withPlugin} but returns the transaction.
+   */
+  withPlugin(plugin: KyselyPlugin): Transaction<DB>
+
+  /**
+   * Similar to {@link Kysely.withoutPlugins} but returns the transaction.
+   */
+  withoutPlugins(): Transaction<DB>
+
+  /**
+   * Similar to {@link Kysely.withSchema} but returns the transaction.
+   */
+  withSchema(schema: string): Transaction<DB>
+
+  /**
+   * Similar to {@link Kysely.withTables} but returns the transaction.
+   *
+   * @deprecated use {@link $extendTables} instead.
+   */
+  withTables<T extends Record<string, Record<string, any>>>(): Transaction<
+    DrainOuterGeneric<DB & T>
+  >
+
+  /**
+   * Similar to {@link Kysely.$extendTables} but returns the transaction.
+   */
+  $extendTables<T extends Record<string, Record<string, any>>>(): Transaction<
+    DrainOuterGeneric<DB & T>
+  >
+
+  /**
+   * Similar to {@link Kysely.$omitTables} but returns the transaction.
+   */
+  $omitTables<T extends keyof DB>(): Transaction<
+    DB extends object ? Omit<DB, T> : DB
+  >
+
+  /**
+   * Similar to {@link Kysely.$pickTables} but returns the transaction.
+   */
+  $pickTables<T extends keyof DB>(): Transaction<
+    DB extends object ? Pick<DB, T> : DB
+  >
+}
+
+/**
+ * The static side of the {@link Transaction} class.
+ */
+export interface TransactionConstructor {
+  new <DB>(props: KyselyProps): Transaction<DB>
+  readonly prototype: Transaction<any>
+}
+
+class TransactionImpl<DB> extends Kysely<DB> implements TransactionMethods<DB> {
   readonly #props: KyselyProps
 
   constructor(props: KyselyProps) {
@@ -650,74 +756,50 @@ export class Transaction<DB> extends Kysely<DB> {
     this.#props = props
   }
 
-  // The return type is `true` instead of `boolean` to make Kysely<DB>
-  // unassignable to Transaction<DB> while allowing assignment the
-  // other way around.
   override get isTransaction(): true {
     return true
   }
 
-  /**
-   * @deprecated calling the transaction method for a Transaction is not supported
-   */
   override transaction(): never {
     throw new Error(
       'calling the transaction method for a Transaction is not supported',
     )
   }
 
-  /**
-   * @deprecated calling the controlled transaction method for a Transaction is not supported
-   */
   override startTransaction(): never {
     throw new Error(
       'calling the controlled transaction method for a Transaction is not supported',
     )
   }
 
-  /**
-   * @deprecated calling the connection method for a Transaction is not supported
-   */
   override connection(): never {
     throw new Error(
       'calling the connection method for a Transaction is not supported',
     )
   }
 
-  /**
-   * @deprecated calling the destroy method for a Transaction is not supported
-   */
   override destroy(): never {
     throw new Error(
       'calling the destroy method for a Transaction is not supported',
     )
   }
 
-  /**
-   * Similar to {@link Kysely.withPlugin} but returns the transaction.
-   */
   override withPlugin(plugin: KyselyPlugin): Transaction<DB> {
-    return new Transaction({
+    return new TransactionImpl({
       ...this.#props,
       executor: this.#props.executor.withPlugin(plugin),
     })
   }
 
-  /**
-   * Similar to {@link Kysely.withoutPlugins} but returns the transaction.
-   */
   override withoutPlugins(): Transaction<DB> {
-    return new Transaction({
+    return new TransactionImpl({
       ...this.#props,
       executor: this.#props.executor.withoutPlugins(),
     })
   }
 
-  /**
-   * Similar to {@link Kysely.withSchema} but returns the transaction.
-   */
   override withSchema(schema: string): Transaction<DB> {
-    return new Transaction({
+    return new TransactionImpl({
       ...this.#props,
       executor: this.#props.executor.withPluginAtFront(
         new WithSchemaPlugin(schema),
@@ -725,44 +807,32 @@ export class Transaction<DB> extends Kysely<DB> {
     })
   }
 
-  /**
-   * Similar to {@link Kysely.withTables} but returns the transaction.
-   *
-   * @deprecated use {@link $extendTables} instead.
-   */
   override withTables<
     T extends Record<string, Record<string, any>>,
   >(): Transaction<DrainOuterGeneric<DB & T>> {
-    return new Transaction({ ...this.#props })
+    return new TransactionImpl({ ...this.#props })
   }
 
-  /**
-   * Similar to {@link Kysely.$extendTables} but returns the transaction.
-   */
   override $extendTables<
     T extends Record<string, Record<string, any>>,
   >(): Transaction<DrainOuterGeneric<DB & T>> {
-    return new Transaction({ ...this.#props })
+    return new TransactionImpl({ ...this.#props })
   }
 
-  /**
-   * Similar to {@link Kysely.$omitTables} but returns the transaction.
-   */
   override $omitTables<T extends keyof DB>(): Transaction<
     DB extends object ? Omit<DB, T> : DB
   > {
-    return new Transaction({ ...this.#props })
+    return new TransactionImpl({ ...this.#props })
   }
 
-  /**
-   * Similar to {@link Kysely.$pickTables} but returns the transaction.
-   */
   override $pickTables<T extends keyof DB>(): Transaction<
     DB extends object ? Pick<DB, T> : DB
   > {
-    return new Transaction({ ...this.#props })
+    return new TransactionImpl({ ...this.#props })
   }
 }
+
+export const Transaction: TransactionConstructor = TransactionImpl
 
 export interface KyselyProps {
   readonly config: KyselyConfig
@@ -969,40 +1039,33 @@ export class ControlledTransactionBuilder<DB> {
   }
 }
 
-export class ControlledTransaction<
+/**
+ * A {@link Transaction} you commit and roll back yourself.
+ *
+ * You get one from {@link Kysely.startTransaction}. Once it is committed or
+ * rolled back it can't be used anymore - all queries will throw an error.
+ *
+ * Like {@link Transaction}, this is an intersection instead of a subclass for
+ * type check performance reasons.
+ *
+ * It is still a class at runtime so `trx instanceof ControlledTransaction` works.
+ */
+export type ControlledTransaction<
   DB,
   S extends string[] = [],
-> extends Transaction<DB> {
-  readonly #props: ControlledTransactionProps
-  readonly #compileQuery: QueryCompiler['compileQuery']
-  readonly #state: ControlledTransctionState
+> = ControlledTransactionMethods<DB, S> & Transaction<DB>
 
-  constructor(props: ControlledTransactionProps) {
-    const state = { isCommitted: false, isRolledBack: false }
-    props = {
-      ...props,
-      executor: new NotCommittedOrRolledBackAssertingExecutor(
-        props.executor,
-        state,
-      ),
-    }
-    const { connection, ...transactionProps } = props
-    super(transactionProps)
+/**
+ * The methods a {@link ControlledTransaction} has on top of the
+ * {@link Transaction} ones.
+ *
+ * @typeParam S - The names of the savepoints that are currently open, in the
+ *    order they were created.
+ */
+export interface ControlledTransactionMethods<DB, S extends string[] = []> {
+  readonly isCommitted: boolean
 
-    this.#props = freeze(props)
-    this.#state = state
-
-    const queryId = createQueryId()
-    this.#compileQuery = (node) => props.executor.compileQuery(node, queryId)
-  }
-
-  get isCommitted(): boolean {
-    return this.#state.isCommitted
-  }
-
-  get isRolledBack(): boolean {
-    return this.#state.isRolledBack
-  }
+  readonly isRolledBack: boolean
 
   /**
    * Commits the transaction.
@@ -1028,17 +1091,7 @@ export class ControlledTransaction<
    * async function doSomething(kysely: Kysely<Database>) {}
    * ```
    */
-  commit(): Command<void> {
-    assertNotCommittedOrRolledBack(this.#state)
-
-    return new Command(async (): Promise<void> => {
-      await this.#props.driver.commitTransaction(
-        this.#props.connection.connection,
-      )
-      this.#state.isCommitted = true
-      this.#props.connection.release()
-    })
-  }
+  commit(): Command<void>
 
   /**
    * Rolls back the transaction.
@@ -1064,17 +1117,7 @@ export class ControlledTransaction<
    * async function doSomething(kysely: Kysely<Database>) {}
    * ```
    */
-  rollback(): Command<void> {
-    assertNotCommittedOrRolledBack(this.#state)
-
-    return new Command(async (): Promise<void> => {
-      await this.#props.driver.rollbackTransaction(
-        this.#props.connection.connection,
-      )
-      this.#state.isRolledBack = true
-      this.#props.connection.release()
-    })
-  }
+  rollback(): Command<void>
 
   /**
    * Creates a savepoint with a given name.
@@ -1107,21 +1150,7 @@ export class ControlledTransaction<
    */
   savepoint<SN extends string>(
     savepointName: SN extends S ? never : SN,
-  ): Command<ControlledTransaction<DB, [...S, SN]>> {
-    assertNotCommittedOrRolledBack(this.#state)
-
-    return new Command(
-      async (): Promise<ControlledTransaction<DB, [...S, SN]>> => {
-        await this.#props.driver.savepoint?.(
-          this.#props.connection.connection,
-          savepointName,
-          this.#compileQuery,
-        )
-
-        return new ControlledTransaction({ ...this.#props })
-      },
-    )
-  }
+  ): Command<ControlledTransaction<DB, [...S, SN]>>
 
   /**
    * Rolls back to a savepoint with a given name.
@@ -1157,23 +1186,7 @@ export class ControlledTransaction<
     savepointName: SN,
   ): RollbackToSavepoint<S, SN> extends string[]
     ? Command<ControlledTransaction<DB, RollbackToSavepoint<S, SN>>>
-    : never {
-    assertNotCommittedOrRolledBack(this.#state)
-
-    return new Command(
-      async (): Promise<
-        ControlledTransaction<DB, RollbackToSavepoint<S, SN>>
-      > => {
-        await this.#props.driver.rollbackToSavepoint?.(
-          this.#props.connection.connection,
-          savepointName,
-          this.#compileQuery,
-        )
-
-        return new ControlledTransaction({ ...this.#props })
-      },
-    ) as never
-  }
+    : never
 
   /**
    * Releases a savepoint with a given name.
@@ -1214,6 +1227,149 @@ export class ControlledTransaction<
     savepointName: SN,
   ): ReleaseSavepoint<S, SN> extends string[]
     ? Command<ControlledTransaction<DB, ReleaseSavepoint<S, SN>>>
+    : never
+
+  withPlugin(plugin: KyselyPlugin): ControlledTransaction<DB, S>
+
+  withoutPlugins(): ControlledTransaction<DB, S>
+
+  withSchema(schema: string): ControlledTransaction<DB, S>
+
+  withTables<
+    T extends Record<string, Record<string, any>>,
+  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+
+  $extendTables<
+    T extends Record<string, Record<string, any>>,
+  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+
+  $omitTables<T extends keyof DB>(): ControlledTransaction<
+    DB extends object ? Omit<DB, T> : DB,
+    S
+  >
+
+  $pickTables<T extends keyof DB>(): ControlledTransaction<
+    DB extends object ? Pick<DB, T> : DB,
+    S
+  >
+}
+
+/**
+ * The static side of the {@link ControlledTransaction} class.
+ */
+export interface ControlledTransactionConstructor {
+  new <DB, S extends string[] = []>(
+    props: ControlledTransactionProps,
+  ): ControlledTransaction<DB, S>
+  readonly prototype: ControlledTransaction<any, any>
+}
+
+class ControlledTransactionImpl<DB, S extends string[] = []>
+  extends TransactionImpl<DB>
+  implements ControlledTransactionMethods<DB, S>
+{
+  readonly #props: ControlledTransactionProps
+  readonly #compileQuery: QueryCompiler['compileQuery']
+  readonly #state: ControlledTransctionState
+
+  constructor(props: ControlledTransactionProps) {
+    const state = { isCommitted: false, isRolledBack: false }
+    props = {
+      ...props,
+      executor: new NotCommittedOrRolledBackAssertingExecutor(
+        props.executor,
+        state,
+      ),
+    }
+    const { connection, ...transactionProps } = props
+    super(transactionProps)
+
+    this.#props = freeze(props)
+    this.#state = state
+
+    const queryId = createQueryId()
+    this.#compileQuery = (node) => props.executor.compileQuery(node, queryId)
+  }
+
+  get isCommitted(): boolean {
+    return this.#state.isCommitted
+  }
+
+  get isRolledBack(): boolean {
+    return this.#state.isRolledBack
+  }
+
+  commit(): Command<void> {
+    assertNotCommittedOrRolledBack(this.#state)
+
+    return new Command(async (): Promise<void> => {
+      await this.#props.driver.commitTransaction(
+        this.#props.connection.connection,
+      )
+      this.#state.isCommitted = true
+      this.#props.connection.release()
+    })
+  }
+
+  rollback(): Command<void> {
+    assertNotCommittedOrRolledBack(this.#state)
+
+    return new Command(async (): Promise<void> => {
+      await this.#props.driver.rollbackTransaction(
+        this.#props.connection.connection,
+      )
+      this.#state.isRolledBack = true
+      this.#props.connection.release()
+    })
+  }
+
+  savepoint<SN extends string>(
+    savepointName: SN extends S ? never : SN,
+  ): Command<ControlledTransaction<DB, [...S, SN]>> {
+    assertNotCommittedOrRolledBack(this.#state)
+
+    return new Command(
+      async (): Promise<ControlledTransaction<DB, [...S, SN]>> => {
+        await this.#props.driver.savepoint?.(
+          this.#props.connection.connection,
+          savepointName,
+          this.#compileQuery,
+        )
+
+        // The savepoint name juggling in `rollbackToSavepoint` and
+        // `releaseSavepoint` doesn't survive being related to itself with `S`
+        // instantiated as `[...S, SN]`.
+        return new ControlledTransactionImpl({ ...this.#props }) as never
+      },
+    )
+  }
+
+  rollbackToSavepoint<SN extends S[number]>(
+    savepointName: SN,
+  ): RollbackToSavepoint<S, SN> extends string[]
+    ? Command<ControlledTransaction<DB, RollbackToSavepoint<S, SN>>>
+    : never {
+    assertNotCommittedOrRolledBack(this.#state)
+
+    return new Command(
+      async (): Promise<
+        ControlledTransaction<DB, RollbackToSavepoint<S, SN>>
+      > => {
+        await this.#props.driver.rollbackToSavepoint?.(
+          this.#props.connection.connection,
+          savepointName,
+          this.#compileQuery,
+        )
+
+        return new ControlledTransactionImpl({ ...this.#props })
+      },
+    ) as never
+  }
+
+  releaseSavepoint<SN extends S[number]>(
+    savepointName: SN,
+  ): ReleaseSavepoint<S, SN> extends string[]
+    ? Command<ControlledTransaction<DB, ReleaseSavepoint<S, SN>>>
     : never {
     assertNotCommittedOrRolledBack(this.#state)
 
@@ -1225,27 +1381,27 @@ export class ControlledTransaction<
           this.#compileQuery,
         )
 
-        return new ControlledTransaction({ ...this.#props })
+        return new ControlledTransactionImpl({ ...this.#props })
       },
     ) as never
   }
 
   override withPlugin(plugin: KyselyPlugin): ControlledTransaction<DB, S> {
-    return new ControlledTransaction({
+    return new ControlledTransactionImpl({
       ...this.#props,
       executor: this.#props.executor.withPlugin(plugin),
     })
   }
 
   override withoutPlugins(): ControlledTransaction<DB, S> {
-    return new ControlledTransaction({
+    return new ControlledTransactionImpl({
       ...this.#props,
       executor: this.#props.executor.withoutPlugins(),
     })
   }
 
   override withSchema(schema: string): ControlledTransaction<DB, S> {
-    return new ControlledTransaction({
+    return new ControlledTransactionImpl({
       ...this.#props,
       executor: this.#props.executor.withPluginAtFront(
         new WithSchemaPlugin(schema),
@@ -1256,29 +1412,32 @@ export class ControlledTransaction<
   override withTables<
     T extends Record<string, Record<string, any>>,
   >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S> {
-    return new ControlledTransaction({ ...this.#props })
+    return new ControlledTransactionImpl({ ...this.#props })
   }
 
   override $extendTables<
     T extends Record<string, Record<string, any>>,
   >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S> {
-    return new ControlledTransaction({ ...this.#props })
+    return new ControlledTransactionImpl({ ...this.#props })
   }
 
   override $omitTables<T extends keyof DB>(): ControlledTransaction<
     DB extends object ? Omit<DB, T> : DB,
     S
   > {
-    return new ControlledTransaction({ ...this.#props })
+    return new ControlledTransactionImpl({ ...this.#props })
   }
 
   override $pickTables<T extends keyof DB>(): ControlledTransaction<
     DB extends object ? Pick<DB, T> : DB,
     S
   > {
-    return new ControlledTransaction({ ...this.#props })
+    return new ControlledTransactionImpl({ ...this.#props })
   }
 }
+
+export const ControlledTransaction: ControlledTransactionConstructor =
+  ControlledTransactionImpl
 
 interface ControlledTransctionState {
   isCommitted: boolean

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -1,5 +1,6 @@
 import { bench } from '@ark/attest'
 import type {
+  ControlledTransaction,
   DeleteQueryBuilder,
   ExpressionBuilder,
   Generated,
@@ -91,14 +92,6 @@ declare function acceptsNarrowMergeQueryBuilder(
   qb: WheneableMergeQueryBuilder<{ a: A; b: B }, 'a', 'a', unknown>,
 ): void
 
-// Handing a transaction to a function that takes a `Kysely` is one of the most
-// common things users do, and it is not cheap: `Transaction` and `Kysely` are
-// different generic types, so the compiler compares them member by member, and
-// `$extendTables`/`$omitTables`/`$pickTables` each return a handle over a
-// transformed `DB`, which makes that comparison recurse.
-declare const transaction: Transaction<{ a: A; b: B }>
-declare function acceptsKysely(db: Kysely<{ a: A; b: B }>): void
-
 // `MergeQueryBuilder.using()` returns a computed type, the same shape that makes
 // the join result types expensive.
 declare const wideMergeInto: MergeQueryBuilder<
@@ -119,6 +112,13 @@ declare function selectParentId(
     'parent' | 'petJoin'
   >,
 ): readonly ['parent.id']
+
+declare const plainKysely: Kysely<{ a: A; b: B }>
+declare const transaction: Transaction<{ a: A; b: B }>
+declare function acceptsKysely(db: Kysely<{ a: A; b: B }>): void
+
+declare const controlledTransaction: ControlledTransaction<{ a: A; b: B }>
+declare function acceptsTransaction(trx: Transaction<{ a: A; b: B }>): void
 
 console.log('generic.bench.ts:\n')
 
@@ -146,7 +146,7 @@ bench('select(genericSelectHelper) on a left joined query', () => {
 
 bench('DeleteQueryBuilder assignable to narrower DeleteQueryBuilder', () => {
   return acceptsNarrowDeleteQueryBuilder(wideDeleteQueryBuilder)
-}).types([10920, 'instantiations'])
+}).types([10919, 'instantiations'])
 
 bench('UpdateQueryBuilder assignable to narrower UpdateQueryBuilder', () => {
   return acceptsNarrowUpdateQueryBuilder(wideUpdateQueryBuilder)
@@ -156,10 +156,22 @@ bench('WheneableMergeQueryBuilder assignable to a narrower one', () => {
   return acceptsNarrowMergeQueryBuilder(wideMergeQueryBuilder)
 }).types([7573, 'instantiations'])
 
-bench('Transaction assignable to Kysely', () => {
-  return acceptsKysely(transaction)
-}).types([162352, 'instantiations'])
-
 bench('MergeQueryBuilder assignable to narrower MergeQueryBuilder', () => {
   return acceptsNarrowMergeInto(wideMergeInto)
 }).types([22733, 'instantiations'])
+
+bench('Kysely assignable to Kysely', () => {
+  return acceptsKysely(plainKysely)
+}).types([11784, 'instantiations'])
+
+bench('Transaction assignable to Kysely', () => {
+  return acceptsKysely(transaction)
+}).types([11832, 'instantiations'])
+
+bench('ControlledTransaction assignable to Kysely', () => {
+  return acceptsKysely(controlledTransaction)
+}).types([11846, 'instantiations'])
+
+bench('ControlledTransaction assignable to Transaction', () => {
+  return acceptsTransaction(controlledTransaction)
+}).types([330097, 'instantiations'])

--- a/test/typings/test-d/readonly.test-d.ts
+++ b/test/typings/test-d/readonly.test-d.ts
@@ -10,6 +10,7 @@ import {
   type AbortableOperationOptions,
   type ControlledTransaction,
   type ControlledTransactionBuilder,
+  type ControlledTransactionMethods,
   createQueryId,
   DeleteQueryNode,
   type InferResult,
@@ -421,14 +422,14 @@ async function testReadonlyControlledTransaction(
     | (keyof typeof tx & string)
   >(keyof(rtx))
 
+  // The table helpers only change the database, so the open savepoints are
+  // still the ones `tx` was declared with.
   expectType<
     ReadonlyControlledTransaction<
       DatabaseOf<
         ReturnType<typeof tx.$extendTables<{ moshe: { haim: true } }>>
       >,
-      SavepointsOf<
-        ReturnType<typeof tx.$extendTables<{ moshe: { haim: true } }>>
-      >
+      ['haim', 'moshe']
     >
   >(rtx.$extendTables<{ moshe: { haim: true } }>())
   expectNotDeprecated(rtx.$extendTables)
@@ -436,7 +437,7 @@ async function testReadonlyControlledTransaction(
   expectType<
     ReadonlyControlledTransaction<
       DatabaseOf<ReturnType<typeof tx.$omitTables<'person_metadata'>>>,
-      SavepointsOf<ReturnType<typeof tx.$omitTables<'person_metadata'>>>
+      ['haim', 'moshe']
     >
   >(rtx.$omitTables<'person_metadata'>())
   expectNotDeprecated(rtx.$omitTables)
@@ -444,7 +445,7 @@ async function testReadonlyControlledTransaction(
   expectType<
     ReadonlyControlledTransaction<
       DatabaseOf<ReturnType<typeof tx.$pickTables<'person_metadata'>>>,
-      SavepointsOf<ReturnType<typeof tx.$pickTables<'person_metadata'>>>
+      ['haim', 'moshe']
     >
   >(rtx.$pickTables<'person_metadata'>())
   expectNotDeprecated(rtx.$pickTables)
@@ -497,11 +498,7 @@ async function testReadonlyControlledTransaction(
 
   expectType<
     ReadonlyControlledTransaction<
-      DatabaseOf<
-        Awaited<
-          ReturnType<ReturnType<typeof tx.releaseSavepoint<'moshe'>>['execute']>
-        >
-      >,
+      Database,
       SavepointsOf<
         Awaited<
           ReturnType<ReturnType<typeof tx.releaseSavepoint<'moshe'>>['execute']>
@@ -520,13 +517,7 @@ async function testReadonlyControlledTransaction(
 
   expectType<
     ReadonlyControlledTransaction<
-      DatabaseOf<
-        Awaited<
-          ReturnType<
-            ReturnType<typeof tx.rollbackToSavepoint<'haim'>>['execute']
-          >
-        >
-      >,
+      Database,
       SavepointsOf<
         Awaited<
           ReturnType<
@@ -541,9 +532,7 @@ async function testReadonlyControlledTransaction(
 
   expectType<
     ReadonlyControlledTransaction<
-      DatabaseOf<
-        Awaited<ReturnType<ReturnType<typeof tx.savepoint<'rivka'>>['execute']>>
-      >,
+      Database,
       SavepointsOf<
         Awaited<ReturnType<ReturnType<typeof tx.savepoint<'rivka'>>['execute']>>
       >
@@ -591,14 +580,14 @@ async function testReadonlyControlledTransaction(
   expectNotDeprecated(rtx.withoutPlugins)
 }
 
-type DatabaseOf<K> = K extends
-  | Kysely<infer DB>
-  | Transaction<infer DB>
-  | ControlledTransaction<infer DB, any>
-  ? DB
-  : never
+// `Transaction` and `ControlledTransaction` are intersections, and TypeScript
+// can't infer type arguments from an intersection. Both of them contain a
+// `Kysely<DB>` to infer the database from, and the open savepoints can be
+// inferred from `ControlledTransactionMethods`.
+type DatabaseOf<K> = K extends Kysely<infer DB> ? DB : never
 
-type SavepointsOf<T> = T extends ControlledTransaction<any, infer S> ? S : never
+type SavepointsOf<T> =
+  T extends ControlledTransactionMethods<any, infer S> ? S : never
 
 declare function keyof<T>(thing: T): keyof T & string
 


### PR DESCRIPTION
It's a very common thing to have a function that takes a Kysely as an argument and then to pass in a Transaction instance.

Before this commit it was extremely slow. Like hundreds of thousands of type instantations slow, even for a trivial database.

| Case | TS | Instantiations (before → after) | Check time (before → after) |
|---|---|---|---|
| Kysely assignable to Kysely | 5.9 | 11,713 → 11,731 | 60ms → 60ms |
| | 6.0 | 11,786 → 11,804 | 60ms → 60ms |
| | 7.0 | 56,344 → 56,362 | 25ms → 25ms |
| Transaction assignable to Kysely | 5.9 | 149,117 → **11,779** | 270ms → **60ms** |
| | 6.0 | 162,354 → **11,852** | 280ms → **60ms** |
| | 7.0 | 290,374 → **56,410** | 118ms → **24ms** |
| ControlledTransaction assignable to Kysely | 5.9 | 149,342 → **11,793** | 270ms → **60ms** |
| | 6.0 | 162,579 → **11,866** | 290ms → **60ms** |
| | 7.0 | 291,279 → **56,424** | 118ms → **25ms** |
| ControlledTransaction assignable to Transaction | 5.9 | 149,354 → *316,077* | 260ms → *480ms* |
| | 6.0 | 162,591 → *330,118* | 290ms → *500ms* |
| | 7.0 | 291,315 → *338,539* | 123ms → *173ms* |

This change is debatable. It doesn't actually remove the infinite recursion (TS7 still produces more instantations) and it makes assigning `ControlledTransaction` to `Transaction` slower.

I'm fine with not merging this. Let's first see if it's possible to get rid of the recursion alltogether.