### PR TITLE
Update link to Migrator API docs

### DIFF
--- a/site/docs/migrations.mdx
+++ b/site/docs/migrations.mdx
@@ -206,4 +206,4 @@ The migration methods use a lock on the database level and parallel calls are ex
 
 ## Reference documentation
 
-[Migrator](https://kysely-org.github.io/kysely-apidoc/classes/Migrator.html)
+[Migrator](https://kysely-org.github.io/kysely-apidoc/classes/migration.Migrator.html)


### PR DESCRIPTION
The current link 404s.