### PR TITLE
feat(introspector): add `where` option in `getSchemas`.

### DIFF
--- a/src/dialect/database-introspector.ts
+++ b/src/dialect/database-introspector.ts
@@ -8,12 +8,27 @@ export interface DatabaseIntrospector {
   /**
    * Get schema metadata.
    */
-  getSchemas(): Promise<SchemaMetadata[]>
+  getSchemas(options?: DatabaseSchemaMetadataOptions): Promise<SchemaMetadata[]>
 
   /**
    * Get tables and views metadata.
    */
   getTables(options?: DatabaseMetadataOptions): Promise<TableMetadata[]>
+}
+
+export interface DatabaseSchemaMetadataOptions {
+  /**
+   * An optional SQL `where` expression for filtering the schemas returned by
+   * the introspector.
+   *
+   * The refs argument contains an SQL reference to the schema name column
+   * within the catalog query this expression will be used in.
+   */
+  where?: (
+    refs: Readonly<{
+      schema: Expression<string>
+    }>,
+  ) => Expression<SqlBool>
 }
 
 export interface DatabaseMetadataOptions {

--- a/src/dialect/mssql/mssql-introspector.ts
+++ b/src/dialect/mssql/mssql-introspector.ts
@@ -2,6 +2,7 @@ import type { Kysely } from '../../kysely.js'
 import type {
   DatabaseIntrospector,
   DatabaseMetadataOptions,
+  DatabaseSchemaMetadataOptions,
   SchemaMetadata,
   TableMetadata,
 } from '../database-introspector.js'
@@ -19,8 +20,16 @@ export class MssqlIntrospector implements DatabaseIntrospector {
     this.#db = db
   }
 
-  async getSchemas(): Promise<SchemaMetadata[]> {
-    return await this.#db.selectFrom('sys.schemas').select('name').execute()
+  async getSchemas(
+    options: DatabaseSchemaMetadataOptions = {},
+  ): Promise<SchemaMetadata[]> {
+    let query = this.#db.selectFrom('sys.schemas').select('name')
+
+    if (options.where) {
+      query = query.where(options.where({ schema: sql.ref<string>('name') }))
+    }
+
+    return await query.execute()
   }
 
   async getTables(

--- a/src/dialect/mysql/mysql-introspector.ts
+++ b/src/dialect/mysql/mysql-introspector.ts
@@ -25,8 +25,8 @@ export class MysqlIntrospector implements DatabaseIntrospector {
   ): Promise<SchemaMetadata[]> {
     let query = this.#db
       .selectFrom('information_schema.schemata')
-      .select('schema_name')
-      .$castTo<RawSchemaMetadata>()
+      .select('schema_name as name')
+      .$castTo<SchemaMetadata>()
 
     if (options.where) {
       query = query.where(
@@ -34,9 +34,7 @@ export class MysqlIntrospector implements DatabaseIntrospector {
       )
     }
 
-    const rawSchemas = await query.execute()
-
-    return rawSchemas.map((it) => ({ name: it.SCHEMA_NAME }))
+    return await query.execute()
   }
 
   async getTables(
@@ -116,10 +114,6 @@ export class MysqlIntrospector implements DatabaseIntrospector {
       return tables
     }, [])
   }
-}
-
-interface RawSchemaMetadata {
-  SCHEMA_NAME: string
 }
 
 interface RawColumnMetadata {

--- a/src/dialect/mysql/mysql-introspector.ts
+++ b/src/dialect/mysql/mysql-introspector.ts
@@ -26,7 +26,7 @@ export class MysqlIntrospector implements DatabaseIntrospector {
     let query = this.#db
       .selectFrom('information_schema.schemata')
       .select('schema_name as name')
-      .$castTo<SchemaMetadata>()
+      .$narrowType<SchemaMetadata>()
 
     if (options.where) {
       query = query.where(

--- a/src/dialect/mysql/mysql-introspector.ts
+++ b/src/dialect/mysql/mysql-introspector.ts
@@ -1,6 +1,7 @@
 import type {
   DatabaseIntrospector,
   DatabaseMetadataOptions,
+  DatabaseSchemaMetadataOptions,
   SchemaMetadata,
   TableMetadata,
 } from '../database-introspector.js'
@@ -19,12 +20,21 @@ export class MysqlIntrospector implements DatabaseIntrospector {
     this.#db = db
   }
 
-  async getSchemas(): Promise<SchemaMetadata[]> {
-    let rawSchemas = await this.#db
+  async getSchemas(
+    options: DatabaseSchemaMetadataOptions = {},
+  ): Promise<SchemaMetadata[]> {
+    let query = this.#db
       .selectFrom('information_schema.schemata')
       .select('schema_name')
       .$castTo<RawSchemaMetadata>()
-      .execute()
+
+    if (options.where) {
+      query = query.where(
+        options.where({ schema: sql.ref<string>('schema_name') }),
+      )
+    }
+
+    const rawSchemas = await query.execute()
 
     return rawSchemas.map((it) => ({ name: it.SCHEMA_NAME }))
   }

--- a/src/dialect/postgres/postgres-introspector.ts
+++ b/src/dialect/postgres/postgres-introspector.ts
@@ -26,7 +26,7 @@ export class PostgresIntrospector implements DatabaseIntrospector {
     let query = this.#db
       .selectFrom('pg_catalog.pg_namespace')
       .select('nspname as name')
-      .$castTo<SchemaMetadata>()
+      .$narrowType<SchemaMetadata>()
 
     if (options.where) {
       query = query.where(options.where({ schema: sql.ref<string>('nspname') }))

--- a/src/dialect/postgres/postgres-introspector.ts
+++ b/src/dialect/postgres/postgres-introspector.ts
@@ -25,16 +25,14 @@ export class PostgresIntrospector implements DatabaseIntrospector {
   ): Promise<SchemaMetadata[]> {
     let query = this.#db
       .selectFrom('pg_catalog.pg_namespace')
-      .select('nspname')
-      .$castTo<RawSchemaMetadata>()
+      .select('nspname as name')
+      .$castTo<SchemaMetadata>()
 
     if (options.where) {
       query = query.where(options.where({ schema: sql.ref<string>('nspname') }))
     }
 
-    const rawSchemas = await query.execute()
-
-    return rawSchemas.map((it) => ({ name: it.nspname }))
+    return await query.execute()
   }
 
   async getTables(
@@ -154,10 +152,6 @@ export class PostgresIntrospector implements DatabaseIntrospector {
 
     return tables
   }
-}
-
-interface RawSchemaMetadata {
-  nspname: string
 }
 
 interface RawColumnMetadata {

--- a/src/dialect/postgres/postgres-introspector.ts
+++ b/src/dialect/postgres/postgres-introspector.ts
@@ -1,6 +1,7 @@
 import type {
   DatabaseIntrospector,
   DatabaseMetadataOptions,
+  DatabaseSchemaMetadataOptions,
   SchemaMetadata,
   TableMetadata,
 } from '../database-introspector.js'
@@ -19,12 +20,19 @@ export class PostgresIntrospector implements DatabaseIntrospector {
     this.#db = db
   }
 
-  async getSchemas(): Promise<SchemaMetadata[]> {
-    let rawSchemas = await this.#db
+  async getSchemas(
+    options: DatabaseSchemaMetadataOptions = {},
+  ): Promise<SchemaMetadata[]> {
+    let query = this.#db
       .selectFrom('pg_catalog.pg_namespace')
       .select('nspname')
       .$castTo<RawSchemaMetadata>()
-      .execute()
+
+    if (options.where) {
+      query = query.where(options.where({ schema: sql.ref<string>('nspname') }))
+    }
+
+    const rawSchemas = await query.execute()
 
     return rawSchemas.map((it) => ({ name: it.nspname }))
   }

--- a/src/migration/migrator.ts
+++ b/src/migration/migrator.ts
@@ -405,7 +405,7 @@ export class Migrator {
       return
     }
 
-    const schemaExists = await this.#doesSchemaExist()
+    const schemaExists = await this.#doesSchemaExist(this.#migrationTableSchema)
 
     if (schemaExists) {
       return
@@ -416,7 +416,9 @@ export class Migrator {
         this.#props.db.schema.createSchema(this.#migrationTableSchema),
       )
     } catch (error) {
-      const schemaExists = await this.#doesSchemaExist()
+      const schemaExists = await this.#doesSchemaExist(
+        this.#migrationTableSchema,
+      )
 
       // At least on PostgreSQL, `if not exists` doesn't guarantee the `create schema`
       // query doesn't throw if the schema already exits. That's why we check if
@@ -521,10 +523,12 @@ export class Migrator {
     }
   }
 
-  async #doesSchemaExist(): Promise<boolean> {
-    const schemas = await this.#props.db.introspection.getSchemas()
+  async #doesSchemaExist(schemaName: string): Promise<boolean> {
+    const schemas = await this.#props.db.introspection.getSchemas({
+      where: ({ schema }) => sql<SqlBool>`${schema} = ${schemaName}`,
+    })
 
-    return schemas.some((it) => it.name === this.#migrationTableSchema)
+    return schemas.some((it) => it.name === schemaName)
   }
 
   async #doesTableExist(

--- a/src/migration/migrator.ts
+++ b/src/migration/migrator.ts
@@ -528,6 +528,8 @@ export class Migrator {
       where: ({ schema }) => sql<SqlBool>`${schema} = ${schemaName}`,
     })
 
+    // we still keep this in case the introspector doesn't implement support for
+    // `where`.
     return schemas.some((it) => it.name === schemaName)
   }
 

--- a/test/node/src/introspect.test.ts
+++ b/test/node/src/introspect.test.ts
@@ -77,6 +77,21 @@ for (const dialect of DIALECTS) {
           expect(schemas).to.eql([])
         }
       })
+
+      it('should apply a where expression to the metadata query', async () => {
+        const schemaName =
+          sqlSpec === 'postgres' || sqlSpec === 'mssql'
+            ? 'some_schema'
+            : sqlSpec === 'mysql'
+              ? 'kysely_test'
+              : undefined
+        const schemas = await ctx.db.introspection.getSchemas({
+          where: ({ schema }) =>
+            sql<SqlBool>`${schema} = ${schemaName ?? 'some_schema'}`,
+        })
+
+        expect(schemas).to.eql(schemaName ? [{ name: schemaName }] : [])
+      })
     })
 
     describe('getTables', () => {

--- a/test/node/src/migration.test.ts
+++ b/test/node/src/migration.test.ts
@@ -99,7 +99,16 @@ for (const dialect of DIALECTS) {
           .get(() => whereIgnoringIntrospector)
 
         try {
-          const { migrator } = createMigrations(['migration1'])
+          const { migrator } = createMigrations(
+            ['migration1'],
+            sqlSpec === 'postgres' || sqlSpec === 'mssql'
+              ? {
+                  migrationLockTableName: CUSTOM_MIGRATION_LOCK_TABLE,
+                  migrationTableName: CUSTOM_MIGRATION_TABLE,
+                  migrationTableSchema: CUSTOM_MIGRATION_SCHEMA,
+                }
+              : undefined,
+          )
 
           expect(await migrator.getMigrations()).to.have.length(1)
           expect((await migrator.migrateUp()).error).to.be.undefined


### PR DESCRIPTION
Hey :wave:

This PR adds the `where` option to `getSchemas`, matching the partial-introspection API introduced for `getTables` in #2005.

This allows consumers to filter schemas on the database side using any boolean SQL expression, with the schema-name column reference provided by the introspector. The migrator uses the option when checking whether its configured migration schema exists, while retaining the exact-name check for custom introspectors that ignore the option.

Closes #1502.