### PR TITLE
test(cancellation): cover connection release when abort strategy is unsupported

### DIFF
--- a/test/node/src/cancellation.test.ts
+++ b/test/node/src/cancellation.test.ts
@@ -164,6 +164,28 @@ for (const dialect of DIALECTS) {
       })
     }
 
+    if (variant === 'sqlite' || variant === 'pglite') {
+      for (const strategy of ['cancel query', 'kill session'] as const) {
+        it(`should release the connection when inflightQueryAbortStrategy '${strategy}' is unsupported`, async () => {
+          // A non-aborted signal is required so execution reaches the
+          // unsupported-strategy check rather than the aborted-signal path.
+          await expect(
+            ctx.db.selectFrom('person').selectAll().execute({
+              inflightQueryAbortStrategy: strategy,
+              signal: new AbortController().signal,
+            }),
+          ).to.eventually.be.rejectedWith(/doesn't support/)
+
+          // The unsupported-strategy error must release the controlled
+          // connection first. On a single-connection dialect a leaked
+          // connection would deadlock this next query. Regression test for the
+          // fix in #1971.
+          await expect(ctx.db.selectFrom('person').selectAll().execute()).to.not
+            .be.eventually.rejected
+        })
+      }
+    }
+
     it('should throw an abort error when aborted during result transformation', async () => {
       const abortController = new AbortController()
 


### PR DESCRIPTION
#1971 fixed a connection leak: when `inflightQueryAbortStrategy` is `'cancel query'` or `'kill session'` and the dialect's connection implements neither `cancelQuery` nor `killSession`, `getInflightQueryAbortHandler` now calls `beforeThrow()` (the controlled-connection `release`) before throwing the "doesn't support" error. That fix shipped without a test.

This adds one, gated to the single-connection dialects (`sqlite`, `pglite`). Both set `supportsMultipleConnections = false`, so `RuntimeDriver` serializes on a `ConnectionMutex`. If the unsupported-strategy error is thrown without releasing the connection, the mutex is never released and the next query deadlocks. The test runs an unsupported-strategy query with a non-aborted signal (so execution reaches the strategy check rather than the aborted-signal path), asserts it rejects with the "doesn't support" error, then asserts a following plain query resolves. Before #1971 that second query hangs.

### How it was verified

I could not run the full test harness on this machine (no native `better-sqlite3` build for my Node version), so I reproduced the exact path against `src` with a minimal single-connection driver through `RuntimeDriver`/`ConnectionMutex` and the real abort/connection code:

- current `main` (fix present): the unsupported-strategy query rejects, and the following query resolves (connection released).
- with the two `beforeThrow()` calls in `abort.ts` reverted (pre-#1971): the following query deadlocks (connection leaked).

So the test passes on `main` and fails against the pre-fix code, which is what a regression test should do. CI is the confirming run across the real `sqlite` and `pglite` drivers.

One choice worth flagging: the failing case relies on the mocha timeout, since a leaked connection hangs rather than errors. I kept it simple to match the existing cancellation tests, but I am happy to wrap the second query in an explicit short timeout if you would rather the failure be fast and self-describing.

---

*Disclosure: I used an AI coding assistant on this work. The reproduction and the pre/post-fix runs above were executed and confirmed by me.*
