### PR TITLE
perf(types): validate join references in check position (−88% instantiations on huge-db)

### DIFF
--- a/src/parser/join-parser.ts
+++ b/src/parser/join-parser.ts
@@ -5,6 +5,7 @@ import type {
   AnyColumnWithTable,
   DrainOuterGeneric,
 } from '../util/type-utils.js'
+import type { KyselyTypeError } from '../util/type-error.js'
 import { parseReferentialBinaryOperation } from './binary-operation-parser.js'
 import { createJoinBuilder } from './parse-utils.js'
 import {
@@ -21,6 +22,22 @@ export type JoinReferenceExpression<
 > = DrainOuterGeneric<
   AnyJoinColumn<DB, TB, TE> | AnyJoinColumnWithTable<DB, TB, TE>
 >
+
+/**
+ * Validates a join reference in check position instead of in `K`'s constraint.
+ *
+ * As a constraint, `JoinReferenceExpression` is reached through the constraint
+ * of the deferred conditionals behind it, which fans
+ * `ExtractAliasFromTableExpression` out over every member of
+ * `TableExpression<DB, TB>` - once per join, per distinct `TB`. Behind a
+ * non-distributive conditional the same type is evaluated once per call, with
+ * `TE` and `K` already fixed, so the inferred result is identical.
+ */
+export type ValidateJoinReference<DB, TB extends keyof DB, TE, K> = [
+  K,
+] extends [JoinReferenceExpression<DB, TB, TE>]
+  ? unknown
+  : KyselyTypeError<`This is not a valid join reference for the joined tables: ${K & string}`>
 
 export type JoinCallbackExpression<DB, TB extends keyof DB, TE> = (
   join: JoinBuilder<From<DB, TE>, FromTables<DB, TB, TE>>,

--- a/src/query-builder/delete-query-builder.ts
+++ b/src/query-builder/delete-query-builder.ts
@@ -3,6 +3,7 @@ import type { CompiledQuery } from '../query-compiler/compiled-query.js'
 import {
   type JoinCallbackExpression,
   type JoinReferenceExpression,
+  type ValidateJoinReference,
   parseJoin,
 } from '../parser/join-parser.js'
 import {
@@ -403,9 +404,13 @@ export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
    */
   innerJoin<
     TE extends TableExpression<DB, TB>,
-    K1 extends JoinReferenceExpression<DB, TB, TE>,
-    K2 extends JoinReferenceExpression<DB, TB, TE>,
-  >(table: TE, k1: K1, k2: K2): DeleteQueryBuilderWithInnerJoin<DB, TB, O, TE>
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): DeleteQueryBuilderWithInnerJoin<DB, TB, O, TE>
 
   innerJoin<
     TE extends TableExpression<DB, TB>,
@@ -421,9 +426,13 @@ export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
    */
   leftJoin<
     TE extends TableExpression<DB, TB>,
-    K1 extends JoinReferenceExpression<DB, TB, TE>,
-    K2 extends JoinReferenceExpression<DB, TB, TE>,
-  >(table: TE, k1: K1, k2: K2): DeleteQueryBuilderWithLeftJoin<DB, TB, O, TE>
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): DeleteQueryBuilderWithLeftJoin<DB, TB, O, TE>
 
   leftJoin<
     TE extends TableExpression<DB, TB>,
@@ -439,9 +448,13 @@ export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
    */
   rightJoin<
     TE extends TableExpression<DB, TB>,
-    K1 extends JoinReferenceExpression<DB, TB, TE>,
-    K2 extends JoinReferenceExpression<DB, TB, TE>,
-  >(table: TE, k1: K1, k2: K2): DeleteQueryBuilderWithRightJoin<DB, TB, O, TE>
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): DeleteQueryBuilderWithRightJoin<DB, TB, O, TE>
 
   rightJoin<
     TE extends TableExpression<DB, TB>,
@@ -457,9 +470,13 @@ export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
    */
   fullJoin<
     TE extends TableExpression<DB, TB>,
-    K1 extends JoinReferenceExpression<DB, TB, TE>,
-    K2 extends JoinReferenceExpression<DB, TB, TE>,
-  >(table: TE, k1: K1, k2: K2): DeleteQueryBuilderWithFullJoin<DB, TB, O, TE>
+    K1 extends string,
+    K2 extends string,
+  >(
+    table: TE,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
+  ): DeleteQueryBuilderWithFullJoin<DB, TB, O, TE>
 
   fullJoin<
     TE extends TableExpression<DB, TB>,

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -4,6 +4,7 @@ import { SelectModifierNode } from '../operation-node/select-modifier-node.js'
 import {
   type JoinCallbackExpression,
   type JoinReferenceExpression,
+  type ValidateJoinReference,
   parseJoin,
 } from '../parser/join-parser.js'
 import { type TableExpression, parseTable } from '../parser/table-parser.js'
@@ -710,12 +711,12 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    */
   innerJoin<
     TE extends TableExpression<DB, TB>,
-    K1 extends JoinReferenceExpression<DB, TB, TE>,
-    K2 extends JoinReferenceExpression<DB, TB, TE>,
+    K1 extends string,
+    K2 extends string,
   >(
     table: TE,
-    k1: K1,
-    k2: K2,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
   ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
 
   innerJoin<
@@ -731,12 +732,12 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    */
   leftJoin<
     TE extends TableExpression<DB, TB>,
-    K1 extends JoinReferenceExpression<DB, TB, TE>,
-    K2 extends JoinReferenceExpression<DB, TB, TE>,
+    K1 extends string,
+    K2 extends string,
   >(
     table: TE,
-    k1: K1,
-    k2: K2,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
   ): SelectQueryBuilderWithLeftJoin<DB, TB, O, TE>
 
   leftJoin<
@@ -752,12 +753,12 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    */
   rightJoin<
     TE extends TableExpression<DB, TB>,
-    K1 extends JoinReferenceExpression<DB, TB, TE>,
-    K2 extends JoinReferenceExpression<DB, TB, TE>,
+    K1 extends string,
+    K2 extends string,
   >(
     table: TE,
-    k1: K1,
-    k2: K2,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
   ): SelectQueryBuilderWithRightJoin<DB, TB, O, TE>
 
   rightJoin<
@@ -775,12 +776,12 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    */
   fullJoin<
     TE extends TableExpression<DB, TB>,
-    K1 extends JoinReferenceExpression<DB, TB, TE>,
-    K2 extends JoinReferenceExpression<DB, TB, TE>,
+    K1 extends string,
+    K2 extends string,
   >(
     table: TE,
-    k1: K1,
-    k2: K2,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
   ): SelectQueryBuilderWithFullJoin<DB, TB, O, TE>
 
   fullJoin<
@@ -835,12 +836,12 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    */
   innerJoinLateral<
     TE extends TableExpression<DB, TB>,
-    K1 extends JoinReferenceExpression<DB, TB, TE>,
-    K2 extends JoinReferenceExpression<DB, TB, TE>,
+    K1 extends string,
+    K2 extends string,
   >(
     table: TE,
-    k1: K1,
-    k2: K2,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
   ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>
 
   innerJoinLateral<
@@ -888,12 +889,12 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    */
   leftJoinLateral<
     TE extends TableExpression<DB, TB>,
-    K1 extends JoinReferenceExpression<DB, TB, TE>,
-    K2 extends JoinReferenceExpression<DB, TB, TE>,
+    K1 extends string,
+    K2 extends string,
   >(
     table: TE,
-    k1: K1,
-    k2: K2,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
   ): SelectQueryBuilderWithLeftJoin<DB, TB, O, TE>
 
   leftJoinLateral<

--- a/src/query-builder/update-query-builder.ts
+++ b/src/query-builder/update-query-builder.ts
@@ -3,6 +3,7 @@ import type { CompiledQuery } from '../query-compiler/compiled-query.js'
 import {
   type JoinCallbackExpression,
   type JoinReferenceExpression,
+  type ValidateJoinReference,
   parseJoin,
 } from '../parser/join-parser.js'
 import {
@@ -362,12 +363,12 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
    */
   innerJoin<
     TE extends TableExpression<DB, TB>,
-    K1 extends JoinReferenceExpression<DB, TB, TE>,
-    K2 extends JoinReferenceExpression<DB, TB, TE>,
+    K1 extends string,
+    K2 extends string,
   >(
     table: TE,
-    k1: K1,
-    k2: K2,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
   ): UpdateQueryBuilderWithInnerJoin<DB, UT, TB, O, TE>
 
   innerJoin<
@@ -384,12 +385,12 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
    */
   leftJoin<
     TE extends TableExpression<DB, TB>,
-    K1 extends JoinReferenceExpression<DB, TB, TE>,
-    K2 extends JoinReferenceExpression<DB, TB, TE>,
+    K1 extends string,
+    K2 extends string,
   >(
     table: TE,
-    k1: K1,
-    k2: K2,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
   ): UpdateQueryBuilderWithLeftJoin<DB, UT, TB, O, TE>
 
   leftJoin<
@@ -406,12 +407,12 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
    */
   rightJoin<
     TE extends TableExpression<DB, TB>,
-    K1 extends JoinReferenceExpression<DB, TB, TE>,
-    K2 extends JoinReferenceExpression<DB, TB, TE>,
+    K1 extends string,
+    K2 extends string,
   >(
     table: TE,
-    k1: K1,
-    k2: K2,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
   ): UpdateQueryBuilderWithRightJoin<DB, UT, TB, O, TE>
 
   rightJoin<
@@ -428,12 +429,12 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
    */
   fullJoin<
     TE extends TableExpression<DB, TB>,
-    K1 extends JoinReferenceExpression<DB, TB, TE>,
-    K2 extends JoinReferenceExpression<DB, TB, TE>,
+    K1 extends string,
+    K2 extends string,
   >(
     table: TE,
-    k1: K1,
-    k2: K2,
+    k1: K1 & ValidateJoinReference<DB, TB, TE, K1>,
+    k2: K2 & ValidateJoinReference<DB, TB, TE, K2>,
   ): UpdateQueryBuilderWithFullJoin<DB, UT, TB, O, TE>
 
   fullJoin<

--- a/test/ts-benchmarks/delete-returning.bench.ts
+++ b/test/ts-benchmarks/delete-returning.bench.ts
@@ -17,48 +17,48 @@ bench.baseline(() => {
 
 bench('kysely.deleteFrom(table).returning(column)', () =>
   deleteQuery.returning('col_164b7896ec8e770207febe0812c5f052'),
-).types([304, 'instantiations'])
+).types([300, 'instantiations'])
 
 bench('kysely.deleteFrom(table)..returning(~column)', () =>
   // @ts-expect-error
   deleteQuery.returning('col_164b7896ec8e770207febe0812c5f052_'),
-).types([7349, 'instantiations'])
+).types([7345, 'instantiations'])
 
 bench('kysely.deleteFrom(table)..returning(table.column)', () =>
   deleteQuery.returning('my_table.col_164b7896ec8e770207febe0812c5f052'),
-).types([304, 'instantiations'])
+).types([300, 'instantiations'])
 
 bench('kysely.deleteFrom(table)..returning(~table.column)', () =>
   // @ts-expect-error
   deleteQuery.returning('my_table_.col_164b7896ec8e770207febe0812c5f052'),
-).types([7349, 'instantiations'])
+).types([7345, 'instantiations'])
 
 bench('kysely.deleteFrom(table)..returning(table.column as alias)', () =>
   deleteQuery.returning('my_table.col_164b7896ec8e770207febe0812c5f052 as foo'),
-).types([304, 'instantiations'])
+).types([300, 'instantiations'])
 
 bench('kysely.deleteFrom(table)..returning(column as alias)', () =>
   deleteQuery.returning('col_164b7896ec8e770207febe0812c5f052 as foo'),
-).types([304, 'instantiations'])
+).types([300, 'instantiations'])
 
 bench('kysely.deleteFrom(table)..returningAll()', () =>
   deleteQuery.returningAll(),
-).types([91, 'instantiations'])
+).types([87, 'instantiations'])
 
 bench('kyselyAny.deleteFrom(table)..returning(column)', () =>
   deleteQueryAny.returning('col_164b7896ec8e770207febe0812c5f052'),
-).types([238, 'instantiations'])
+).types([234, 'instantiations'])
 
 bench('kyselyAny.deleteFrom(table)..returning(table.column)', () =>
   deleteQueryAny.returning('my_table.col_164b7896ec8e770207febe0812c5f052'),
-).types([238, 'instantiations'])
+).types([234, 'instantiations'])
 
 bench('kyselyAny.deleteFrom(table)..returning(table.column as alias)', () =>
   deleteQueryAny.returning(
     'my_table.col_164b7896ec8e770207febe0812c5f052 as foo',
   ),
-).types([238, 'instantiations'])
+).types([234, 'instantiations'])
 
 bench('kyselyAny.deleteFrom(table)..returningAll()', () =>
   deleteQueryAny.returningAll(),
-).types([91, 'instantiations'])
+).types([87, 'instantiations'])

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -126,15 +126,15 @@ bench.baseline(() => {})
 
 bench('SelectQueryBuilder assignable to narrower SelectQueryBuilder', () => {
   return acceptsNarrowSelectQueryBuilder(wideSelectQueryBuilder)
-}).types([45134, 'instantiations'])
+}).types([46936, 'instantiations'])
 
 bench('ExpressionBuilder assignable to narrower ExpressionBuilder', () => {
   return acceptsNarrowExpressionBuilder(wideExpressionBuilder)
-}).types([55494, 'instantiations'])
+}).types([57296, 'instantiations'])
 
 bench('ExpressionBuilder passed to function expecting fewer tables', () => {
   return acceptsTwoTableExpressionBuilder(threeTableExpressionBuilder)
-}).types([55545, 'instantiations'])
+}).types([57347, 'instantiations'])
 
 bench('select(genericSelectHelper) on a left joined query', () => {
   return kysely
@@ -142,15 +142,15 @@ bench('select(genericSelectHelper) on a left joined query', () => {
     .leftJoin('person as personJoin', 'personJoin.parent_id', 'parent.id')
     .leftJoin('pet as petJoin', 'petJoin.owner_id', 'personJoin.id')
     .select(selectParentId)
-}).types([57871, 'instantiations'])
+}).types([58729, 'instantiations'])
 
 bench('DeleteQueryBuilder assignable to narrower DeleteQueryBuilder', () => {
   return acceptsNarrowDeleteQueryBuilder(wideDeleteQueryBuilder)
-}).types([10920, 'instantiations'])
+}).types([12045, 'instantiations'])
 
 bench('UpdateQueryBuilder assignable to narrower UpdateQueryBuilder', () => {
   return acceptsNarrowUpdateQueryBuilder(wideUpdateQueryBuilder)
-}).types([91178, 'instantiations'])
+}).types([94302, 'instantiations'])
 
 bench('WheneableMergeQueryBuilder assignable to a narrower one', () => {
   return acceptsNarrowMergeQueryBuilder(wideMergeQueryBuilder)
@@ -158,7 +158,7 @@ bench('WheneableMergeQueryBuilder assignable to a narrower one', () => {
 
 bench('Transaction assignable to Kysely', () => {
   return acceptsKysely(transaction)
-}).types([162352, 'instantiations'])
+}).types([167174, 'instantiations'])
 
 bench('MergeQueryBuilder assignable to narrower MergeQueryBuilder', () => {
   return acceptsNarrowMergeInto(wideMergeInto)

--- a/test/ts-benchmarks/inner-join.bench.ts
+++ b/test/ts-benchmarks/inner-join.bench.ts
@@ -21,7 +21,7 @@ bench('kysely..innerJoin(table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([6538, 'instantiations'])
+).types([797, 'instantiations'])
 
 bench('kysely..innerJoin(~table, k1, k2)', () =>
   query.innerJoin(
@@ -30,7 +30,7 @@ bench('kysely..innerJoin(~table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([21845, 'instantiations'])
+).types([1350, 'instantiations'])
 
 bench('kysely..innerJoin(table, ~k1, k2)', () =>
   query.innerJoin(
@@ -39,7 +39,7 @@ bench('kysely..innerJoin(table, ~k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052_',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([7086, 'instantiations'])
+).types([1281, 'instantiations'])
 
 bench('kysely..innerJoin(table, k1, ~k2)', () =>
   query.innerJoin(
@@ -48,7 +48,7 @@ bench('kysely..innerJoin(table, k1, ~k2)', () =>
     // @ts-expect-error
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4_',
   ),
-).types([7089, 'instantiations'])
+).types([1297, 'instantiations'])
 
 bench('kysely..innerJoin(table as alias, k1, k2)', () =>
   query.innerJoin(
@@ -56,7 +56,7 @@ bench('kysely..innerJoin(table as alias, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     't2.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([6534, 'instantiations'])
+).types([793, 'instantiations'])
 
 bench('kysely..innerJoin(table, cb)', () =>
   query.innerJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -66,7 +66,7 @@ bench('kysely..innerJoin(table, cb)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([2246, 'instantiations'])
+).types([2262, 'instantiations'])
 
 bench('kysely..innerJoin(table, cb with ~column)', () =>
   query.innerJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -77,7 +77,7 @@ bench('kysely..innerJoin(table, cb with ~column)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([2302, 'instantiations'])
+).types([2318, 'instantiations'])
 
 //
 
@@ -87,7 +87,7 @@ bench('kyselyAny..innerJoin(table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([883, 'instantiations'])
+).types([291, 'instantiations'])
 
 bench('kyselyAny..innerJoin(~table, k1, k2)', () =>
   queryAny.innerJoin(
@@ -95,7 +95,7 @@ bench('kyselyAny..innerJoin(~table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([883, 'instantiations'])
+).types([291, 'instantiations'])
 
 bench('kyselyAny..innerJoin(table, ~k1, k2)', () =>
   queryAny.innerJoin(
@@ -103,7 +103,7 @@ bench('kyselyAny..innerJoin(table, ~k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052_',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([883, 'instantiations'])
+).types([291, 'instantiations'])
 
 bench('kyselyAny..innerJoin(table, k1, ~k2)', () =>
   queryAny.innerJoin(
@@ -111,7 +111,7 @@ bench('kyselyAny..innerJoin(table, k1, ~k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4_',
   ),
-).types([883, 'instantiations'])
+).types([291, 'instantiations'])
 
 bench('kyselyAny..innerJoin(table as alias, k1, k2)', () =>
   queryAny.innerJoin(
@@ -119,7 +119,7 @@ bench('kyselyAny..innerJoin(table as alias, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     't2.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([881, 'instantiations'])
+).types([289, 'instantiations'])
 
 bench('kyselyAny..innerJoin(table, cb)', () =>
   queryAny.innerJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -129,7 +129,7 @@ bench('kyselyAny..innerJoin(table, cb)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([1499, 'instantiations'])
+).types([1515, 'instantiations'])
 
 bench('kyselyAny..innerJoin(table, cb with ~column)', () =>
   queryAny.innerJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -139,4 +139,4 @@ bench('kyselyAny..innerJoin(table, cb with ~column)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([1499, 'instantiations'])
+).types([1515, 'instantiations'])

--- a/test/ts-benchmarks/left-join.bench.ts
+++ b/test/ts-benchmarks/left-join.bench.ts
@@ -21,7 +21,7 @@ bench('kysely..leftJoin(table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([6546, 'instantiations'])
+).types([805, 'instantiations'])
 
 bench('kysely..leftJoin(~table, k1, k2)', () =>
   query.leftJoin(
@@ -30,7 +30,7 @@ bench('kysely..leftJoin(~table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([21845, 'instantiations'])
+).types([1350, 'instantiations'])
 
 bench('kysely..leftJoin(table, ~k1, k2)', () =>
   query.leftJoin(
@@ -39,7 +39,7 @@ bench('kysely..leftJoin(table, ~k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052_',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([7094, 'instantiations'])
+).types([1289, 'instantiations'])
 
 bench('kysely..leftJoin(table, k1, ~k2)', () =>
   query.leftJoin(
@@ -48,7 +48,7 @@ bench('kysely..leftJoin(table, k1, ~k2)', () =>
     // @ts-expect-error
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4_',
   ),
-).types([7097, 'instantiations'])
+).types([1305, 'instantiations'])
 
 bench('kysely..leftJoin(table as alias, k1, k2)', () =>
   query.leftJoin(
@@ -56,7 +56,7 @@ bench('kysely..leftJoin(table as alias, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     't2.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([6534, 'instantiations'])
+).types([793, 'instantiations'])
 
 bench('kysely..leftJoin(table, cb)', () =>
   query.leftJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -66,7 +66,7 @@ bench('kysely..leftJoin(table, cb)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([2254, 'instantiations'])
+).types([2270, 'instantiations'])
 
 bench('kysely..leftJoin(table, cb with ~column)', () =>
   query.leftJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -77,7 +77,7 @@ bench('kysely..leftJoin(table, cb with ~column)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([2310, 'instantiations'])
+).types([2326, 'instantiations'])
 
 //
 
@@ -87,7 +87,7 @@ bench('kyselyAny..leftJoin(table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([891, 'instantiations'])
+).types([299, 'instantiations'])
 
 bench('kyselyAny..leftJoin(~table, k1, k2)', () =>
   queryAny.leftJoin(
@@ -95,7 +95,7 @@ bench('kyselyAny..leftJoin(~table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([891, 'instantiations'])
+).types([299, 'instantiations'])
 
 bench('kyselyAny..leftJoin(table, ~k1, k2)', () =>
   queryAny.leftJoin(
@@ -103,7 +103,7 @@ bench('kyselyAny..leftJoin(table, ~k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052_',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([891, 'instantiations'])
+).types([299, 'instantiations'])
 
 bench('kyselyAny..leftJoin(table, k1, ~k2)', () =>
   queryAny.leftJoin(
@@ -111,7 +111,7 @@ bench('kyselyAny..leftJoin(table, k1, ~k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4_',
   ),
-).types([891, 'instantiations'])
+).types([299, 'instantiations'])
 
 bench('kyselyAny..leftJoin(table as alias, k1, k2)', () =>
   queryAny.leftJoin(
@@ -119,7 +119,7 @@ bench('kyselyAny..leftJoin(table as alias, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     't2.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([881, 'instantiations'])
+).types([289, 'instantiations'])
 
 bench('kyselyAny..leftJoin(table, cb)', () =>
   queryAny.leftJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -129,7 +129,7 @@ bench('kyselyAny..leftJoin(table, cb)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([1507, 'instantiations'])
+).types([1523, 'instantiations'])
 
 bench('kyselyAny..leftJoin(table, cb with ~column)', () =>
   queryAny.leftJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -139,4 +139,4 @@ bench('kyselyAny..leftJoin(table, cb with ~column)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([1507, 'instantiations'])
+).types([1523, 'instantiations'])

--- a/test/ts-benchmarks/with.bench.ts
+++ b/test/ts-benchmarks/with.bench.ts
@@ -19,11 +19,11 @@ bench('kysely.with(cte, qc => qc.insertInto(table))', () => {
 
 bench('kysely.with(cte, qc => qc.updateTable(table))', () => {
   return kysely.with('cte', (qc) => qc.updateTable('my_table').returningAll())
-}).types([23938, 'instantiations'])
+}).types([25062, 'instantiations'])
 
 bench('kysely.with(cte, qc => qc.deleteFrom(table))', () => {
   return kysely.with('cte', (qc) => qc.deleteFrom('my_table').returningAll())
-}).types([11503, 'instantiations'])
+}).types([12624, 'instantiations'])
 
 bench('kyselyAny.with(cte, qc => qc.selectFrom(table))', () => {
   return kyselyAny.with('cte', (qc) => qc.selectFrom('my_table').selectAll())
@@ -37,11 +37,11 @@ bench('kyselyAny.with(cte, qc => qc.updateTable(table))', () => {
   return kyselyAny.with('cte', (qc) =>
     qc.updateTable('my_table').returningAll(),
   )
-}).types([23728, 'instantiations'])
+}).types([24852, 'instantiations'])
 
 bench('kyselyAny.with(cte, qc => qc.deleteFrom(table))', () => {
   return kyselyAny.with('cte', (qc) => qc.deleteFrom('my_table').returningAll())
-}).types([11299, 'instantiations'])
+}).types([12420, 'instantiations'])
 
 bench('kysely.with(cte, () => selectQuery)', () => {
   return kysely.with('cte', () => kysely.selectFrom('my_table').selectAll())
@@ -53,11 +53,11 @@ bench('kysely.with(cte, () => insertQuery)', () => {
 
 bench('kysely.with(cte, () => updateQuery)', () => {
   return kysely.with('cte', () => kysely.updateTable('my_table').returningAll())
-}).types([23926, 'instantiations'])
+}).types([25050, 'instantiations'])
 
 bench('kysely.with(cte, () => deleteQuery)', () => {
   return kysely.with('cte', () => kysely.deleteFrom('my_table').returningAll())
-}).types([11491, 'instantiations'])
+}).types([12612, 'instantiations'])
 
 bench('kyselyAny.with(cte, () => selectQuery)', () => {
   return kyselyAny.with('cte', () =>
@@ -75,13 +75,13 @@ bench('kyselyAny.with(cte, () => updateQuery)', () => {
   return kyselyAny.with('cte', () =>
     kyselyAny.updateTable('my_table').returningAll(),
   )
-}).types([23716, 'instantiations'])
+}).types([24840, 'instantiations'])
 
 bench('kyselyAny.with(cte, () => deleteQuery)', () => {
   return kyselyAny.with('cte', () =>
     kyselyAny.deleteFrom('my_table').returningAll(),
   )
-}).types([11287, 'instantiations'])
+}).types([12408, 'instantiations'])
 
 bench('kysely.with(cte, selectQuery)', () => {
   return kysely.with('cte', kysely.selectFrom('my_table').selectAll())
@@ -93,11 +93,11 @@ bench('kysely.with(cte, insertQuery)', () => {
 
 bench('kysely.with(cte, updateQuery)', () => {
   return kysely.with('cte', kysely.updateTable('my_table').returningAll())
-}).types([23970, 'instantiations'])
+}).types([25094, 'instantiations'])
 
 bench('kysely.with(cte, deleteQuery)', () => {
   return kysely.with('cte', kysely.deleteFrom('my_table').returningAll())
-}).types([11536, 'instantiations'])
+}).types([12657, 'instantiations'])
 
 bench('kyselyAny.with(cte, selectQuery)', () => {
   return kyselyAny.with('cte', kyselyAny.selectFrom('my_table').selectAll())
@@ -109,8 +109,8 @@ bench('kyselyAny.with(cte, insertQuery)', () => {
 
 bench('kyselyAny.with(cte, updateQuery)', () => {
   return kyselyAny.with('cte', kyselyAny.updateTable('my_table').returningAll())
-}).types([23760, 'instantiations'])
+}).types([24884, 'instantiations'])
 
 bench('kyselyAny.with(cte, deleteQuery)', () => {
   return kyselyAny.with('cte', kyselyAny.deleteFrom('my_table').returningAll())
-}).types([11332, 'instantiations'])
+}).types([12453, 'instantiations'])


### PR DESCRIPTION
Kysely accounts for roughly 30% of all types created when typechecking a large codebase I work on (1.4M of 4.7M types, measured with --generateTrace). The program is 8,899 files / 3.6M lines against a 504-table schema, on TypeScript 7 (@typescript/native 7.0.2).

Cold typechecking takes ~9 minutes for that codebase. This PR cuts it roughly in half (measured at 178.7s → 90.1s with --checkers 1, with identical diagnostics) by deferring the join reference check until the joined table is known.

**Detailed explanation**

`K1`/`K2` are constrained by `JoinReferenceExpression<DB, TB, TE>`. Resolving a constraint for them while `TE` is still generic sends the checker through the deferred conditionals behind that type, instantiating `ExtractAliasFromTableExpression` at `TE :=` the whole `TableExpression<DB, TB>` union - per join, per distinct `TB`. The cost is linear in the size of `DB`, so it is invisible on a small schema and dominates on a large one.

Constrain `K1`/`K2` to `string` and re-attach the check in the parameter, behind a non-distributive conditional:

    export type ValidateJoinReference<DB, TB extends keyof DB, TE, K> =
      [K] extends [JoinReferenceExpression<DB, TB, TE>] ? unknown : KyselyTypeError<...>

The default constraint of that conditional is computed from its branches alone, so the checker never walks into `JoinReferenceExpression` to get one. The expensive type is evaluated exactly once per call, after inference, with `TE`, `TB` and `K` all fixed - which is the only point at which the answer can differ from `unknown`. Inferred result types are unchanged; `TE`, the `table` parameter and the return type are untouched.

Applied to the 14 three-argument join overloads (6 select including laterals, 4 update, 4 delete). Each is rewritten in place - no overloads are added.

Invalid references now report through `KyselyTypeError`, which names the offending reference:

    Argument of type '"person.NOPE"' is not assignable to parameter of type
    '"person.NOPE" & KyselyTypeError<"This is not a valid join reference for
    the joined tables: person.NOPE">'

against the previous `AnyJoinColumn<DB, "person", "pet"> | AnyJoinColumnWithTable<DB, "person", "pet">`, which named the aliases rather than the columns.

**Benchmarks** with huge-db

  innerJoin(table, k1, k2):             6538 → 797   -88%
  innerJoin(table as alias, k1, k2):    6534 → 793   -88%
  innerJoin(~table, k1, k2):           21845 → 1350  -94%
  innerJoin(table, ~k1, k2):            7086 → 1281  -82%

Seven benchmarks regress, all within 10%, in `with(cte, deleteQuery)` and `DeleteQueryBuilder` assignability.