### PR TITLE
fix: allow referencing never-update columns in on conflict where clauses

### DIFF
--- a/src/query-builder/insert-query-builder.ts
+++ b/src/query-builder/insert-query-builder.ts
@@ -43,10 +43,10 @@ import { ColumnNode } from '../operation-node/column-node.js'
 import type { ReturningInterface } from './returning-interface.js'
 import {
   OnConflictBuilder,
-  type OnConflictDatabase,
   type OnConflictDoNothingBuilder,
   type OnConflictTables,
   type OnConflictUpdateBuilder,
+  type OnConflictWhereDatabase,
 } from './on-conflict-builder.js'
 import { OnConflictNode } from '../operation-node/on-conflict-node.js'
 import type { Selectable } from '../util/column-type.js'
@@ -885,7 +885,7 @@ export class InsertQueryBuilder<DB, TB extends keyof DB, out O>
       builder: OnConflictBuilder<DB, TB>,
     ) =>
       | OnConflictUpdateBuilder<
-          OnConflictDatabase<DB, TB>,
+          OnConflictWhereDatabase<DB, TB>,
           OnConflictTables<TB>
         >
       | OnConflictDoNothingBuilder<DB, TB>,

--- a/src/query-builder/on-conflict-builder.ts
+++ b/src/query-builder/on-conflict-builder.ts
@@ -15,7 +15,7 @@ import {
   type UpdateObjectExpression,
   parseUpdateObjectExpression,
 } from '../parser/update-set-parser.js'
-import type { Updateable } from '../util/column-type.js'
+import type { Selectable, Updateable } from '../util/column-type.js'
 import { freeze } from '../util/object-utils.js'
 import type { AnyColumn, SqlBool } from '../util/type-utils.js'
 import type { WhereInterface } from './where-interface.js'
@@ -254,7 +254,10 @@ export class OnConflictBuilder<
       OnConflictTables<TB>,
       OnConflictTables<TB>
     >,
-  ): OnConflictUpdateBuilder<OnConflictDatabase<DB, TB>, OnConflictTables<TB>> {
+  ): OnConflictUpdateBuilder<
+    OnConflictWhereDatabase<DB, TB>,
+    OnConflictTables<TB>
+  > {
     return new OnConflictUpdateBuilder({
       ...this.#props,
       onConflictNode: OnConflictNode.cloneWith(this.#props.onConflictNode, {
@@ -278,6 +281,15 @@ export interface OnConflictBuilderProps {
 
 export type OnConflictDatabase<DB, TB extends keyof DB> = {
   [K in keyof DB | 'excluded']: Updateable<K extends keyof DB ? DB[K] : DB[TB]>
+}
+
+/**
+ * Same as {@link OnConflictDatabase} but for read-only contexts such as the
+ * `where` clause of an update action. All columns are referenceable, including
+ * those whose update type is `never`.
+ */
+export type OnConflictWhereDatabase<DB, TB extends keyof DB> = {
+  [K in keyof DB | 'excluded']: Selectable<K extends keyof DB ? DB[K] : DB[TB]>
 }
 
 export type OnConflictTables<TB> = TB | 'excluded'

--- a/test/typings/test-d/insert.test-d.ts
+++ b/test/typings/test-d/insert.test-d.ts
@@ -110,6 +110,31 @@ async function testInsert(db: Kysely<Database>) {
       ),
   )
 
+  // Columns whose update type is `never` are referenceable in an
+  // on-conflict `where` clause.
+  const r7 = await db
+    .insertInto('person')
+    .values(person)
+    .onConflict((oc) =>
+      oc
+        .column('id')
+        .doUpdateSet({ first_name: 'foo' })
+        .where('modified_at', '=', new Date()),
+    )
+    .executeTakeFirst()
+
+  expectType<InsertResult>(r7)
+
+  // Columns whose update type is `never` are not allowed in `doUpdateSet`.
+  expectError(
+    db
+      .insertInto('person')
+      .values(person)
+      .onConflict((oc) =>
+        oc.column('id').doUpdateSet({ modified_at: new Date() }),
+      ),
+  )
+
   // GeneratedAlways column is not allowed to be inserted
   expectError(db.insertInto('book').values({ id: 1, name: 'foo' }))
 


### PR DESCRIPTION
## Summary

Columns whose update type is `never` could not be referenced in the `where` clause of an on-conflict update action. The builder typed the where scope as `OnConflictDatabase`, which wraps every table in `Updateable` and drops such columns entirely. This adds an `OnConflictWhereDatabase` type that keeps all columns readable and uses it for the update action's `where`/`whereRef`. The `doUpdateSet` argument still only accepts updatable columns.

Fixes #1409

## Testing

Reproduced with a tsd typings test that references `modified_at` (`ColumnType<Date, never, never>`) inside `doUpdateSet(...).where(...)`. It failed before the change with the error reported in the issue and passes after it. An additional `expectError` asserts such columns stay rejected in `doUpdateSet`. Full typings suite passes; tsc build and prettier are clean.

## Checklist

- bug reproduced
- root cause identified
- fix implemented
- tests passed
- diff reviewed
