### PR TITLE
perf(types): literal-first overload tiers + check-position join validation

### DIFF
--- a/src/expression/expression-builder.ts
+++ b/src/expression/expression-builder.ts
@@ -6,6 +6,7 @@ import { SelectQueryNode } from '../operation-node/select-query-node.js'
 import {
   parseTableExpressionOrList,
   type TableExpressionOrList,
+  type ValidateAliasedTable,
   parseTable,
 } from '../parser/table-parser.js'
 import { createQueryId } from '../util/query-id.js'
@@ -292,6 +293,12 @@ export interface ExpressionBuilder<DB, TB extends keyof DB> {
    * that case Kysely typings wouldn't allow you to reference `pet.owner_id`
    * because `pet` is not joined to that query.
    */
+  selectFrom<TE extends keyof DB & string>(from: TE): SelectFrom<DB, TB, TE>
+
+  selectFrom<TE extends `${string} as ${string}`>(
+    from: TE & ValidateAliasedTable<DB, TE>,
+  ): SelectFrom<DB, TB, TE>
+
   selectFrom<TE extends TableExpressionOrList<DB, TB>>(
     from: TE,
   ): SelectFrom<DB, TB, TE>

--- a/src/parser/delete-from-parser.ts
+++ b/src/parser/delete-from-parser.ts
@@ -1,16 +1,15 @@
 import type { DeleteQueryBuilder } from '../query-builder/delete-query-builder.js'
 import type { DeleteResult } from '../query-builder/delete-result.js'
 import type { ShallowRecord } from '../util/type-utils.js'
-import type {
-  ExtractTableAlias,
-  From,
-  FromTables,
-  TableExpressionOrList,
-} from './table-parser.js'
+import type { ExtractTableAlias, From, FromTables } from './table-parser.js'
 
-export type DeleteFrom<DB, TE extends TableExpressionOrList<DB, never>> = [
+export type DeleteFrom<
+  DB,
+  // Intentionally unconstrained. Constraining this to `TableExpression`
+  // rejects the template-literal overload tiers that keep call sites off that
+  // union, and every branch below already validates `TE` on its own.
   TE,
-] extends [keyof DB]
+> = [TE] extends [keyof DB]
   ? // This branch creates a good-looking type for the most common case:
     // deleteFrom('person') --> DeleteQueryBuilder<DB, 'person', {}>.
     // ExtractTableAlias is needed for the case where DB == any. Without it:

--- a/src/parser/join-parser.ts
+++ b/src/parser/join-parser.ts
@@ -22,6 +22,23 @@ export type JoinReferenceExpression<
   AnyJoinColumn<DB, TB, TE> | AnyJoinColumnWithTable<DB, TB, TE>
 >
 
+/**
+ * Validates a join reference _in check position_ instead of in a type
+ * parameter's constraint.
+ *
+ * When `JoinReferenceExpression` is used as the constraint of `K1`/`K2`, the
+ * compiler resolves the constraint of the deferred conditionals behind it and
+ * fans `ExtractAliasFromTableExpression` out over every member of
+ * `TableExpression<DB, TB>`. Behind a non-distributive conditional the
+ * expensive type is instead evaluated once per call, with `TE` and `K`
+ * already fixed.
+ */
+export type ValidateJoinReference<DB, TB extends keyof DB, TE, K> = [
+  K,
+] extends [JoinReferenceExpression<DB, TB, TE>]
+  ? unknown
+  : never
+
 export type JoinCallbackExpression<DB, TB extends keyof DB, TE> = (
   join: JoinBuilder<From<DB, TE>, FromTables<DB, TB, TE>>,
 ) => JoinBuilder<any, any>

--- a/src/parser/select-from-parser.ts
+++ b/src/parser/select-from-parser.ts
@@ -1,16 +1,14 @@
 import type { SelectQueryBuilder } from '../query-builder/select-query-builder.js'
 import type { ShallowRecord } from '../util/type-utils.js'
-import type {
-  ExtractTableAlias,
-  From,
-  FromTables,
-  TableExpressionOrList,
-} from './table-parser.js'
+import type { ExtractTableAlias, From, FromTables } from './table-parser.js'
 
 export type SelectFrom<
   DB,
   TB extends keyof DB,
-  TE extends TableExpressionOrList<DB, TB>,
+  // Intentionally unconstrained. Constraining this to `TableExpression`
+  // rejects the template-literal overload tiers that keep call sites off that
+  // union, and every branch below already validates `TE` on its own.
+  TE,
 > = [TE] extends [keyof DB]
   ? // This branch creates a good-looking type for the most common case:
     // selectFrom('person') --> SelectQueryBuilder<DB, 'person', {}>.

--- a/src/parser/table-parser.ts
+++ b/src/parser/table-parser.ts
@@ -24,6 +24,24 @@ export type TableExpressionOrList<DB, TB extends keyof DB> =
   TableExpression<DB, TB> | ReadonlyArray<TableExpression<DB, TB>>
 
 export type SimpleTableReference<DB> = AnyAliasedTable<DB> | AnyTable<DB>
+
+/**
+ * Validates a `'table as alias'` string _in check position_ instead of in a
+ * type parameter's constraint.
+ *
+ * `AnyAliasedTable<DB>` is a union of one template literal per table, so using
+ * it as a constraint makes the compiler rebuild and renormalize a
+ * literals-plus-templates union on every call. This parses the alias once and
+ * does a single `keyof DB` lookup instead.
+ */
+export type ValidateAliasedTable<DB, TE> = [TE] extends [
+  `${infer T} as ${string}`,
+]
+  ? [T] extends [keyof DB]
+    ? unknown
+    : never
+  : never
+
 export type AnyAliasedTable<DB> = `${AnyTable<DB>} as ${string}`
 export type AnyTable<DB> = keyof DB & string
 

--- a/src/parser/update-parser.ts
+++ b/src/parser/update-parser.ts
@@ -1,16 +1,15 @@
 import type { UpdateQueryBuilder } from '../query-builder/update-query-builder.js'
 import type { UpdateResult } from '../query-builder/update-result.js'
 import type { ShallowRecord } from '../util/type-utils.js'
-import type {
-  ExtractTableAlias,
-  From,
-  FromTables,
-  TableExpressionOrList,
-} from './table-parser.js'
+import type { ExtractTableAlias, From, FromTables } from './table-parser.js'
 
-export type UpdateTable<DB, TE extends TableExpressionOrList<DB, never>> = [
+export type UpdateTable<
+  DB,
+  // Intentionally unconstrained. Constraining this to `TableExpression`
+  // rejects the template-literal overload tiers that keep call sites off that
+  // union, and every branch below already validates `TE` on its own.
   TE,
-] extends [keyof DB]
+> = [TE] extends [keyof DB]
   ? // This branch creates a good-looking type for the most common case:
     // updateTable('person') --> UpdateQueryBuilder<DB, 'person', 'person', {}>.
     // ExtractTableAlias is needed for the case where DB == any. Without it:

--- a/src/query-builder/delete-query-builder.ts
+++ b/src/query-builder/delete-query-builder.ts
@@ -3,6 +3,7 @@ import type { CompiledQuery } from '../query-compiler/compiled-query.js'
 import {
   type JoinCallbackExpression,
   type JoinReferenceExpression,
+  type ValidateJoinReference,
   parseJoin,
 } from '../parser/join-parser.js'
 import {
@@ -11,6 +12,7 @@ import {
   parseTableExpressionOrList,
   type TableExpression,
   type TableExpressionOrList,
+  type ValidateAliasedTable,
 } from '../parser/table-parser.js'
 import {
   parseSelectArg,
@@ -401,11 +403,50 @@ export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
    * on "doggos"."owner_id" = "person"."id"
    * ```
    */
+  innerJoin<TE extends keyof DB & string, K1 extends string, K2 extends string>(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): DeleteQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
+  innerJoin<
+    TE extends `${string} as ${string}`,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): DeleteQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
+  innerJoin<
+    TE extends TableExpression<DB, TB>,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): DeleteQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
   innerJoin<
     TE extends TableExpression<DB, TB>,
     K1 extends JoinReferenceExpression<DB, TB, TE>,
     K2 extends JoinReferenceExpression<DB, TB, TE>,
   >(table: TE, k1: K1, k2: K2): DeleteQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
+  innerJoin<
+    TE extends keyof DB & string,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(table: TE, callback: FN): DeleteQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
+  innerJoin<
+    TE extends `${string} as ${string}`,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    callback: FN,
+  ): DeleteQueryBuilderWithInnerJoin<DB, TB, O, TE>
 
   innerJoin<
     TE extends TableExpression<DB, TB>,
@@ -419,11 +460,50 @@ export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
   /**
    * Just like {@link innerJoin} but adds a left join instead of an inner join.
    */
+  leftJoin<TE extends keyof DB & string, K1 extends string, K2 extends string>(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): DeleteQueryBuilderWithLeftJoin<DB, TB, O, TE>
+
+  leftJoin<
+    TE extends `${string} as ${string}`,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): DeleteQueryBuilderWithLeftJoin<DB, TB, O, TE>
+
+  leftJoin<
+    TE extends TableExpression<DB, TB>,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): DeleteQueryBuilderWithLeftJoin<DB, TB, O, TE>
+
   leftJoin<
     TE extends TableExpression<DB, TB>,
     K1 extends JoinReferenceExpression<DB, TB, TE>,
     K2 extends JoinReferenceExpression<DB, TB, TE>,
   >(table: TE, k1: K1, k2: K2): DeleteQueryBuilderWithLeftJoin<DB, TB, O, TE>
+
+  leftJoin<
+    TE extends keyof DB & string,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(table: TE, callback: FN): DeleteQueryBuilderWithLeftJoin<DB, TB, O, TE>
+
+  leftJoin<
+    TE extends `${string} as ${string}`,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    callback: FN,
+  ): DeleteQueryBuilderWithLeftJoin<DB, TB, O, TE>
 
   leftJoin<
     TE extends TableExpression<DB, TB>,
@@ -437,11 +517,50 @@ export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
   /**
    * Just like {@link innerJoin} but adds a right join instead of an inner join.
    */
+  rightJoin<TE extends keyof DB & string, K1 extends string, K2 extends string>(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): DeleteQueryBuilderWithRightJoin<DB, TB, O, TE>
+
+  rightJoin<
+    TE extends `${string} as ${string}`,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): DeleteQueryBuilderWithRightJoin<DB, TB, O, TE>
+
+  rightJoin<
+    TE extends TableExpression<DB, TB>,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): DeleteQueryBuilderWithRightJoin<DB, TB, O, TE>
+
   rightJoin<
     TE extends TableExpression<DB, TB>,
     K1 extends JoinReferenceExpression<DB, TB, TE>,
     K2 extends JoinReferenceExpression<DB, TB, TE>,
   >(table: TE, k1: K1, k2: K2): DeleteQueryBuilderWithRightJoin<DB, TB, O, TE>
+
+  rightJoin<
+    TE extends keyof DB & string,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(table: TE, callback: FN): DeleteQueryBuilderWithRightJoin<DB, TB, O, TE>
+
+  rightJoin<
+    TE extends `${string} as ${string}`,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    callback: FN,
+  ): DeleteQueryBuilderWithRightJoin<DB, TB, O, TE>
 
   rightJoin<
     TE extends TableExpression<DB, TB>,
@@ -455,11 +574,50 @@ export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
   /**
    * Just like {@link innerJoin} but adds a full join instead of an inner join.
    */
+  fullJoin<TE extends keyof DB & string, K1 extends string, K2 extends string>(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): DeleteQueryBuilderWithFullJoin<DB, TB, O, TE>
+
+  fullJoin<
+    TE extends `${string} as ${string}`,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): DeleteQueryBuilderWithFullJoin<DB, TB, O, TE>
+
+  fullJoin<
+    TE extends TableExpression<DB, TB>,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): DeleteQueryBuilderWithFullJoin<DB, TB, O, TE>
+
   fullJoin<
     TE extends TableExpression<DB, TB>,
     K1 extends JoinReferenceExpression<DB, TB, TE>,
     K2 extends JoinReferenceExpression<DB, TB, TE>,
   >(table: TE, k1: K1, k2: K2): DeleteQueryBuilderWithFullJoin<DB, TB, O, TE>
+
+  fullJoin<
+    TE extends keyof DB & string,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(table: TE, callback: FN): DeleteQueryBuilderWithFullJoin<DB, TB, O, TE>
+
+  fullJoin<
+    TE extends `${string} as ${string}`,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    callback: FN,
+  ): DeleteQueryBuilderWithFullJoin<DB, TB, O, TE>
 
   fullJoin<
     TE extends TableExpression<DB, TB>,
@@ -1163,7 +1321,10 @@ export type DeleteQueryBuilderWithInnerJoin<
   DB,
   TB extends keyof DB,
   O,
-  TE extends TableExpression<DB, TB>,
+  // Intentionally unconstrained. Constraining this to `TableExpression`
+  // rejects the template-literal overload tiers that keep call sites off that
+  // union, and every branch below already validates `TE` on its own.
+  TE,
 > = TE extends `${infer T} as ${infer A}`
   ? T extends keyof DB
     ? InnerJoinedBuilder<DB, TB, O, A, DB[T]>
@@ -1195,7 +1356,10 @@ export type DeleteQueryBuilderWithLeftJoin<
   DB,
   TB extends keyof DB,
   O,
-  TE extends TableExpression<DB, TB>,
+  // Intentionally unconstrained. Constraining this to `TableExpression`
+  // rejects the template-literal overload tiers that keep call sites off that
+  // union, and every branch below already validates `TE` on its own.
+  TE,
 > = TE extends `${infer T} as ${infer A}`
   ? T extends keyof DB
     ? LeftJoinedBuilder<DB, TB, O, A, DB[T]>
@@ -1231,7 +1395,10 @@ export type DeleteQueryBuilderWithRightJoin<
   DB,
   TB extends keyof DB,
   O,
-  TE extends TableExpression<DB, TB>,
+  // Intentionally unconstrained. Constraining this to `TableExpression`
+  // rejects the template-literal overload tiers that keep call sites off that
+  // union, and every branch below already validates `TE` on its own.
+  TE,
 > = TE extends `${infer T} as ${infer A}`
   ? T extends keyof DB
     ? RightJoinedBuilder<DB, TB, O, A, DB[T]>
@@ -1271,7 +1438,10 @@ export type DeleteQueryBuilderWithFullJoin<
   DB,
   TB extends keyof DB,
   O,
-  TE extends TableExpression<DB, TB>,
+  // Intentionally unconstrained. Constraining this to `TableExpression`
+  // rejects the template-literal overload tiers that keep call sites off that
+  // union, and every branch below already validates `TE` on its own.
+  TE,
 > = TE extends `${infer T} as ${infer A}`
   ? T extends keyof DB
     ? OuterJoinedBuilder<DB, TB, O, A, DB[T]>

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -4,9 +4,14 @@ import { SelectModifierNode } from '../operation-node/select-modifier-node.js'
 import {
   type JoinCallbackExpression,
   type JoinReferenceExpression,
+  type ValidateJoinReference,
   parseJoin,
 } from '../parser/join-parser.js'
-import { type TableExpression, parseTable } from '../parser/table-parser.js'
+import {
+  type TableExpression,
+  type ValidateAliasedTable,
+  parseTable,
+} from '../parser/table-parser.js'
 import {
   parseSelectArg,
   parseSelectAll,
@@ -708,6 +713,32 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    * on "doggos"."owner" = "person"."id"
    * ```
    */
+  innerJoin<TE extends keyof DB & string, K1 extends string, K2 extends string>(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
+  innerJoin<
+    TE extends `${string} as ${string}`,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
+  innerJoin<
+    TE extends TableExpression<DB, TB>,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
   innerJoin<
     TE extends TableExpression<DB, TB>,
     K1 extends JoinReferenceExpression<DB, TB, TE>,
@@ -716,6 +747,22 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
     table: TE,
     k1: K1,
     k2: K2,
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
+  innerJoin<
+    TE extends keyof DB & string,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE,
+    callback: FN,
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
+  innerJoin<
+    TE extends `${string} as ${string}`,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    callback: FN,
   ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
 
   innerJoin<
@@ -729,6 +776,32 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
   /**
    * Just like {@link innerJoin} but adds a `left join` instead of an `inner join`.
    */
+  leftJoin<TE extends keyof DB & string, K1 extends string, K2 extends string>(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): SelectQueryBuilderWithLeftJoin<DB, TB, O, TE>
+
+  leftJoin<
+    TE extends `${string} as ${string}`,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): SelectQueryBuilderWithLeftJoin<DB, TB, O, TE>
+
+  leftJoin<
+    TE extends TableExpression<DB, TB>,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): SelectQueryBuilderWithLeftJoin<DB, TB, O, TE>
+
   leftJoin<
     TE extends TableExpression<DB, TB>,
     K1 extends JoinReferenceExpression<DB, TB, TE>,
@@ -737,6 +810,22 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
     table: TE,
     k1: K1,
     k2: K2,
+  ): SelectQueryBuilderWithLeftJoin<DB, TB, O, TE>
+
+  leftJoin<
+    TE extends keyof DB & string,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE,
+    callback: FN,
+  ): SelectQueryBuilderWithLeftJoin<DB, TB, O, TE>
+
+  leftJoin<
+    TE extends `${string} as ${string}`,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    callback: FN,
   ): SelectQueryBuilderWithLeftJoin<DB, TB, O, TE>
 
   leftJoin<
@@ -750,6 +839,32 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
   /**
    * Just like {@link innerJoin} but adds a `right join` instead of an `inner join`.
    */
+  rightJoin<TE extends keyof DB & string, K1 extends string, K2 extends string>(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): SelectQueryBuilderWithRightJoin<DB, TB, O, TE>
+
+  rightJoin<
+    TE extends `${string} as ${string}`,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): SelectQueryBuilderWithRightJoin<DB, TB, O, TE>
+
+  rightJoin<
+    TE extends TableExpression<DB, TB>,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): SelectQueryBuilderWithRightJoin<DB, TB, O, TE>
+
   rightJoin<
     TE extends TableExpression<DB, TB>,
     K1 extends JoinReferenceExpression<DB, TB, TE>,
@@ -758,6 +873,22 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
     table: TE,
     k1: K1,
     k2: K2,
+  ): SelectQueryBuilderWithRightJoin<DB, TB, O, TE>
+
+  rightJoin<
+    TE extends keyof DB & string,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE,
+    callback: FN,
+  ): SelectQueryBuilderWithRightJoin<DB, TB, O, TE>
+
+  rightJoin<
+    TE extends `${string} as ${string}`,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    callback: FN,
   ): SelectQueryBuilderWithRightJoin<DB, TB, O, TE>
 
   rightJoin<
@@ -773,6 +904,32 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    *
    * This is only supported by some dialects like PostgreSQL, MS SQL Server and SQLite.
    */
+  fullJoin<TE extends keyof DB & string, K1 extends string, K2 extends string>(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): SelectQueryBuilderWithFullJoin<DB, TB, O, TE>
+
+  fullJoin<
+    TE extends `${string} as ${string}`,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): SelectQueryBuilderWithFullJoin<DB, TB, O, TE>
+
+  fullJoin<
+    TE extends TableExpression<DB, TB>,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): SelectQueryBuilderWithFullJoin<DB, TB, O, TE>
+
   fullJoin<
     TE extends TableExpression<DB, TB>,
     K1 extends JoinReferenceExpression<DB, TB, TE>,
@@ -781,6 +938,22 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
     table: TE,
     k1: K1,
     k2: K2,
+  ): SelectQueryBuilderWithFullJoin<DB, TB, O, TE>
+
+  fullJoin<
+    TE extends keyof DB & string,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE,
+    callback: FN,
+  ): SelectQueryBuilderWithFullJoin<DB, TB, O, TE>
+
+  fullJoin<
+    TE extends `${string} as ${string}`,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    callback: FN,
   ): SelectQueryBuilderWithFullJoin<DB, TB, O, TE>
 
   fullJoin<
@@ -794,6 +967,14 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
   /**
    * Just like {@link innerJoin} but adds a `cross join` instead of an `inner join`.
    */
+  crossJoin<TE extends keyof DB & string>(
+    table: TE,
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
+  crossJoin<TE extends `${string} as ${string}`>(
+    table: TE & ValidateAliasedTable<DB, TE>,
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
   crossJoin<TE extends TableExpression<DB, TB>>(
     table: TE,
   ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
@@ -834,6 +1015,36 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    * ```
    */
   innerJoinLateral<
+    TE extends keyof DB & string,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
+  innerJoinLateral<
+    TE extends `${string} as ${string}`,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
+  innerJoinLateral<
+    TE extends TableExpression<DB, TB>,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
+  innerJoinLateral<
     TE extends TableExpression<DB, TB>,
     K1 extends JoinReferenceExpression<DB, TB, TE>,
     K2 extends JoinReferenceExpression<DB, TB, TE>,
@@ -841,6 +1052,22 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
     table: TE,
     k1: K1,
     k2: K2,
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
+  innerJoinLateral<
+    TE extends keyof DB & string,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE,
+    callback: FN,
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
+  innerJoinLateral<
+    TE extends `${string} as ${string}`,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    callback: FN,
   ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
 
   innerJoinLateral<
@@ -887,6 +1114,36 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    * ```
    */
   leftJoinLateral<
+    TE extends keyof DB & string,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): SelectQueryBuilderWithLeftJoin<DB, TB, O, TE>
+
+  leftJoinLateral<
+    TE extends `${string} as ${string}`,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): SelectQueryBuilderWithLeftJoin<DB, TB, O, TE>
+
+  leftJoinLateral<
+    TE extends TableExpression<DB, TB>,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): SelectQueryBuilderWithLeftJoin<DB, TB, O, TE>
+
+  leftJoinLateral<
     TE extends TableExpression<DB, TB>,
     K1 extends JoinReferenceExpression<DB, TB, TE>,
     K2 extends JoinReferenceExpression<DB, TB, TE>,
@@ -894,6 +1151,22 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
     table: TE,
     k1: K1,
     k2: K2,
+  ): SelectQueryBuilderWithLeftJoin<DB, TB, O, TE>
+
+  leftJoinLateral<
+    TE extends keyof DB & string,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE,
+    callback: FN,
+  ): SelectQueryBuilderWithLeftJoin<DB, TB, O, TE>
+
+  leftJoinLateral<
+    TE extends `${string} as ${string}`,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    callback: FN,
   ): SelectQueryBuilderWithLeftJoin<DB, TB, O, TE>
 
   leftJoinLateral<
@@ -938,6 +1211,14 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    * order by "first_name"
    * ```
    */
+  crossJoinLateral<TE extends keyof DB & string>(
+    table: TE,
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
+  crossJoinLateral<TE extends `${string} as ${string}`>(
+    table: TE & ValidateAliasedTable<DB, TE>,
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
   crossJoinLateral<TE extends TableExpression<DB, TB>>(
     table: TE,
   ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
@@ -976,6 +1257,14 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    * order by "first_name"
    * ```
    */
+  crossApply<TE extends keyof DB & string>(
+    table: TE,
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
+  crossApply<TE extends `${string} as ${string}`>(
+    table: TE & ValidateAliasedTable<DB, TE>,
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
+
   crossApply<TE extends TableExpression<DB, TB>>(
     table: TE,
   ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
@@ -985,6 +1274,14 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    *
    * This is only supported by some dialects like MS SQL Server.
    */
+  outerApply<TE extends keyof DB & string>(
+    table: TE,
+  ): SelectQueryBuilderWithLeftJoin<DB, TB, O, TE>
+
+  outerApply<TE extends `${string} as ${string}`>(
+    table: TE & ValidateAliasedTable<DB, TE>,
+  ): SelectQueryBuilderWithLeftJoin<DB, TB, O, TE>
+
   outerApply<TE extends TableExpression<DB, TB>>(
     table: TE,
   ): SelectQueryBuilderWithLeftJoin<DB, TB, O, TE>
@@ -2811,7 +3108,10 @@ export type SelectQueryBuilderWithInnerJoin<
   DB,
   TB extends keyof DB,
   O,
-  TE extends TableExpression<DB, TB>,
+  // Intentionally unconstrained. Constraining this to `TableExpression`
+  // rejects the template-literal overload tiers that keep call sites off that
+  // union, and every branch below already validates `TE` on its own.
+  TE,
 > =
   TableExpression<DB, TB> extends TE
     ? JoinResultForUnknownTable<O>
@@ -2846,7 +3146,10 @@ export type SelectQueryBuilderWithLeftJoin<
   DB,
   TB extends keyof DB,
   O,
-  TE extends TableExpression<DB, TB>,
+  // Intentionally unconstrained. Constraining this to `TableExpression`
+  // rejects the template-literal overload tiers that keep call sites off that
+  // union, and every branch below already validates `TE` on its own.
+  TE,
 > =
   TableExpression<DB, TB> extends TE
     ? JoinResultForUnknownTable<O>
@@ -2885,7 +3188,10 @@ export type SelectQueryBuilderWithRightJoin<
   DB,
   TB extends keyof DB,
   O,
-  TE extends TableExpression<DB, TB>,
+  // Intentionally unconstrained. Constraining this to `TableExpression`
+  // rejects the template-literal overload tiers that keep call sites off that
+  // union, and every branch below already validates `TE` on its own.
+  TE,
 > =
   TableExpression<DB, TB> extends TE
     ? JoinResultForUnknownTable<O>
@@ -2928,7 +3234,10 @@ export type SelectQueryBuilderWithFullJoin<
   DB,
   TB extends keyof DB,
   O,
-  TE extends TableExpression<DB, TB>,
+  // Intentionally unconstrained. Constraining this to `TableExpression`
+  // rejects the template-literal overload tiers that keep call sites off that
+  // union, and every branch below already validates `TE` on its own.
+  TE,
 > =
   TableExpression<DB, TB> extends TE
     ? JoinResultForUnknownTable<O>

--- a/src/query-builder/update-query-builder.ts
+++ b/src/query-builder/update-query-builder.ts
@@ -3,6 +3,7 @@ import type { CompiledQuery } from '../query-compiler/compiled-query.js'
 import {
   type JoinCallbackExpression,
   type JoinReferenceExpression,
+  type ValidateJoinReference,
   parseJoin,
 } from '../parser/join-parser.js'
 import {
@@ -11,6 +12,7 @@ import {
   type FromTables,
   parseTableExpressionOrList,
   type TableExpressionOrList,
+  type ValidateAliasedTable,
 } from '../parser/table-parser.js'
 import {
   parseSelectArg,
@@ -233,6 +235,14 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
    * where "pet"."owner_id" = "person"."id"
    * ```
    */
+  from<TE extends keyof DB & string>(
+    table: TE,
+  ): UpdateQueryBuilder<From<DB, TE>, UT, FromTables<DB, TB, TE>, O>
+
+  from<TE extends `${string} as ${string}`>(
+    table: TE & ValidateAliasedTable<DB, TE>,
+  ): UpdateQueryBuilder<From<DB, TE>, UT, FromTables<DB, TB, TE>, O>
+
   from<TE extends TableExpression<DB, TB>>(
     table: TE,
   ): UpdateQueryBuilder<From<DB, TE>, UT, FromTables<DB, TB, TE>, O>
@@ -360,6 +370,32 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
    * on "doggos"."owner_id" = "person"."id"
    * ```
    */
+  innerJoin<TE extends keyof DB & string, K1 extends string, K2 extends string>(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): UpdateQueryBuilderWithInnerJoin<DB, UT, TB, O, TE>
+
+  innerJoin<
+    TE extends `${string} as ${string}`,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): UpdateQueryBuilderWithInnerJoin<DB, UT, TB, O, TE>
+
+  innerJoin<
+    TE extends TableExpression<DB, TB>,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): UpdateQueryBuilderWithInnerJoin<DB, UT, TB, O, TE>
+
   innerJoin<
     TE extends TableExpression<DB, TB>,
     K1 extends JoinReferenceExpression<DB, TB, TE>,
@@ -368,6 +404,19 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
     table: TE,
     k1: K1,
     k2: K2,
+  ): UpdateQueryBuilderWithInnerJoin<DB, UT, TB, O, TE>
+
+  innerJoin<
+    TE extends keyof DB & string,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(table: TE, callback: FN): UpdateQueryBuilderWithInnerJoin<DB, UT, TB, O, TE>
+
+  innerJoin<
+    TE extends `${string} as ${string}`,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    callback: FN,
   ): UpdateQueryBuilderWithInnerJoin<DB, UT, TB, O, TE>
 
   innerJoin<
@@ -382,6 +431,32 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
   /**
    * Just like {@link innerJoin} but adds a left join instead of an inner join.
    */
+  leftJoin<TE extends keyof DB & string, K1 extends string, K2 extends string>(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): UpdateQueryBuilderWithLeftJoin<DB, UT, TB, O, TE>
+
+  leftJoin<
+    TE extends `${string} as ${string}`,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): UpdateQueryBuilderWithLeftJoin<DB, UT, TB, O, TE>
+
+  leftJoin<
+    TE extends TableExpression<DB, TB>,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): UpdateQueryBuilderWithLeftJoin<DB, UT, TB, O, TE>
+
   leftJoin<
     TE extends TableExpression<DB, TB>,
     K1 extends JoinReferenceExpression<DB, TB, TE>,
@@ -390,6 +465,19 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
     table: TE,
     k1: K1,
     k2: K2,
+  ): UpdateQueryBuilderWithLeftJoin<DB, UT, TB, O, TE>
+
+  leftJoin<
+    TE extends keyof DB & string,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(table: TE, callback: FN): UpdateQueryBuilderWithLeftJoin<DB, UT, TB, O, TE>
+
+  leftJoin<
+    TE extends `${string} as ${string}`,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    callback: FN,
   ): UpdateQueryBuilderWithLeftJoin<DB, UT, TB, O, TE>
 
   leftJoin<
@@ -404,6 +492,32 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
   /**
    * Just like {@link innerJoin} but adds a right join instead of an inner join.
    */
+  rightJoin<TE extends keyof DB & string, K1 extends string, K2 extends string>(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): UpdateQueryBuilderWithRightJoin<DB, UT, TB, O, TE>
+
+  rightJoin<
+    TE extends `${string} as ${string}`,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): UpdateQueryBuilderWithRightJoin<DB, UT, TB, O, TE>
+
+  rightJoin<
+    TE extends TableExpression<DB, TB>,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): UpdateQueryBuilderWithRightJoin<DB, UT, TB, O, TE>
+
   rightJoin<
     TE extends TableExpression<DB, TB>,
     K1 extends JoinReferenceExpression<DB, TB, TE>,
@@ -412,6 +526,19 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
     table: TE,
     k1: K1,
     k2: K2,
+  ): UpdateQueryBuilderWithRightJoin<DB, UT, TB, O, TE>
+
+  rightJoin<
+    TE extends keyof DB & string,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(table: TE, callback: FN): UpdateQueryBuilderWithRightJoin<DB, UT, TB, O, TE>
+
+  rightJoin<
+    TE extends `${string} as ${string}`,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    callback: FN,
   ): UpdateQueryBuilderWithRightJoin<DB, UT, TB, O, TE>
 
   rightJoin<
@@ -426,6 +553,32 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
   /**
    * Just like {@link innerJoin} but adds a full join instead of an inner join.
    */
+  fullJoin<TE extends keyof DB & string, K1 extends string, K2 extends string>(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): UpdateQueryBuilderWithFullJoin<DB, UT, TB, O, TE>
+
+  fullJoin<
+    TE extends `${string} as ${string}`,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): UpdateQueryBuilderWithFullJoin<DB, UT, TB, O, TE>
+
+  fullJoin<
+    TE extends TableExpression<DB, TB>,
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): UpdateQueryBuilderWithFullJoin<DB, UT, TB, O, TE>
+
   fullJoin<
     TE extends TableExpression<DB, TB>,
     K1 extends JoinReferenceExpression<DB, TB, TE>,
@@ -434,6 +587,19 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
     table: TE,
     k1: K1,
     k2: K2,
+  ): UpdateQueryBuilderWithFullJoin<DB, UT, TB, O, TE>
+
+  fullJoin<
+    TE extends keyof DB & string,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(table: TE, callback: FN): UpdateQueryBuilderWithFullJoin<DB, UT, TB, O, TE>
+
+  fullJoin<
+    TE extends `${string} as ${string}`,
+    const FN extends JoinCallbackExpression<DB, TB, TE>,
+  >(
+    table: TE & ValidateAliasedTable<DB, TE>,
+    callback: FN,
   ): UpdateQueryBuilderWithFullJoin<DB, UT, TB, O, TE>
 
   fullJoin<
@@ -1261,7 +1427,10 @@ export type UpdateQueryBuilderWithInnerJoin<
   UT extends keyof DB,
   TB extends keyof DB,
   O,
-  TE extends TableExpression<DB, TB>,
+  // Intentionally unconstrained. Constraining this to `TableExpression`
+  // rejects the template-literal overload tiers that keep call sites off that
+  // union, and every branch below already validates `TE` on its own.
+  TE,
 > = TE extends `${infer T} as ${infer A}`
   ? T extends keyof DB
     ? InnerJoinedBuilder<DB, UT, TB, O, A, DB[T]>
@@ -1295,7 +1464,10 @@ export type UpdateQueryBuilderWithLeftJoin<
   UT extends keyof DB,
   TB extends keyof DB,
   O,
-  TE extends TableExpression<DB, TB>,
+  // Intentionally unconstrained. Constraining this to `TableExpression`
+  // rejects the template-literal overload tiers that keep call sites off that
+  // union, and every branch below already validates `TE` on its own.
+  TE,
 > = TE extends `${infer T} as ${infer A}`
   ? T extends keyof DB
     ? LeftJoinedBuilder<DB, UT, TB, O, A, DB[T]>
@@ -1333,7 +1505,10 @@ export type UpdateQueryBuilderWithRightJoin<
   UT extends keyof DB,
   TB extends keyof DB,
   O,
-  TE extends TableExpression<DB, TB>,
+  // Intentionally unconstrained. Constraining this to `TableExpression`
+  // rejects the template-literal overload tiers that keep call sites off that
+  // union, and every branch below already validates `TE` on its own.
+  TE,
 > = TE extends `${infer T} as ${infer A}`
   ? T extends keyof DB
     ? RightJoinedBuilder<DB, UT, TB, O, A, DB[T]>
@@ -1375,7 +1550,10 @@ export type UpdateQueryBuilderWithFullJoin<
   UT extends keyof DB,
   TB extends keyof DB,
   O,
-  TE extends TableExpression<DB, TB>,
+  // Intentionally unconstrained. Constraining this to `TableExpression`
+  // rejects the template-literal overload tiers that keep call sites off that
+  // union, and every branch below already validates `TE` on its own.
+  TE,
 > = TE extends `${infer T} as ${infer A}`
   ? T extends keyof DB
     ? OuterJoinedBuilder<DB, UT, TB, O, A, DB[T]>

--- a/src/query-creator.ts
+++ b/src/query-creator.ts
@@ -14,6 +14,7 @@ import {
   parseTableExpressionOrList,
   type TableExpressionOrList,
   type SimpleTableReference,
+  type ValidateAliasedTable,
   parseAliasedTable,
 } from './parser/table-parser.js'
 import type { QueryExecutor } from './query-executor/query-executor.js'
@@ -162,6 +163,16 @@ export class QueryCreator<DB> {
    *   (select 1 as one) as "q"
    * ```
    */
+  selectFrom<TE extends keyof DB & string>(from: TE): SelectFrom<DB, never, TE>
+
+  selectFrom<TE extends `${string} as ${string}`>(
+    from: TE & ValidateAliasedTable<DB, TE>,
+  ): SelectFrom<DB, never, TE>
+
+  selectFrom<TE extends TableExpressionOrList<DB, never>>(
+    from: TE,
+  ): SelectFrom<DB, never, TE>
+
   selectFrom<TE extends TableExpressionOrList<DB, never>>(
     from: TE,
   ): SelectFrom<DB, never, TE> {
@@ -396,6 +407,16 @@ export class QueryCreator<DB> {
    * where `person`.`id` = ?
    * ```
    */
+  deleteFrom<TE extends keyof DB & string>(from: TE): DeleteFrom<DB, TE>
+
+  deleteFrom<TE extends `${string} as ${string}`>(
+    from: TE & ValidateAliasedTable<DB, TE>,
+  ): DeleteFrom<DB, TE>
+
+  deleteFrom<TE extends TableExpressionOrList<DB, never>>(
+    from: TE,
+  ): DeleteFrom<DB, TE>
+
   deleteFrom<TE extends TableExpressionOrList<DB, never>>(
     from: TE,
   ): DeleteFrom<DB, TE> {
@@ -432,6 +453,16 @@ export class QueryCreator<DB> {
    * console.log(result.numUpdatedRows)
    * ```
    */
+  updateTable<TE extends keyof DB & string>(tables: TE): UpdateTable<DB, TE>
+
+  updateTable<TE extends `${string} as ${string}`>(
+    tables: TE & ValidateAliasedTable<DB, TE>,
+  ): UpdateTable<DB, TE>
+
+  updateTable<TE extends TableExpressionOrList<DB, never>>(
+    tables: TE,
+  ): UpdateTable<DB, TE>
+
   updateTable<TE extends TableExpressionOrList<DB, never>>(
     tables: TE,
   ): UpdateTable<DB, TE> {

--- a/test/ts-benchmarks/delete-from.bench.ts
+++ b/test/ts-benchmarks/delete-from.bench.ts
@@ -11,36 +11,36 @@ bench.baseline(() => {})
 
 bench('kysely.deleteFrom(table)', () => {
   return kysely.deleteFrom('table_fff4c6195261874920bc7ce92d67d2c2')
-}).types([342, 'instantiations'])
+}).types([53, 'instantiations'])
 
 bench('kysely.deleteFrom(~table)', () => {
   // @ts-expect-error
   return kysely.deleteFrom('my_table2')
-}).types([5085, 'instantiations'])
+}).types([14579, 'instantiations'])
 
 bench('kysely.deleteFrom(table as alias)', () => {
   return kysely.deleteFrom('my_table as mt')
-}).types([356, 'instantiations'])
+}).types([150, 'instantiations'])
 
 bench('kysely.deleteFrom([table])', () => {
   return kysely.deleteFrom(['my_table'])
-}).types([379, 'instantiations'])
+}).types([467, 'instantiations'])
 
 bench('kysely.deleteFrom([~table])', () => {
   // @ts-expect-error
   return kysely.deleteFrom(['my_table2'])
-}).types([5126, 'instantiations'])
+}).types([14631, 'instantiations'])
 
 bench('kysely.deleteFrom([table as alias])', () => {
   return kysely.deleteFrom(['my_table as mt'])
-}).types([379, 'instantiations'])
+}).types([467, 'instantiations'])
 
 bench('kysely.deleteFrom([table, table])', () => {
   return kysely.deleteFrom([
     'my_table',
     'table_000a8a0cb7f265a624c851d3e7f8b946',
   ])
-}).types([379, 'instantiations'])
+}).types([467, 'instantiations'])
 
 bench('kysely.deleteFrom([table, ~table])', () => {
   return kysely.deleteFrom([
@@ -48,24 +48,24 @@ bench('kysely.deleteFrom([table, ~table])', () => {
     // @ts-expect-error
     'table_000a8a0cb7f265a624c851d3e7f8b9462',
   ])
-}).types([5129, 'instantiations'])
+}).types([14637, 'instantiations'])
 
 bench('kysely.deleteFrom([table as alias, table as alias])', () => {
   return kysely.deleteFrom([
     'my_table as mt',
     'table_000a8a0cb7f265a624c851d3e7f8b946 as t',
   ])
-}).types([379, 'instantiations'])
+}).types([467, 'instantiations'])
 
 bench('kysely.deleteFrom(kysely.selectFrom(table).as(t))', () => {
   return kysely.deleteFrom(kysely.selectFrom('my_table').as('t'))
-}).types([1263, 'instantiations'])
+}).types([579, 'instantiations'])
 
 bench('kysely.$pickTables<tables>.deleteFrom(table)', () => {
   return kysely
     .$pickTables<'table_fff4c6195261874920bc7ce92d67d2c2'>()
     .deleteFrom('table_fff4c6195261874920bc7ce92d67d2c2')
-}).types([115, 'instantiations'])
+}).types([71, 'instantiations'])
 
 bench('kysely.$pickTables<tables>.deleteFrom(~table)', () => {
   return (
@@ -74,49 +74,49 @@ bench('kysely.$pickTables<tables>.deleteFrom(~table)', () => {
       // @ts-expect-error
       .deleteFrom('my_table2')
   )
-}).types([208, 'instantiations'])
+}).types([893, 'instantiations'])
 
 bench('kyselyAny.deleteFrom(table)', () => {
   return kyselyAny.deleteFrom('table_fff4c6195261874920bc7ce92d67d2c2')
-}).types([94, 'instantiations'])
+}).types([53, 'instantiations'])
 
 bench('kyselyAny.deleteFrom(~table)', () => {
   return kyselyAny.deleteFrom('my_table2')
-}).types([94, 'instantiations'])
+}).types([53, 'instantiations'])
 
 bench('kyselyAny.deleteFrom(table as alias)', () => {
   return kyselyAny.deleteFrom('my_table as mt')
-}).types([94, 'instantiations'])
+}).types([53, 'instantiations'])
 
 bench('kyselyAny.deleteFrom([table])', () => {
   return kyselyAny.deleteFrom(['my_table'])
-}).types([131, 'instantiations'])
+}).types([221, 'instantiations'])
 
 bench('kyselyAny.deleteFrom([~table])', () => {
   return kyselyAny.deleteFrom(['my_table2'])
-}).types([131, 'instantiations'])
+}).types([221, 'instantiations'])
 
 bench('kyselyAny.deleteFrom([table as alias])', () => {
   return kyselyAny.deleteFrom(['my_table as mt'])
-}).types([131, 'instantiations'])
+}).types([221, 'instantiations'])
 
 bench('kyselyAny.deleteFrom([table, table])', () => {
   return kyselyAny.deleteFrom([
     'my_table',
     'table_000a8a0cb7f265a624c851d3e7f8b946',
   ])
-}).types([131, 'instantiations'])
+}).types([221, 'instantiations'])
 
 bench('kyselyAny.deleteFrom([table, ~table])', () => {
   return kyselyAny.deleteFrom([
     'my_table',
     'table_000a8a0cb7f265a624c851d3e7f8b9462',
   ])
-}).types([131, 'instantiations'])
+}).types([221, 'instantiations'])
 
 bench('kyselyAny.deleteFrom([table as alias, table as alias])', () => {
   return kyselyAny.deleteFrom([
     'my_table as mt',
     'table_000a8a0cb7f265a624c851d3e7f8b946 as t',
   ])
-}).types([131, 'instantiations'])
+}).types([221, 'instantiations'])

--- a/test/ts-benchmarks/delete-returning.bench.ts
+++ b/test/ts-benchmarks/delete-returning.bench.ts
@@ -17,48 +17,48 @@ bench.baseline(() => {
 
 bench('kysely.deleteFrom(table).returning(column)', () =>
   deleteQuery.returning('col_164b7896ec8e770207febe0812c5f052'),
-).types([304, 'instantiations'])
+).types([300, 'instantiations'])
 
 bench('kysely.deleteFrom(table)..returning(~column)', () =>
   // @ts-expect-error
   deleteQuery.returning('col_164b7896ec8e770207febe0812c5f052_'),
-).types([7349, 'instantiations'])
+).types([7235, 'instantiations'])
 
 bench('kysely.deleteFrom(table)..returning(table.column)', () =>
   deleteQuery.returning('my_table.col_164b7896ec8e770207febe0812c5f052'),
-).types([304, 'instantiations'])
+).types([300, 'instantiations'])
 
 bench('kysely.deleteFrom(table)..returning(~table.column)', () =>
   // @ts-expect-error
   deleteQuery.returning('my_table_.col_164b7896ec8e770207febe0812c5f052'),
-).types([7349, 'instantiations'])
+).types([7235, 'instantiations'])
 
 bench('kysely.deleteFrom(table)..returning(table.column as alias)', () =>
   deleteQuery.returning('my_table.col_164b7896ec8e770207febe0812c5f052 as foo'),
-).types([304, 'instantiations'])
+).types([300, 'instantiations'])
 
 bench('kysely.deleteFrom(table)..returning(column as alias)', () =>
   deleteQuery.returning('col_164b7896ec8e770207febe0812c5f052 as foo'),
-).types([304, 'instantiations'])
+).types([300, 'instantiations'])
 
 bench('kysely.deleteFrom(table)..returningAll()', () =>
   deleteQuery.returningAll(),
-).types([91, 'instantiations'])
+).types([87, 'instantiations'])
 
 bench('kyselyAny.deleteFrom(table)..returning(column)', () =>
   deleteQueryAny.returning('col_164b7896ec8e770207febe0812c5f052'),
-).types([238, 'instantiations'])
+).types([231, 'instantiations'])
 
 bench('kyselyAny.deleteFrom(table)..returning(table.column)', () =>
   deleteQueryAny.returning('my_table.col_164b7896ec8e770207febe0812c5f052'),
-).types([238, 'instantiations'])
+).types([231, 'instantiations'])
 
 bench('kyselyAny.deleteFrom(table)..returning(table.column as alias)', () =>
   deleteQueryAny.returning(
     'my_table.col_164b7896ec8e770207febe0812c5f052 as foo',
   ),
-).types([238, 'instantiations'])
+).types([231, 'instantiations'])
 
 bench('kyselyAny.deleteFrom(table)..returningAll()', () =>
   deleteQueryAny.returningAll(),
-).types([91, 'instantiations'])
+).types([87, 'instantiations'])

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -126,15 +126,15 @@ bench.baseline(() => {})
 
 bench('SelectQueryBuilder assignable to narrower SelectQueryBuilder', () => {
   return acceptsNarrowSelectQueryBuilder(wideSelectQueryBuilder)
-}).types([45134, 'instantiations'])
+}).types([60551, 'instantiations'])
 
 bench('ExpressionBuilder assignable to narrower ExpressionBuilder', () => {
   return acceptsNarrowExpressionBuilder(wideExpressionBuilder)
-}).types([55494, 'instantiations'])
+}).types([71074, 'instantiations'])
 
 bench('ExpressionBuilder passed to function expecting fewer tables', () => {
   return acceptsTwoTableExpressionBuilder(threeTableExpressionBuilder)
-}).types([55545, 'instantiations'])
+}).types([71125, 'instantiations'])
 
 bench('select(genericSelectHelper) on a left joined query', () => {
   return kysely
@@ -142,15 +142,15 @@ bench('select(genericSelectHelper) on a left joined query', () => {
     .leftJoin('person as personJoin', 'personJoin.parent_id', 'parent.id')
     .leftJoin('pet as petJoin', 'petJoin.owner_id', 'personJoin.id')
     .select(selectParentId)
-}).types([57871, 'instantiations'])
+}).types([72641, 'instantiations'])
 
 bench('DeleteQueryBuilder assignable to narrower DeleteQueryBuilder', () => {
   return acceptsNarrowDeleteQueryBuilder(wideDeleteQueryBuilder)
-}).types([10920, 'instantiations'])
+}).types([16728, 'instantiations'])
 
 bench('UpdateQueryBuilder assignable to narrower UpdateQueryBuilder', () => {
   return acceptsNarrowUpdateQueryBuilder(wideUpdateQueryBuilder)
-}).types([91178, 'instantiations'])
+}).types([127693, 'instantiations'])
 
 bench('WheneableMergeQueryBuilder assignable to a narrower one', () => {
   return acceptsNarrowMergeQueryBuilder(wideMergeQueryBuilder)
@@ -158,7 +158,7 @@ bench('WheneableMergeQueryBuilder assignable to a narrower one', () => {
 
 bench('Transaction assignable to Kysely', () => {
   return acceptsKysely(transaction)
-}).types([162352, 'instantiations'])
+}).types([206953, 'instantiations'])
 
 bench('MergeQueryBuilder assignable to narrower MergeQueryBuilder', () => {
   return acceptsNarrowMergeInto(wideMergeInto)

--- a/test/ts-benchmarks/group-by.bench.ts
+++ b/test/ts-benchmarks/group-by.bench.ts
@@ -39,7 +39,7 @@ bench('kysely..groupBy(sql)', () =>
 
 bench('kysely..groupBy(eb => ref)', () =>
   query.groupBy((eb) => eb.ref('col_164b7896ec8e770207febe0812c5f052')),
-).types([974, 'instantiations'])
+).types([951, 'instantiations'])
 
 bench('kysely..groupBy(column).groupBy(column)', () =>
   query

--- a/test/ts-benchmarks/having.bench.ts
+++ b/test/ts-benchmarks/having.bench.ts
@@ -17,25 +17,25 @@ bench.baseline(() => {
 
 bench('kysely..having(column, op, value)', () =>
   query.having('col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([2210, 'instantiations'])
+).types([2102, 'instantiations'])
 
 bench('kysely..having(~column, op, value)', () =>
   // @ts-expect-error
   query.having('col_1d726898491fbca9a8dac855d2be1be8_', '=', 123),
-).types([3461, 'instantiations'])
+).types([3353, 'instantiations'])
 
 bench('kysely..having(table.column, op, value)', () =>
   query.having('my_table.col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([2213, 'instantiations'])
+).types([2105, 'instantiations'])
 
 bench('kysely..having(~table.column, op, value)', () =>
   // @ts-expect-error
   query.having('my_table_.col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([3461, 'instantiations'])
+).types([3353, 'instantiations'])
 
 bench('kysely..having(column, is, null)', () =>
   query.having('col_6f5e1903664b084bf6197f2b86849d5e', 'is', null),
-).types([2216, 'instantiations'])
+).types([2108, 'instantiations'])
 
 bench('kysely..having(column, op, select)', () =>
   query.having(
@@ -46,11 +46,11 @@ bench('kysely..having(column, op, select)', () =>
       .select('t2.col_1d726898491fbca9a8dac855d2be1be8')
       .limit(1),
   ),
-).types([3329, 'instantiations'])
+).types([3078, 'instantiations'])
 
 bench('kysely..having(eb => eb(...))', () =>
   query.having((eb) => eb('col_1d726898491fbca9a8dac855d2be1be8', '=', 123)),
-).types([2799, 'instantiations'])
+).types([2691, 'instantiations'])
 
 bench('kysely..having(eb => eb.and([...]))', () =>
   query.having((eb) =>
@@ -59,7 +59,7 @@ bench('kysely..having(eb => eb.and([...]))', () =>
       eb('col_4d742b2f247bec99b41a60acbebc149a', '=', 456),
     ]),
   ),
-).types([2894, 'instantiations'])
+).types([2786, 'instantiations'])
 
 bench('kysely..having(sql`...`)', () =>
   query.having(sql<boolean>`col = 'foo'`),
@@ -86,19 +86,19 @@ bench('kysely..havingRef(~column, op, column)', () =>
 
 bench('kyselyAny..having(column, op, value)', () =>
   queryAny.having('col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([707, 'instantiations'])
+).types([709, 'instantiations'])
 
 bench('kyselyAny..having(~column, op, value)', () =>
   queryAny.having('col_1d726898491fbca9a8dac855d2be1be8_', '=', 123),
-).types([707, 'instantiations'])
+).types([709, 'instantiations'])
 
 bench('kyselyAny..having(table.column, op, value)', () =>
   queryAny.having('my_table.col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([693, 'instantiations'])
+).types([695, 'instantiations'])
 
 bench('kyselyAny..having(eb => eb(...))', () =>
   queryAny.having((eb) => eb('col_1d726898491fbca9a8dac855d2be1be8', '=', 123)),
-).types([979, 'instantiations'])
+).types([981, 'instantiations'])
 
 bench('kyselyAny..having(sql`...`)', () =>
   queryAny.having(sql<boolean>`col = 'foo'`),

--- a/test/ts-benchmarks/inner-join.bench.ts
+++ b/test/ts-benchmarks/inner-join.bench.ts
@@ -21,7 +21,7 @@ bench('kysely..innerJoin(table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([6538, 'instantiations'])
+).types([529, 'instantiations'])
 
 bench('kysely..innerJoin(~table, k1, k2)', () =>
   query.innerJoin(
@@ -30,7 +30,7 @@ bench('kysely..innerJoin(~table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([21845, 'instantiations'])
+).types([26379, 'instantiations'])
 
 bench('kysely..innerJoin(table, ~k1, k2)', () =>
   query.innerJoin(
@@ -39,7 +39,7 @@ bench('kysely..innerJoin(table, ~k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052_',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([7086, 'instantiations'])
+).types([7484, 'instantiations'])
 
 bench('kysely..innerJoin(table, k1, ~k2)', () =>
   query.innerJoin(
@@ -48,7 +48,7 @@ bench('kysely..innerJoin(table, k1, ~k2)', () =>
     // @ts-expect-error
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4_',
   ),
-).types([7089, 'instantiations'])
+).types([7513, 'instantiations'])
 
 bench('kysely..innerJoin(table as alias, k1, k2)', () =>
   query.innerJoin(
@@ -56,7 +56,7 @@ bench('kysely..innerJoin(table as alias, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     't2.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([6534, 'instantiations'])
+).types([629, 'instantiations'])
 
 bench('kysely..innerJoin(table, cb)', () =>
   query.innerJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -66,7 +66,7 @@ bench('kysely..innerJoin(table, cb)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([2246, 'instantiations'])
+).types([1793, 'instantiations'])
 
 bench('kysely..innerJoin(table, cb with ~column)', () =>
   query.innerJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -77,7 +77,7 @@ bench('kysely..innerJoin(table, cb with ~column)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([2302, 'instantiations'])
+).types([1849, 'instantiations'])
 
 //
 
@@ -87,7 +87,7 @@ bench('kyselyAny..innerJoin(table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([883, 'instantiations'])
+).types([270, 'instantiations'])
 
 bench('kyselyAny..innerJoin(~table, k1, k2)', () =>
   queryAny.innerJoin(
@@ -95,7 +95,7 @@ bench('kyselyAny..innerJoin(~table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([883, 'instantiations'])
+).types([270, 'instantiations'])
 
 bench('kyselyAny..innerJoin(table, ~k1, k2)', () =>
   queryAny.innerJoin(
@@ -103,7 +103,7 @@ bench('kyselyAny..innerJoin(table, ~k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052_',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([883, 'instantiations'])
+).types([270, 'instantiations'])
 
 bench('kyselyAny..innerJoin(table, k1, ~k2)', () =>
   queryAny.innerJoin(
@@ -111,7 +111,7 @@ bench('kyselyAny..innerJoin(table, k1, ~k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4_',
   ),
-).types([883, 'instantiations'])
+).types([270, 'instantiations'])
 
 bench('kyselyAny..innerJoin(table as alias, k1, k2)', () =>
   queryAny.innerJoin(
@@ -119,7 +119,7 @@ bench('kyselyAny..innerJoin(table as alias, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     't2.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([881, 'instantiations'])
+).types([268, 'instantiations'])
 
 bench('kyselyAny..innerJoin(table, cb)', () =>
   queryAny.innerJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -129,7 +129,7 @@ bench('kyselyAny..innerJoin(table, cb)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([1499, 'instantiations'])
+).types([1540, 'instantiations'])
 
 bench('kyselyAny..innerJoin(table, cb with ~column)', () =>
   queryAny.innerJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -139,4 +139,4 @@ bench('kyselyAny..innerJoin(table, cb with ~column)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([1499, 'instantiations'])
+).types([1540, 'instantiations'])

--- a/test/ts-benchmarks/left-join.bench.ts
+++ b/test/ts-benchmarks/left-join.bench.ts
@@ -21,7 +21,7 @@ bench('kysely..leftJoin(table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([6546, 'instantiations'])
+).types([537, 'instantiations'])
 
 bench('kysely..leftJoin(~table, k1, k2)', () =>
   query.leftJoin(
@@ -30,7 +30,7 @@ bench('kysely..leftJoin(~table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([21845, 'instantiations'])
+).types([28347, 'instantiations'])
 
 bench('kysely..leftJoin(table, ~k1, k2)', () =>
   query.leftJoin(
@@ -39,7 +39,7 @@ bench('kysely..leftJoin(table, ~k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052_',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([7094, 'instantiations'])
+).types([7492, 'instantiations'])
 
 bench('kysely..leftJoin(table, k1, ~k2)', () =>
   query.leftJoin(
@@ -48,7 +48,7 @@ bench('kysely..leftJoin(table, k1, ~k2)', () =>
     // @ts-expect-error
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4_',
   ),
-).types([7097, 'instantiations'])
+).types([7521, 'instantiations'])
 
 bench('kysely..leftJoin(table as alias, k1, k2)', () =>
   query.leftJoin(
@@ -56,7 +56,7 @@ bench('kysely..leftJoin(table as alias, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     't2.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([6534, 'instantiations'])
+).types([629, 'instantiations'])
 
 bench('kysely..leftJoin(table, cb)', () =>
   query.leftJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -66,7 +66,7 @@ bench('kysely..leftJoin(table, cb)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([2254, 'instantiations'])
+).types([1801, 'instantiations'])
 
 bench('kysely..leftJoin(table, cb with ~column)', () =>
   query.leftJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -77,7 +77,7 @@ bench('kysely..leftJoin(table, cb with ~column)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([2310, 'instantiations'])
+).types([1857, 'instantiations'])
 
 //
 
@@ -87,7 +87,7 @@ bench('kyselyAny..leftJoin(table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([891, 'instantiations'])
+).types([278, 'instantiations'])
 
 bench('kyselyAny..leftJoin(~table, k1, k2)', () =>
   queryAny.leftJoin(
@@ -95,7 +95,7 @@ bench('kyselyAny..leftJoin(~table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([891, 'instantiations'])
+).types([278, 'instantiations'])
 
 bench('kyselyAny..leftJoin(table, ~k1, k2)', () =>
   queryAny.leftJoin(
@@ -103,7 +103,7 @@ bench('kyselyAny..leftJoin(table, ~k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052_',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([891, 'instantiations'])
+).types([278, 'instantiations'])
 
 bench('kyselyAny..leftJoin(table, k1, ~k2)', () =>
   queryAny.leftJoin(
@@ -111,7 +111,7 @@ bench('kyselyAny..leftJoin(table, k1, ~k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4_',
   ),
-).types([891, 'instantiations'])
+).types([278, 'instantiations'])
 
 bench('kyselyAny..leftJoin(table as alias, k1, k2)', () =>
   queryAny.leftJoin(
@@ -119,7 +119,7 @@ bench('kyselyAny..leftJoin(table as alias, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     't2.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([881, 'instantiations'])
+).types([268, 'instantiations'])
 
 bench('kyselyAny..leftJoin(table, cb)', () =>
   queryAny.leftJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -129,7 +129,7 @@ bench('kyselyAny..leftJoin(table, cb)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([1507, 'instantiations'])
+).types([1548, 'instantiations'])
 
 bench('kyselyAny..leftJoin(table, cb with ~column)', () =>
   queryAny.leftJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -139,4 +139,4 @@ bench('kyselyAny..leftJoin(table, cb with ~column)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([1507, 'instantiations'])
+).types([1548, 'instantiations'])

--- a/test/ts-benchmarks/order-by.bench.ts
+++ b/test/ts-benchmarks/order-by.bench.ts
@@ -77,7 +77,7 @@ bench('kysely..orderBy(select)', () =>
       )
       .limit(1),
   ),
-).types([556, 'instantiations'])
+).types([308, 'instantiations'])
 
 bench('kysely..orderBy(eb => select)', () =>
   query.orderBy((eb) =>
@@ -88,7 +88,7 @@ bench('kysely..orderBy(eb => select)', () =>
       )
       .limit(1),
   ),
-).types([713, 'instantiations'])
+).types([448, 'instantiations'])
 
 bench('deprecated - kysely..orderBy(column desc)', () =>
   query.orderBy('col_164b7896ec8e770207febe0812c5f052 desc'),
@@ -199,4 +199,4 @@ bench('kyselyAny..orderBy(eb => select)', () =>
       .select('col_164b7896ec8e770207febe0812c5f052')
       .limit(1),
   ),
-).types([395, 'instantiations'])
+).types([378, 'instantiations'])

--- a/test/ts-benchmarks/select-from.bench.ts
+++ b/test/ts-benchmarks/select-from.bench.ts
@@ -11,36 +11,36 @@ bench.baseline(() => {})
 
 bench('kysely.selectFrom(table)', () => {
   return kysely.selectFrom('table_fff4c6195261874920bc7ce92d67d2c2')
-}).types([343, 'instantiations'])
+}).types([54, 'instantiations'])
 
 bench('kysely.selectFrom(~table)', () => {
   // @ts-expect-error
   return kysely.selectFrom('my_table2')
-}).types([5086, 'instantiations'])
+}).types([14680, 'instantiations'])
 
 bench('kysely.selectFrom(table as alias)', () => {
   return kysely.selectFrom('my_table as mt')
-}).types([357, 'instantiations'])
+}).types([151, 'instantiations'])
 
 bench('kysely.selectFrom([table])', () => {
   return kysely.selectFrom(['my_table'])
-}).types([380, 'instantiations'])
+}).types([468, 'instantiations'])
 
 bench('kysely.selectFrom([~table])', () => {
   // @ts-expect-error
   return kysely.selectFrom(['my_table2'])
-}).types([5127, 'instantiations'])
+}).types([14732, 'instantiations'])
 
 bench('kysely.selectFrom([table as alias])', () => {
   return kysely.selectFrom(['my_table as mt'])
-}).types([380, 'instantiations'])
+}).types([468, 'instantiations'])
 
 bench('kysely.selectFrom([table, table])', () => {
   return kysely.selectFrom([
     'my_table',
     'table_000a8a0cb7f265a624c851d3e7f8b946',
   ])
-}).types([380, 'instantiations'])
+}).types([468, 'instantiations'])
 
 bench('kysely.selectFrom([table, ~table])', () => {
   return kysely.selectFrom([
@@ -48,24 +48,24 @@ bench('kysely.selectFrom([table, ~table])', () => {
     // @ts-expect-error
     'table_000a8a0cb7f265a624c851d3e7f8b9462',
   ])
-}).types([5130, 'instantiations'])
+}).types([14738, 'instantiations'])
 
 bench('kysely.selectFrom([table as alias, table as alias])', () => {
   return kysely.selectFrom([
     'my_table as mt',
     'table_000a8a0cb7f265a624c851d3e7f8b946 as t',
   ])
-}).types([380, 'instantiations'])
+}).types([468, 'instantiations'])
 
 bench('kysely.selectFrom(kysely.selectFrom(table).as(t))', () => {
   return kysely.selectFrom(kysely.selectFrom('my_table').as('t'))
-}).types([1224, 'instantiations'])
+}).types([574, 'instantiations'])
 
 bench('kysely.$pickTables<tables>.selectFrom(table)', () => {
   return kysely
     .$pickTables<'table_fff4c6195261874920bc7ce92d67d2c2'>()
     .selectFrom('table_fff4c6195261874920bc7ce92d67d2c2')
-}).types([116, 'instantiations'])
+}).types([72, 'instantiations'])
 
 bench('kysely.$pickTables<tables>.selectFrom(~table)', () => {
   return (
@@ -74,49 +74,49 @@ bench('kysely.$pickTables<tables>.selectFrom(~table)', () => {
       // @ts-expect-error
       .selectFrom('my_table2')
   )
-}).types([209, 'instantiations'])
+}).types([902, 'instantiations'])
 
 bench('kyselyAny.selectFrom(table)', () => {
   return kyselyAny.selectFrom('table_fff4c6195261874920bc7ce92d67d2c2')
-}).types([95, 'instantiations'])
+}).types([54, 'instantiations'])
 
 bench('kyselyAny.selectFrom(~table)', () => {
   return kyselyAny.selectFrom('my_table2')
-}).types([95, 'instantiations'])
+}).types([54, 'instantiations'])
 
 bench('kyselyAny.selectFrom(table as alias)', () => {
   return kyselyAny.selectFrom('my_table as mt')
-}).types([95, 'instantiations'])
+}).types([54, 'instantiations'])
 
 bench('kyselyAny.selectFrom([table])', () => {
   return kyselyAny.selectFrom(['my_table'])
-}).types([132, 'instantiations'])
+}).types([222, 'instantiations'])
 
 bench('kyselyAny.selectFrom([~table])', () => {
   return kyselyAny.selectFrom(['my_table2'])
-}).types([132, 'instantiations'])
+}).types([222, 'instantiations'])
 
 bench('kyselyAny.selectFrom([table as alias])', () => {
   return kyselyAny.selectFrom(['my_table as mt'])
-}).types([132, 'instantiations'])
+}).types([222, 'instantiations'])
 
 bench('kyselyAny.selectFrom([table, table])', () => {
   return kyselyAny.selectFrom([
     'my_table',
     'table_000a8a0cb7f265a624c851d3e7f8b946',
   ])
-}).types([132, 'instantiations'])
+}).types([222, 'instantiations'])
 
 bench('kyselyAny.selectFrom([table, ~table])', () => {
   return kyselyAny.selectFrom([
     'my_table',
     'table_000a8a0cb7f265a624c851d3e7f8b9462',
   ])
-}).types([132, 'instantiations'])
+}).types([222, 'instantiations'])
 
 bench('kyselyAny.selectFrom([table as alias, table as alias])', () => {
   return kyselyAny.selectFrom([
     'my_table as mt',
     'table_000a8a0cb7f265a624c851d3e7f8b946 as t',
   ])
-}).types([132, 'instantiations'])
+}).types([222, 'instantiations'])

--- a/test/ts-benchmarks/select-no-from.bench.ts
+++ b/test/ts-benchmarks/select-no-from.bench.ts
@@ -19,13 +19,13 @@ bench('kysely.selectNoFrom([sql0.as(alias0), sql1.as(alias1)])', () =>
 
 bench('kysely.selectNoFrom((eb) => selectFrom)', () =>
   kysely.selectNoFrom((eb) => eb.selectFrom('my_table').selectAll().as('foo')),
-).types([760, 'instantiations'])
+).types([473, 'instantiations'])
 
 bench('kysely.selectNoFrom((eb) => [selectFrom])', () =>
   kysely.selectNoFrom((eb) => [
     eb.selectFrom('my_table').selectAll().as('foo'),
   ]),
-).types([778, 'instantiations'])
+).types([491, 'instantiations'])
 
 bench('kyselyAny.selectNoFrom(sql.as(alias))', () =>
   kyselyAny.selectNoFrom(sql`1`.as('foo')),
@@ -39,10 +39,10 @@ bench('kyselyAny.selectNoFrom((eb) => selectFrom)', () =>
   kyselyAny.selectNoFrom((eb) =>
     eb.selectFrom('my_table').selectAll().as('foo'),
   ),
-).types([512, 'instantiations'])
+).types([473, 'instantiations'])
 
 bench('kyselyAny.selectNoFrom((eb) => [selectFrom])', () =>
   kyselyAny.selectNoFrom((eb) => [
     eb.selectFrom('my_table').selectAll().as('foo'),
   ]),
-).types([530, 'instantiations'])
+).types([491, 'instantiations'])

--- a/test/ts-benchmarks/select.bench.ts
+++ b/test/ts-benchmarks/select.bench.ts
@@ -22,7 +22,7 @@ bench('kysely..select(column)', () =>
 bench('kysely..select(~column)', () =>
   // @ts-expect-error
   query.select('col_164b7896ec8e770207febe0812c5f052_'),
-).types([7231, 'instantiations'])
+).types([7123, 'instantiations'])
 
 bench('kysely..select(table.column)', () =>
   query.select('my_table.col_164b7896ec8e770207febe0812c5f052'),
@@ -31,7 +31,7 @@ bench('kysely..select(table.column)', () =>
 bench('kysely..select(~table.column)', () =>
   // @ts-expect-error
   query.select('my_table_.col_164b7896ec8e770207febe0812c5f052'),
-).types([7231, 'instantiations'])
+).types([7123, 'instantiations'])
 
 bench('kysely..select(table.column as alias)', () =>
   query.select('my_table.col_164b7896ec8e770207febe0812c5f052 as foo'),
@@ -47,26 +47,26 @@ bench('kysely..selectAll()', () => query.selectAll()).types([
 ])
 
 bench('kysely..selectAll(table)', () => query.selectAll('my_table')).types([
-  446,
+  336,
   'instantiations',
 ])
 
 bench('kysely..selectAll(~table)', () =>
   // @ts-expect-error
   query.selectAll('NO_SUCH_TABLE'),
-).types([625, 'instantiations'])
+).types([515, 'instantiations'])
 
 bench('kyselyAny..select(column)', () =>
   queryAny.select('col_164b7896ec8e770207febe0812c5f052'),
-).types([213, 'instantiations'])
+).types([210, 'instantiations'])
 
 bench('kyselyAny..select(table.column)', () =>
   queryAny.select('my_table.col_164b7896ec8e770207febe0812c5f052'),
-).types([213, 'instantiations'])
+).types([210, 'instantiations'])
 
 bench('kyselyAny..select(table.column as alias)', () =>
   queryAny.select('my_table.col_164b7896ec8e770207febe0812c5f052 as foo'),
-).types([213, 'instantiations'])
+).types([210, 'instantiations'])
 
 bench('kyselyAny..selectAll()', () => queryAny.selectAll()).types([
   37,

--- a/test/ts-benchmarks/update-returning.bench.ts
+++ b/test/ts-benchmarks/update-returning.bench.ts
@@ -22,7 +22,7 @@ bench('kysely.updateTable(table).returning(column)', () =>
 bench('kysely.updateTable(table)..returning(~column)', () =>
   // @ts-expect-error
   updateQuery.returning('col_164b7896ec8e770207febe0812c5f052_'),
-).types([7159, 'instantiations'])
+).types([7049, 'instantiations'])
 
 bench('kysely.updateTable(table)..returning(table.column)', () =>
   updateQuery.returning('my_table.col_164b7896ec8e770207febe0812c5f052'),
@@ -31,7 +31,7 @@ bench('kysely.updateTable(table)..returning(table.column)', () =>
 bench('kysely.updateTable(table)..returning(~table.column)', () =>
   // @ts-expect-error
   updateQuery.returning('my_table_.col_164b7896ec8e770207febe0812c5f052'),
-).types([7159, 'instantiations'])
+).types([7049, 'instantiations'])
 
 bench('kysely.updateTable(table)..returning(table.column as alias)', () =>
   updateQuery.returning('my_table.col_164b7896ec8e770207febe0812c5f052 as foo'),
@@ -47,17 +47,17 @@ bench('kysely.updateTable(table)..returningAll()', () =>
 
 bench('kyselyAny.updateTable(table)..returning(column)', () =>
   updateQueryAny.returning('col_164b7896ec8e770207febe0812c5f052'),
-).types([235, 'instantiations'])
+).types([232, 'instantiations'])
 
 bench('kyselyAny.updateTable(table)..returning(table.column)', () =>
   updateQueryAny.returning('my_table.col_164b7896ec8e770207febe0812c5f052'),
-).types([235, 'instantiations'])
+).types([232, 'instantiations'])
 
 bench('kyselyAny.updateTable(table)..returning(table.column as alias)', () =>
   updateQueryAny.returning(
     'my_table.col_164b7896ec8e770207febe0812c5f052 as foo',
   ),
-).types([235, 'instantiations'])
+).types([232, 'instantiations'])
 
 bench('kyselyAny.updateTable(table)..returningAll()', () =>
   updateQueryAny.returningAll(),

--- a/test/ts-benchmarks/update-table.bench.ts
+++ b/test/ts-benchmarks/update-table.bench.ts
@@ -11,36 +11,36 @@ bench.baseline(() => {})
 
 bench('kysely.updateTable(table)', () => {
   return kysely.updateTable('table_fff4c6195261874920bc7ce92d67d2c2')
-}).types([342, 'instantiations'])
+}).types([53, 'instantiations'])
 
 bench('kysely.updateTable(~table)', () => {
   // @ts-expect-error
   return kysely.updateTable('my_table2')
-}).types([5085, 'instantiations'])
+}).types([14592, 'instantiations'])
 
 bench('kysely.updateTable(table as alias)', () => {
   return kysely.updateTable('my_table as mt')
-}).types([356, 'instantiations'])
+}).types([150, 'instantiations'])
 
 bench('kysely.updateTable([table])', () => {
   return kysely.updateTable(['my_table'])
-}).types([379, 'instantiations'])
+}).types([467, 'instantiations'])
 
 bench('kysely.updateTable([~table])', () => {
   // @ts-expect-error
   return kysely.updateTable(['my_table2'])
-}).types([5126, 'instantiations'])
+}).types([14644, 'instantiations'])
 
 bench('kysely.updateTable([table as alias])', () => {
   return kysely.updateTable(['my_table as mt'])
-}).types([379, 'instantiations'])
+}).types([467, 'instantiations'])
 
 bench('kysely.updateTable([table, table])', () => {
   return kysely.updateTable([
     'my_table',
     'table_000a8a0cb7f265a624c851d3e7f8b946',
   ])
-}).types([379, 'instantiations'])
+}).types([467, 'instantiations'])
 
 bench('kysely.updateTable([table, ~table])', () => {
   return kysely.updateTable([
@@ -48,56 +48,56 @@ bench('kysely.updateTable([table, ~table])', () => {
     // @ts-expect-error
     'table_000a8a0cb7f265a624c851d3e7f8b9462',
   ])
-}).types([5129, 'instantiations'])
+}).types([14650, 'instantiations'])
 
 bench('kysely.updateTable([table as alias, table as alias])', () => {
   return kysely.updateTable([
     'my_table as mt',
     'table_000a8a0cb7f265a624c851d3e7f8b946 as t',
   ])
-}).types([379, 'instantiations'])
+}).types([467, 'instantiations'])
 
 bench('kyselyAny.updateTable(table)', () => {
   return kyselyAny.updateTable('table_fff4c6195261874920bc7ce92d67d2c2')
-}).types([94, 'instantiations'])
+}).types([53, 'instantiations'])
 
 bench('kyselyAny.updateTable(~table)', () => {
   return kyselyAny.updateTable('my_table2')
-}).types([94, 'instantiations'])
+}).types([53, 'instantiations'])
 
 bench('kyselyAny.updateTable(table as alias)', () => {
   return kyselyAny.updateTable('my_table as mt')
-}).types([94, 'instantiations'])
+}).types([53, 'instantiations'])
 
 bench('kyselyAny.updateTable([table])', () => {
   return kyselyAny.updateTable(['my_table'])
-}).types([131, 'instantiations'])
+}).types([221, 'instantiations'])
 
 bench('kyselyAny.updateTable([~table])', () => {
   return kyselyAny.updateTable(['my_table2'])
-}).types([131, 'instantiations'])
+}).types([221, 'instantiations'])
 
 bench('kyselyAny.updateTable([table as alias])', () => {
   return kyselyAny.updateTable(['my_table as mt'])
-}).types([131, 'instantiations'])
+}).types([221, 'instantiations'])
 
 bench('kyselyAny.updateTable([table, table])', () => {
   return kyselyAny.updateTable([
     'my_table',
     'table_000a8a0cb7f265a624c851d3e7f8b946',
   ])
-}).types([131, 'instantiations'])
+}).types([221, 'instantiations'])
 
 bench('kyselyAny.updateTable([table, ~table])', () => {
   return kyselyAny.updateTable([
     'my_table',
     'table_000a8a0cb7f265a624c851d3e7f8b9462',
   ])
-}).types([131, 'instantiations'])
+}).types([221, 'instantiations'])
 
 bench('kyselyAny.updateTable([table as alias, table as alias])', () => {
   return kyselyAny.updateTable([
     'my_table as mt',
     'table_000a8a0cb7f265a624c851d3e7f8b946 as t',
   ])
-}).types([131, 'instantiations'])
+}).types([221, 'instantiations'])

--- a/test/ts-benchmarks/where.bench.ts
+++ b/test/ts-benchmarks/where.bench.ts
@@ -17,25 +17,25 @@ bench.baseline(() => {
 
 bench('kysely..where(column, op, value)', () =>
   query.where('col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([2210, 'instantiations'])
+).types([2102, 'instantiations'])
 
 bench('kysely..where(~column, op, value)', () =>
   // @ts-expect-error
   query.where('col_1d726898491fbca9a8dac855d2be1be8_', '=', 123),
-).types([3461, 'instantiations'])
+).types([3353, 'instantiations'])
 
 bench('kysely..where(table.column, op, value)', () =>
   query.where('my_table.col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([2213, 'instantiations'])
+).types([2105, 'instantiations'])
 
 bench('kysely..where(~table.column, op, value)', () =>
   // @ts-expect-error
   query.where('my_table_.col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([3461, 'instantiations'])
+).types([3353, 'instantiations'])
 
 bench('kysely..where(column, is, null)', () =>
   query.where('col_6f5e1903664b084bf6197f2b86849d5e', 'is', null),
-).types([2216, 'instantiations'])
+).types([2108, 'instantiations'])
 
 bench('kysely..where(column, op, select)', () =>
   query.where(
@@ -46,11 +46,11 @@ bench('kysely..where(column, op, select)', () =>
       .select('t2.col_1d726898491fbca9a8dac855d2be1be8')
       .limit(1),
   ),
-).types([3329, 'instantiations'])
+).types([3078, 'instantiations'])
 
 bench('kysely..where(eb => eb(...))', () =>
   query.where((eb) => eb('col_1d726898491fbca9a8dac855d2be1be8', '=', 123)),
-).types([2799, 'instantiations'])
+).types([2691, 'instantiations'])
 
 bench('kysely..where(eb => eb.and([...]))', () =>
   query.where((eb) =>
@@ -59,7 +59,7 @@ bench('kysely..where(eb => eb.and([...]))', () =>
       eb('col_4d742b2f247bec99b41a60acbebc149a', '=', 456),
     ]),
   ),
-).types([2894, 'instantiations'])
+).types([2786, 'instantiations'])
 
 bench('kysely..where(sql`...`)', () =>
   query.where(sql<boolean>`col = 'foo'`),
@@ -86,19 +86,19 @@ bench('kysely..whereRef(~column, op, column)', () =>
 
 bench('kyselyAny..where(column, op, value)', () =>
   queryAny.where('col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([707, 'instantiations'])
+).types([709, 'instantiations'])
 
 bench('kyselyAny..where(~column, op, value)', () =>
   queryAny.where('col_1d726898491fbca9a8dac855d2be1be8_', '=', 123),
-).types([707, 'instantiations'])
+).types([709, 'instantiations'])
 
 bench('kyselyAny..where(table.column, op, value)', () =>
   queryAny.where('my_table.col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([693, 'instantiations'])
+).types([695, 'instantiations'])
 
 bench('kyselyAny..where(eb => eb(...))', () =>
   queryAny.where((eb) => eb('col_1d726898491fbca9a8dac855d2be1be8', '=', 123)),
-).types([979, 'instantiations'])
+).types([981, 'instantiations'])
 
 bench('kyselyAny..where(sql`...`)', () =>
   queryAny.where(sql<boolean>`col = 'foo'`),

--- a/test/ts-benchmarks/with.bench.ts
+++ b/test/ts-benchmarks/with.bench.ts
@@ -11,7 +11,7 @@ bench.baseline(() => {})
 
 bench('kysely.with(cte, qc => qc.selectFrom(table))', () => {
   return kysely.with('cte', (qc) => qc.selectFrom('my_table').selectAll())
-}).types([659, 'instantiations'])
+}).types([370, 'instantiations'])
 
 bench('kysely.with(cte, qc => qc.insertInto(table))', () => {
   return kysely.with('cte', (qc) => qc.insertInto('my_table').returningAll())
@@ -19,15 +19,15 @@ bench('kysely.with(cte, qc => qc.insertInto(table))', () => {
 
 bench('kysely.with(cte, qc => qc.updateTable(table))', () => {
   return kysely.with('cte', (qc) => qc.updateTable('my_table').returningAll())
-}).types([23938, 'instantiations'])
+}).types([32166, 'instantiations'])
 
 bench('kysely.with(cte, qc => qc.deleteFrom(table))', () => {
   return kysely.with('cte', (qc) => qc.deleteFrom('my_table').returningAll())
-}).types([11503, 'instantiations'])
+}).types([17035, 'instantiations'])
 
 bench('kyselyAny.with(cte, qc => qc.selectFrom(table))', () => {
   return kyselyAny.with('cte', (qc) => qc.selectFrom('my_table').selectAll())
-}).types([455, 'instantiations'])
+}).types([414, 'instantiations'])
 
 bench('kyselyAny.with(cte, qc => qc.insertInto(table))', () => {
   return kyselyAny.with('cte', (qc) => qc.insertInto('my_table').returningAll())
@@ -37,15 +37,15 @@ bench('kyselyAny.with(cte, qc => qc.updateTable(table))', () => {
   return kyselyAny.with('cte', (qc) =>
     qc.updateTable('my_table').returningAll(),
   )
-}).types([23728, 'instantiations'])
+}).types([32204, 'instantiations'])
 
 bench('kyselyAny.with(cte, qc => qc.deleteFrom(table))', () => {
   return kyselyAny.with('cte', (qc) => qc.deleteFrom('my_table').returningAll())
-}).types([11299, 'instantiations'])
+}).types([17079, 'instantiations'])
 
 bench('kysely.with(cte, () => selectQuery)', () => {
   return kysely.with('cte', () => kysely.selectFrom('my_table').selectAll())
-}).types([647, 'instantiations'])
+}).types([358, 'instantiations'])
 
 bench('kysely.with(cte, () => insertQuery)', () => {
   return kysely.with('cte', () => kysely.insertInto('my_table').returningAll())
@@ -53,17 +53,17 @@ bench('kysely.with(cte, () => insertQuery)', () => {
 
 bench('kysely.with(cte, () => updateQuery)', () => {
   return kysely.with('cte', () => kysely.updateTable('my_table').returningAll())
-}).types([23926, 'instantiations'])
+}).types([32154, 'instantiations'])
 
 bench('kysely.with(cte, () => deleteQuery)', () => {
   return kysely.with('cte', () => kysely.deleteFrom('my_table').returningAll())
-}).types([11491, 'instantiations'])
+}).types([17023, 'instantiations'])
 
 bench('kyselyAny.with(cte, () => selectQuery)', () => {
   return kyselyAny.with('cte', () =>
     kyselyAny.selectFrom('my_table').selectAll(),
   )
-}).types([443, 'instantiations'])
+}).types([402, 'instantiations'])
 
 bench('kyselyAny.with(cte, () => insertQuery)', () => {
   return kyselyAny.with('cte', () =>
@@ -75,17 +75,17 @@ bench('kyselyAny.with(cte, () => updateQuery)', () => {
   return kyselyAny.with('cte', () =>
     kyselyAny.updateTable('my_table').returningAll(),
   )
-}).types([23716, 'instantiations'])
+}).types([32192, 'instantiations'])
 
 bench('kyselyAny.with(cte, () => deleteQuery)', () => {
   return kyselyAny.with('cte', () =>
     kyselyAny.deleteFrom('my_table').returningAll(),
   )
-}).types([11287, 'instantiations'])
+}).types([17067, 'instantiations'])
 
 bench('kysely.with(cte, selectQuery)', () => {
   return kysely.with('cte', kysely.selectFrom('my_table').selectAll())
-}).types([906, 'instantiations'])
+}).types([617, 'instantiations'])
 
 bench('kysely.with(cte, insertQuery)', () => {
   return kysely.with('cte', kysely.insertInto('my_table').returningAll())
@@ -93,15 +93,15 @@ bench('kysely.with(cte, insertQuery)', () => {
 
 bench('kysely.with(cte, updateQuery)', () => {
   return kysely.with('cte', kysely.updateTable('my_table').returningAll())
-}).types([23970, 'instantiations'])
+}).types([32198, 'instantiations'])
 
 bench('kysely.with(cte, deleteQuery)', () => {
   return kysely.with('cte', kysely.deleteFrom('my_table').returningAll())
-}).types([11536, 'instantiations'])
+}).types([17068, 'instantiations'])
 
 bench('kyselyAny.with(cte, selectQuery)', () => {
   return kyselyAny.with('cte', kyselyAny.selectFrom('my_table').selectAll())
-}).types([680, 'instantiations'])
+}).types([639, 'instantiations'])
 
 bench('kyselyAny.with(cte, insertQuery)', () => {
   return kyselyAny.with('cte', kyselyAny.insertInto('my_table').returningAll())
@@ -109,8 +109,8 @@ bench('kyselyAny.with(cte, insertQuery)', () => {
 
 bench('kyselyAny.with(cte, updateQuery)', () => {
   return kyselyAny.with('cte', kyselyAny.updateTable('my_table').returningAll())
-}).types([23760, 'instantiations'])
+}).types([32236, 'instantiations'])
 
 bench('kyselyAny.with(cte, deleteQuery)', () => {
   return kyselyAny.with('cte', kyselyAny.deleteFrom('my_table').returningAll())
-}).types([11332, 'instantiations'])
+}).types([17112, 'instantiations'])


### PR DESCRIPTION
Two type-level costs dominate cold typechecking of a large `DB` schema.

1. Every generic builder call whose constraint is `TableExpression<DB, TB>` makes the compiler rebuild and renormalize a union that mixes one string literal per table with one template literal per table (`AnyAliasedTable<DB>`), running the literal-vs-template subsumption sweep on each call. `insertInto`, whose constraint is the template-free `keyof DB & string`, costs two orders of magnitude less.

2. `JoinReferenceExpression<DB, TB, TE>` in the *constraint* of `K1`/`K2` makes the checker resolve the constraint of the deferred conditionals behind it, fanning `ExtractAliasFromTableExpression` out over every member of `TableExpression<DB, TB>`, per join, per distinct `TB`.

Both are addressed without changing a single inferred type:

- `ValidateJoinReference` re-attaches the join-reference check in *check position* (`[K] extends [JoinReferenceExpression<…>] ? unknown : never`, intersected onto the parameter). Its deferred constraint is `unknown | never`, computed from the branches alone, so the expensive type is evaluated once per call with `TE`, `TB` and `K` already fixed.

- `ValidateAliasedTable` validates `'table as alias'` by parse-then-lookup, so an aliased tier can be constrained by the single template `` `${string} as ${string}` `` instead of a 500-way template union.

- `selectFrom`/`updateTable`/`deleteFrom`, `ExpressionBuilder.selectFrom`, `UpdateQueryBuilder.from` and every join/crossJoin/lateral/apply overload get a plain-table-name tier first and an aliased tier second. The original overload stays last, so invalid input still falls through to it and reports the same errors, and completions keep working through it.

The `TE` parameter of `SelectFrom`, `DeleteFrom`, `UpdateTable` and the `*QueryBuilderWith*Join` aliases is now unconstrained: a `TableExpression`-shaped constraint rejects the template-literal tiers, and every branch of those aliases already validates `TE` on its own.

Benchmark baselines are updated. Highlights (instantiations, huge-db): `selectFrom(table)` 343 -> 54, `selectFrom(table as alias)` 357 -> 151, `innerJoin(table, k1, k2)` 6538 -> 529, `innerJoin(table as alias, k1, k2)` 6534 -> 629. The extra overloads cost more on paths that miss every fast tier: invalid arguments (`selectFrom(~table)` 5086 -> 14680) and structural assignability between two builder types (+27% to +53%).