### PR TITLE
feat(introspector): add `where` option for partial introspection.

### DIFF
--- a/src/dialect/database-introspector.ts
+++ b/src/dialect/database-introspector.ts
@@ -18,14 +18,12 @@ export interface DatabaseIntrospector {
 
 export interface DatabaseMetadataOptions {
   /**
-   * If this is true, the metadata contains the internal kysely tables
-   * such as the migration tables.
-   */
-  withInternalKyselyTables: boolean
-
-  /**
    * An optional SQL expression for filtering the tables returned by the
    * introspector.
+   *
+   * The refs argument contains SQL references to the table name and optional
+   * schema name columns within the catalog query this filter will be used
+   * in.
    */
   filter?: (
     refs: Readonly<{
@@ -33,6 +31,12 @@ export interface DatabaseMetadataOptions {
       schema?: Expression<string>
     }>,
   ) => Expression<SqlBool>
+
+  /**
+   * If this is true, the metadata contains the internal kysely tables
+   * such as the migration tables.
+   */
+  withInternalKyselyTables: boolean
 }
 
 export interface SchemaMetadata {

--- a/src/dialect/database-introspector.ts
+++ b/src/dialect/database-introspector.ts
@@ -18,14 +18,14 @@ export interface DatabaseIntrospector {
 
 export interface DatabaseMetadataOptions {
   /**
-   * An optional SQL expression for filtering the tables returned by the
-   * introspector.
+   * An optional SQL `where` expression for filtering the tables returned by
+   * the introspector.
    *
    * The refs argument contains SQL references to the table name and optional
-   * schema name columns within the catalog query this filter will be used
+   * schema name columns within the catalog query this expression will be used
    * in.
    */
-  filter?: (
+  where?: (
     refs: Readonly<{
       table: Expression<string>
       schema?: Expression<string>

--- a/src/dialect/database-introspector.ts
+++ b/src/dialect/database-introspector.ts
@@ -1,3 +1,6 @@
+import type { Expression } from '../expression/expression.js'
+import type { SqlBool } from '../util/type-utils.js'
+
 /**
  * An interface for getting the database metadata (names of the tables and columns etc.)
  */
@@ -19,6 +22,17 @@ export interface DatabaseMetadataOptions {
    * such as the migration tables.
    */
   withInternalKyselyTables: boolean
+
+  /**
+   * An optional SQL expression for filtering the tables returned by the
+   * introspector.
+   */
+  filter?: (
+    refs: Readonly<{
+      table: Expression<string>
+      schema?: Expression<string>
+    }>,
+  ) => Expression<SqlBool>
 }
 
 export interface SchemaMetadata {

--- a/src/dialect/mssql/mssql-introspector.ts
+++ b/src/dialect/mssql/mssql-introspector.ts
@@ -26,11 +26,11 @@ export class MssqlIntrospector implements DatabaseIntrospector {
   async getTables(
     options: DatabaseMetadataOptions = { withInternalKyselyTables: false },
   ): Promise<TableMetadata[]> {
-    const tablesFilter = options.filter?.({
+    const tablesWhere = options.where?.({
       schema: sql.ref<string>('table_schemas.name'),
       table: sql.ref<string>('tables.name'),
     })
-    const viewsFilter = options.filter?.({
+    const viewsWhere = options.where?.({
       schema: sql.ref<string>('view_schemas.name'),
       table: sql.ref<string>('views.name'),
     })
@@ -68,7 +68,7 @@ export class MssqlIntrospector implements DatabaseIntrospector {
           .where('tables.name', '!=', DEFAULT_MIGRATION_TABLE)
           .where('tables.name', '!=', DEFAULT_MIGRATION_LOCK_TABLE),
       )
-      .$if(!!tablesFilter, (qb) => qb.where(tablesFilter!))
+      .$if(!!tablesWhere, (qb) => qb.where(tablesWhere!))
       .select([
         'tables.name as table_name',
         (eb) =>
@@ -121,7 +121,7 @@ export class MssqlIntrospector implements DatabaseIntrospector {
               .onRef('comments.minor_id', '=', 'columns.column_id')
               .on('comments.name', '=', 'MS_Description'),
           )
-          .$if(!!viewsFilter, (qb) => qb.where(viewsFilter!))
+          .$if(!!viewsWhere, (qb) => qb.where(viewsWhere!))
           .select([
             'views.name as table_name',
             'views.type as table_type',

--- a/src/dialect/mssql/mssql-introspector.ts
+++ b/src/dialect/mssql/mssql-introspector.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_MIGRATION_LOCK_TABLE,
   DEFAULT_MIGRATION_TABLE,
 } from '../../migration/migrator.js'
+import { sql } from '../../raw-builder/sql.js'
 import { freeze } from '../../util/object-utils.js'
 
 export class MssqlIntrospector implements DatabaseIntrospector {
@@ -25,6 +26,15 @@ export class MssqlIntrospector implements DatabaseIntrospector {
   async getTables(
     options: DatabaseMetadataOptions = { withInternalKyselyTables: false },
   ): Promise<TableMetadata[]> {
+    const tablesFilter = options.filter?.({
+      table: sql.ref<string>('tables.name'),
+      schema: sql.ref<string>('table_schemas.name'),
+    })
+    const viewsFilter = options.filter?.({
+      table: sql.ref<string>('views.name'),
+      schema: sql.ref<string>('view_schemas.name'),
+    })
+
     const rawColumns = await this.#db
       .selectFrom('sys.tables as tables')
       .leftJoin(
@@ -58,6 +68,7 @@ export class MssqlIntrospector implements DatabaseIntrospector {
           .where('tables.name', '!=', DEFAULT_MIGRATION_TABLE)
           .where('tables.name', '!=', DEFAULT_MIGRATION_LOCK_TABLE),
       )
+      .$if(!!tablesFilter, (qb) => qb.where(tablesFilter!))
       .select([
         'tables.name as table_name',
         (eb) =>
@@ -110,6 +121,7 @@ export class MssqlIntrospector implements DatabaseIntrospector {
               .onRef('comments.minor_id', '=', 'columns.column_id')
               .on('comments.name', '=', 'MS_Description'),
           )
+          .$if(!!viewsFilter, (qb) => qb.where(viewsFilter!))
           .select([
             'views.name as table_name',
             'views.type as table_type',

--- a/src/dialect/mssql/mssql-introspector.ts
+++ b/src/dialect/mssql/mssql-introspector.ts
@@ -27,12 +27,12 @@ export class MssqlIntrospector implements DatabaseIntrospector {
     options: DatabaseMetadataOptions = { withInternalKyselyTables: false },
   ): Promise<TableMetadata[]> {
     const tablesFilter = options.filter?.({
-      table: sql.ref<string>('tables.name'),
       schema: sql.ref<string>('table_schemas.name'),
+      table: sql.ref<string>('tables.name'),
     })
     const viewsFilter = options.filter?.({
-      table: sql.ref<string>('views.name'),
       schema: sql.ref<string>('view_schemas.name'),
+      table: sql.ref<string>('views.name'),
     })
 
     const rawColumns = await this.#db

--- a/src/dialect/mysql/mysql-introspector.ts
+++ b/src/dialect/mysql/mysql-introspector.ts
@@ -63,6 +63,15 @@ export class MysqlIntrospector implements DatabaseIntrospector {
         .where('columns.TABLE_NAME', '!=', DEFAULT_MIGRATION_LOCK_TABLE)
     }
 
+    if (options.filter) {
+      query = query.where(
+        options.filter({
+          table: sql.ref<string>('columns.TABLE_NAME'),
+          schema: sql.ref<string>('columns.TABLE_SCHEMA'),
+        }),
+      )
+    }
+
     const rawColumns = await query.execute()
     return this.#parseTableMetadata(rawColumns)
   }

--- a/src/dialect/mysql/mysql-introspector.ts
+++ b/src/dialect/mysql/mysql-introspector.ts
@@ -63,9 +63,9 @@ export class MysqlIntrospector implements DatabaseIntrospector {
         .where('columns.TABLE_NAME', '!=', DEFAULT_MIGRATION_LOCK_TABLE)
     }
 
-    if (options.filter) {
+    if (options.where) {
       query = query.where(
-        options.filter({
+        options.where({
           schema: sql.ref<string>('columns.TABLE_SCHEMA'),
           table: sql.ref<string>('columns.TABLE_NAME'),
         }),

--- a/src/dialect/mysql/mysql-introspector.ts
+++ b/src/dialect/mysql/mysql-introspector.ts
@@ -66,8 +66,8 @@ export class MysqlIntrospector implements DatabaseIntrospector {
     if (options.filter) {
       query = query.where(
         options.filter({
-          table: sql.ref<string>('columns.TABLE_NAME'),
           schema: sql.ref<string>('columns.TABLE_SCHEMA'),
+          table: sql.ref<string>('columns.TABLE_NAME'),
         }),
       )
     }

--- a/src/dialect/postgres/postgres-introspector.ts
+++ b/src/dialect/postgres/postgres-introspector.ts
@@ -91,9 +91,9 @@ export class PostgresIntrospector implements DatabaseIntrospector {
         .where('c.relname', '!=', DEFAULT_MIGRATION_LOCK_TABLE)
     }
 
-    if (options.filter) {
+    if (options.where) {
       query = query.where(
-        options.filter({
+        options.where({
           schema: sql.ref<string>('ns.nspname'),
           table: sql.ref<string>('c.relname'),
         }),

--- a/src/dialect/postgres/postgres-introspector.ts
+++ b/src/dialect/postgres/postgres-introspector.ts
@@ -91,6 +91,15 @@ export class PostgresIntrospector implements DatabaseIntrospector {
         .where('c.relname', '!=', DEFAULT_MIGRATION_LOCK_TABLE)
     }
 
+    if (options.filter) {
+      query = query.where(
+        options.filter({
+          table: sql.ref<string>('c.relname'),
+          schema: sql.ref<string>('ns.nspname'),
+        }),
+      )
+    }
+
     const rawColumns = await query.execute()
 
     return this.#parseTableMetadata(rawColumns)

--- a/src/dialect/postgres/postgres-introspector.ts
+++ b/src/dialect/postgres/postgres-introspector.ts
@@ -94,8 +94,8 @@ export class PostgresIntrospector implements DatabaseIntrospector {
     if (options.filter) {
       query = query.where(
         options.filter({
-          table: sql.ref<string>('c.relname'),
           schema: sql.ref<string>('ns.nspname'),
+          table: sql.ref<string>('c.relname'),
         }),
       )
     }

--- a/src/dialect/sqlite/sqlite-introspector.ts
+++ b/src/dialect/sqlite/sqlite-introspector.ts
@@ -70,6 +70,13 @@ export class SqliteIntrospector implements DatabaseIntrospector {
         .where('name', '!=', DEFAULT_MIGRATION_TABLE)
         .where('name', '!=', DEFAULT_MIGRATION_LOCK_TABLE)
     }
+
+    if (options.filter) {
+      tablesQuery = tablesQuery.where(
+        options.filter({ table: sql.ref<string>('name') }),
+      )
+    }
+
     return tablesQuery
   }
 

--- a/src/dialect/sqlite/sqlite-introspector.ts
+++ b/src/dialect/sqlite/sqlite-introspector.ts
@@ -71,9 +71,9 @@ export class SqliteIntrospector implements DatabaseIntrospector {
         .where('name', '!=', DEFAULT_MIGRATION_LOCK_TABLE)
     }
 
-    if (options.filter) {
+    if (options.where) {
       tablesQuery = tablesQuery.where(
-        options.filter({ table: sql.ref<string>('name') }),
+        options.where({ table: sql.ref<string>('name') }),
       )
     }
 

--- a/src/migration/migrator.ts
+++ b/src/migration/migrator.ts
@@ -6,10 +6,12 @@ import type { Kysely } from '../kysely.js'
 import type { KyselyPlugin } from '../plugin/kysely-plugin.js'
 import { NoopPlugin } from '../plugin/noop-plugin.js'
 import { WithSchemaPlugin } from '../plugin/with-schema/with-schema-plugin.js'
+import { sql } from '../raw-builder/sql.js'
 import type { CreateSchemaBuilder } from '../schema/create-schema-builder.js'
 import type { CreateTableBuilder } from '../schema/create-table-builder.js'
 import { logOnce } from '../util/log-once.js'
 import { freeze, isObject } from '../util/object-utils.js'
+import type { SqlBool } from '../util/type-utils.js'
 import type { Migration } from './migration.js'
 
 export const DEFAULT_MIGRATION_TABLE = 'kysely_migration'
@@ -65,7 +67,10 @@ export class Migrator {
    * The returned array is sorted by migration name.
    */
   async getMigrations(): Promise<ReadonlyArray<MigrationInfo>> {
-    const tableExists = await this.#doesTableExist(this.#migrationTable)
+    const tableExists = await this.#doesTableExist(
+      this.#migrationTableSchema,
+      this.#migrationTable,
+    )
 
     const executedMigrations = tableExists
       ? await this.#props.db
@@ -423,7 +428,10 @@ export class Migrator {
   }
 
   async #ensureMigrationTableExists(): Promise<void> {
-    const tableExists = await this.#doesTableExist(this.#migrationTable)
+    const tableExists = await this.#doesTableExist(
+      this.#migrationTableSchema,
+      this.#migrationTable,
+    )
 
     if (tableExists) {
       return
@@ -442,7 +450,10 @@ export class Migrator {
           .addColumn('timestamp', 'varchar(255)', (col) => col.notNull()),
       )
     } catch (error) {
-      const tableExists = await this.#doesTableExist(this.#migrationTable)
+      const tableExists = await this.#doesTableExist(
+        this.#migrationTableSchema,
+        this.#migrationTable,
+      )
 
       // At least on PostgreSQL, `if not exists` doesn't guarantee the `create table`
       // query doesn't throw if the table already exits. That's why we check if
@@ -454,7 +465,10 @@ export class Migrator {
   }
 
   async #ensureMigrationLockTableExists(): Promise<void> {
-    const tableExists = await this.#doesTableExist(this.#migrationLockTable)
+    const tableExists = await this.#doesTableExist(
+      this.#migrationTableSchema,
+      this.#migrationLockTable,
+    )
 
     if (tableExists) {
       return
@@ -471,7 +485,10 @@ export class Migrator {
           ),
       )
     } catch (error) {
-      const tableExists = await this.#doesTableExist(this.#migrationLockTable)
+      const tableExists = await this.#doesTableExist(
+        this.#migrationTableSchema,
+        this.#migrationLockTable,
+      )
 
       // At least on PostgreSQL, `if not exists` doesn't guarantee the `create table`
       // query doesn't throw if the table already exits. That's why we check if
@@ -510,15 +527,23 @@ export class Migrator {
     return schemas.some((it) => it.name === this.#migrationTableSchema)
   }
 
-  async #doesTableExist(tableName: string): Promise<boolean> {
-    const schema = this.#migrationTableSchema
-
+  async #doesTableExist(
+    schemaName: string | undefined,
+    tableName: string,
+  ): Promise<boolean> {
     const tables = await this.#props.db.introspection.getTables({
+      filter: ({ schema, table }) =>
+        schemaName != null && schema
+          ? sql<SqlBool>`${schema} = ${schemaName} and ${table} = ${tableName}`
+          : sql<SqlBool>`${table} = ${tableName}`,
       withInternalKyselyTables: true,
     })
 
+    // we still keep this in case the introspector doesn't implement support for
+    // `filter`.
     return tables.some(
-      (it) => it.name === tableName && (!schema || it.schema === schema),
+      (it) =>
+        it.name === tableName && (!schemaName || it.schema === schemaName),
     )
   }
 

--- a/src/migration/migrator.ts
+++ b/src/migration/migrator.ts
@@ -543,9 +543,7 @@ export class Migrator {
     // `filter`.
     return tables.some(
       (it) =>
-        it.name === tableName &&
-        (!schemaName || it.schema === schemaName) &&
-        !it.isView,
+        it.name === tableName && (!schemaName || it.schema === schemaName),
     )
   }
 

--- a/src/migration/migrator.ts
+++ b/src/migration/migrator.ts
@@ -545,8 +545,7 @@ export class Migrator {
       (it) =>
         it.name === tableName &&
         (!schemaName || it.schema === schemaName) &&
-        !it.isView &&
-        !it.isForeign,
+        !it.isView,
     )
   }
 

--- a/src/migration/migrator.ts
+++ b/src/migration/migrator.ts
@@ -543,7 +543,10 @@ export class Migrator {
     // `filter`.
     return tables.some(
       (it) =>
-        it.name === tableName && (!schemaName || it.schema === schemaName),
+        it.name === tableName &&
+        (!schemaName || it.schema === schemaName) &&
+        !it.isView &&
+        !it.isForeign,
     )
   }
 

--- a/src/migration/migrator.ts
+++ b/src/migration/migrator.ts
@@ -532,7 +532,7 @@ export class Migrator {
     tableName: string,
   ): Promise<boolean> {
     const tables = await this.#props.db.introspection.getTables({
-      filter: ({ schema, table }) =>
+      where: ({ schema, table }) =>
         schemaName != null && schema
           ? sql<SqlBool>`${schema} = ${schemaName} and ${table} = ${tableName}`
           : sql<SqlBool>`${table} = ${tableName}`,
@@ -540,7 +540,7 @@ export class Migrator {
     })
 
     // we still keep this in case the introspector doesn't implement support for
-    // `filter`.
+    // `where`.
     return tables.some(
       (it) =>
         it.name === tableName && (!schemaName || it.schema === schemaName),

--- a/test/node/src/introspect.test.ts
+++ b/test/node/src/introspect.test.ts
@@ -1,4 +1,4 @@
-import { sql } from '../../../dist/index.js'
+import { sql, type SqlBool } from '../../../dist/index.js'
 import {
   clearDatabase,
   destroyTest,
@@ -80,6 +80,15 @@ for (const dialect of DIALECTS) {
     })
 
     describe('getTables', () => {
+      it('should filter tables in the metadata query', async () => {
+        const meta = await ctx.db.introspection.getTables({
+          withInternalKyselyTables: false,
+          filter: ({ table }) => sql<SqlBool>`${table} = ${'person'}`,
+        })
+
+        expect(meta.map((table) => table.name)).to.eql(['person'])
+      })
+
       it('should get table metadata', async () => {
         const meta = await ctx.db.introspection.getTables()
 

--- a/test/node/src/introspect.test.ts
+++ b/test/node/src/introspect.test.ts
@@ -80,15 +80,6 @@ for (const dialect of DIALECTS) {
     })
 
     describe('getTables', () => {
-      it('should filter tables in the metadata query', async () => {
-        const meta = await ctx.db.introspection.getTables({
-          withInternalKyselyTables: false,
-          filter: ({ table }) => sql<SqlBool>`${table} = ${'person'}`,
-        })
-
-        expect(meta.map((table) => table.name)).to.eql(['person'])
-      })
-
       it('should get table metadata', async () => {
         const meta = await ctx.db.introspection.getTables()
 
@@ -903,6 +894,73 @@ for (const dialect of DIALECTS) {
           })
         })
       }
+
+      it('should filter tables by name in the metadata query', async () => {
+        const meta = await ctx.db.introspection.getTables({
+          withInternalKyselyTables: false,
+          filter: ({ table }) => sql<SqlBool>`${table} = ${'person'}`,
+        })
+
+        expect(meta.map((table) => table.name)).to.eql(['person'])
+      })
+
+      it('should filter tables by name and schema in the metadata query', async () => {
+        const schemaName =
+          sqlSpec === 'postgres' || sqlSpec === 'mssql'
+            ? 'some_schema'
+            : sqlSpec === 'mysql'
+              ? 'kysely_test'
+              : undefined
+        const meta = await ctx.db.introspection.getTables({
+          withInternalKyselyTables: false,
+          filter: ({ schema, table }) => {
+            if (schemaName) {
+              if (!schema) {
+                throw new Error('expected the introspector to provide a schema')
+              }
+
+              return sql<SqlBool>`${schema} = ${schemaName} and ${table} = ${'pet'}`
+            }
+
+            expect(schema).to.be.undefined
+
+            return sql<SqlBool>`${table} = ${'pet'}`
+          },
+        })
+
+        expect(meta).to.have.length(1)
+        expect(meta[0].name).to.equal('pet')
+        expect(meta[0].schema).to.equal(schemaName)
+      })
+
+      it('should apply the filter together with the internal table option', async () => {
+        const internalTableName = 'kysely_migration'
+
+        await ctx.db.schema
+          .createTable(internalTableName)
+          .addColumn('name', 'varchar(255)', (col) => col.notNull())
+          .execute()
+
+        try {
+          const excluded = await ctx.db.introspection.getTables({
+            filter: ({ table }) =>
+              sql<SqlBool>`${table} = ${internalTableName}`,
+            withInternalKyselyTables: false,
+          })
+          const included = await ctx.db.introspection.getTables({
+            filter: ({ table }) =>
+              sql<SqlBool>`${table} = ${internalTableName}`,
+            withInternalKyselyTables: true,
+          })
+
+          expect(excluded).to.eql([])
+          expect(included.map((table) => table.name)).to.eql([
+            internalTableName,
+          ])
+        } finally {
+          await ctx.db.schema.dropTable(internalTableName).execute()
+        }
+      })
     })
 
     async function createView() {

--- a/test/node/src/introspect.test.ts
+++ b/test/node/src/introspect.test.ts
@@ -895,16 +895,16 @@ for (const dialect of DIALECTS) {
         })
       }
 
-      it('should filter tables by name in the metadata query', async () => {
+      it('should apply a where expression to the metadata query', async () => {
         const meta = await ctx.db.introspection.getTables({
           withInternalKyselyTables: false,
-          filter: ({ table }) => sql<SqlBool>`${table} = ${'person'}`,
+          where: ({ table }) => sql<SqlBool>`${table} = ${'person'}`,
         })
 
         expect(meta.map((table) => table.name)).to.eql(['person'])
       })
 
-      it('should filter tables by name and schema in the metadata query', async () => {
+      it('should apply a where expression using the table and schema', async () => {
         const schemaName =
           sqlSpec === 'postgres' || sqlSpec === 'mssql'
             ? 'some_schema'
@@ -913,7 +913,7 @@ for (const dialect of DIALECTS) {
               : undefined
         const meta = await ctx.db.introspection.getTables({
           withInternalKyselyTables: false,
-          filter: ({ schema, table }) => {
+          where: ({ schema, table }) => {
             if (schemaName) {
               if (!schema) {
                 throw new Error('expected the introspector to provide a schema')
@@ -933,7 +933,7 @@ for (const dialect of DIALECTS) {
         expect(meta[0].schema).to.equal(schemaName)
       })
 
-      it('should apply the filter together with the internal table option', async () => {
+      it('should apply the where expression together with the internal table option', async () => {
         const internalTableName = 'kysely_migration'
 
         await ctx.db.schema
@@ -943,13 +943,11 @@ for (const dialect of DIALECTS) {
 
         try {
           const excluded = await ctx.db.introspection.getTables({
-            filter: ({ table }) =>
-              sql<SqlBool>`${table} = ${internalTableName}`,
+            where: ({ table }) => sql<SqlBool>`${table} = ${internalTableName}`,
             withInternalKyselyTables: false,
           })
           const included = await ctx.db.introspection.getTables({
-            filter: ({ table }) =>
-              sql<SqlBool>`${table} = ${internalTableName}`,
+            where: ({ table }) => sql<SqlBool>`${table} = ${internalTableName}`,
             withInternalKyselyTables: true,
           })
 

--- a/test/node/src/migration.test.ts
+++ b/test/node/src/migration.test.ts
@@ -82,9 +82,9 @@ for (const dialect of DIALECTS) {
         expect(migrations2[2].executedAt).to.equal(undefined)
       })
 
-      it('should support introspectors that ignore filter', async () => {
+      it('should support introspectors that ignore the where option', async () => {
         const introspector = ctx.db.introspection
-        const filterIgnoringIntrospector = {
+        const whereIgnoringIntrospector = {
           getSchemas: () => introspector.getSchemas(),
           getTables: (options) =>
             introspector.getTables({
@@ -96,7 +96,7 @@ for (const dialect of DIALECTS) {
 
         sandbox
           .stub(ctx.db, 'introspection')
-          .get(() => filterIgnoringIntrospector)
+          .get(() => whereIgnoringIntrospector)
 
         try {
           const { migrator } = createMigrations(['migration1'])

--- a/test/node/src/migration.test.ts
+++ b/test/node/src/migration.test.ts
@@ -3,7 +3,7 @@ import { setTimeout } from 'node:timers/promises'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'pathe'
 import { createSandbox, type SinonSpy } from 'sinon'
-import type { Kysely } from '../../../dist/index.js'
+import type { DatabaseIntrospector, Kysely } from '../../../dist/index.js'
 import {
   FileMigrationProvider,
   type Migration,
@@ -80,6 +80,35 @@ for (const dialect of DIALECTS) {
         expect(migrations2[1].executedAt).to.be.instanceOf(Date)
         expect(migrations2[2].name).to.equal('migration3')
         expect(migrations2[2].executedAt).to.equal(undefined)
+      })
+
+      it('should support introspectors that ignore filter', async () => {
+        const introspector = ctx.db.introspection
+        const filterIgnoringIntrospector = {
+          getSchemas: () => introspector.getSchemas(),
+          getTables: (options) =>
+            introspector.getTables({
+              withInternalKyselyTables:
+                options?.withInternalKyselyTables ?? false,
+            }),
+        } satisfies DatabaseIntrospector
+        const sandbox = createSandbox()
+
+        sandbox
+          .stub(ctx.db, 'introspection')
+          .get(() => filterIgnoringIntrospector)
+
+        try {
+          const { migrator } = createMigrations(['migration1'])
+
+          expect(await migrator.getMigrations()).to.have.length(1)
+          expect((await migrator.migrateUp()).error).to.be.undefined
+          expect(
+            (await migrator.getMigrations())[0].executedAt,
+          ).to.be.instanceOf(Date)
+        } finally {
+          sandbox.restore()
+        }
       })
     })
 


### PR DESCRIPTION
Hey :wave:

This PR adds the `where` option to introspectors.

This enables anything using them to perform partial introspection on the database side using any boolean SQL expression, with the relevant column references for table and schema names provided by the introspector.

The motivation is:

1. production databases might have lots of tables, teams might need just a subset of these type-generated.
2. production systems might have a shared database, but different services would use/know about a small subset of the tables each.
3. we don't want to design a high-level abstraction for filtering, we want to keep it SQL native - letting consumers have full freedom to do whatever they need, not only eq/neq.
4. each introspector has its own references for table and schema name columns. Consumers should not know anything about them but be allowed to use them.
5. `kysely`'s own migrator uses introspection to check for existence of its state tables, and today, without a `where` expression, this forces overfetching the entirety of the database schema just to find a single table. This slows down migration operations. This PR dogfoods the new `where` option in this use case. If an introspector doesn't support the option, everything still works and we still do the same check after the introspection results.
6. tools such as `kysely-codegen` and `better-auth` get partial introspection for various use cases.
7. consumers using managed databases that contain tables that they're not allowed to even introspect, can now use the migrator and anything else using the introspectors.

Closes #1571.

Also addresses the migrator introspection performance concerns described in #1313 and #1707, the schema-scoping case in #1419, and the D1 migration failure in #1108.

Part of #1502.
