### PR TITLE
feat(mysql): add `withNonDefaultDatabases` to support introspection of non-default databases.

### DIFF
--- a/src/dialect/database-introspector.ts
+++ b/src/dialect/database-introspector.ts
@@ -33,6 +33,14 @@ export interface DatabaseSchemaMetadataOptions {
 
 export interface DatabaseMetadataOptions {
   /**
+   * If this is true, only tables from the default database are returned.
+   *
+   * This option only affects MySQL and defaults to true. System databases are
+   * excluded regardless of this option.
+   */
+  defaultDatabaseOnly?: boolean
+
+  /**
    * An optional SQL `where` expression for filtering the tables returned by
    * the introspector.
    *

--- a/src/dialect/database-introspector.ts
+++ b/src/dialect/database-introspector.ts
@@ -33,14 +33,6 @@ export interface DatabaseSchemaMetadataOptions {
 
 export interface DatabaseMetadataOptions {
   /**
-   * If this is true, only tables from the default database are returned.
-   *
-   * This option only affects MySQL and defaults to true. System databases are
-   * excluded regardless of this option.
-   */
-  defaultDatabaseOnly?: boolean
-
-  /**
    * An optional SQL `where` expression for filtering the tables returned by
    * the introspector.
    *
@@ -60,6 +52,14 @@ export interface DatabaseMetadataOptions {
    * such as the migration tables.
    */
   withInternalKyselyTables: boolean
+
+  /**
+   * If this is true, tables from non-default databases are also returned.
+   *
+   * This option only affects MySQL and defaults to false. System databases are
+   * excluded regardless of this option.
+   */
+  withNonDefaultDatabases?: boolean
 }
 
 export interface SchemaMetadata {

--- a/src/dialect/mysql/mysql-introspector.ts
+++ b/src/dialect/mysql/mysql-introspector.ts
@@ -13,6 +13,14 @@ import type { Kysely } from '../../kysely.js'
 import { freeze } from '../../util/object-utils.js'
 import { sql } from '../../raw-builder/sql.js'
 
+const SYSTEM_DATABASES = [
+  'information_schema',
+  'mysql',
+  'performance_schema',
+  'sys',
+  'ndbinfo',
+] as const
+
 export class MysqlIntrospector implements DatabaseIntrospector {
   readonly #db: Kysely<any>
 
@@ -60,10 +68,15 @@ export class MysqlIntrospector implements DatabaseIntrospector {
         'columns.EXTRA',
         'columns.COLUMN_COMMENT',
       ])
-      .where('columns.TABLE_SCHEMA', '=', sql`database()`)
+      .where('columns.TABLE_SCHEMA', 'not in', SYSTEM_DATABASES)
+      .orderBy('columns.TABLE_SCHEMA')
       .orderBy('columns.TABLE_NAME')
       .orderBy('columns.ORDINAL_POSITION')
       .$castTo<RawColumnMetadata>()
+
+    if (options.defaultDatabaseOnly ?? true) {
+      query = query.where('columns.TABLE_SCHEMA', '=', sql`database()`)
+    }
 
     if (!options.withInternalKyselyTables) {
       query = query
@@ -86,7 +99,9 @@ export class MysqlIntrospector implements DatabaseIntrospector {
 
   #parseTableMetadata(columns: RawColumnMetadata[]): TableMetadata[] {
     return columns.reduce<TableMetadata[]>((tables, it) => {
-      let table = tables.find((tbl) => tbl.name === it.TABLE_NAME)
+      let table = tables.find(
+        (tbl) => tbl.name === it.TABLE_NAME && tbl.schema === it.TABLE_SCHEMA,
+      )
 
       if (!table) {
         table = freeze({

--- a/src/dialect/mysql/mysql-introspector.ts
+++ b/src/dialect/mysql/mysql-introspector.ts
@@ -74,7 +74,7 @@ export class MysqlIntrospector implements DatabaseIntrospector {
       .orderBy('columns.ORDINAL_POSITION')
       .$castTo<RawColumnMetadata>()
 
-    if (options.defaultDatabaseOnly ?? true) {
+    if (!options.withNonDefaultDatabases) {
       query = query.where('columns.TABLE_SCHEMA', '=', sql`database()`)
     }
 

--- a/test/node/src/introspect.test.ts
+++ b/test/node/src/introspect.test.ts
@@ -1023,12 +1023,19 @@ for (const dialect of DIALECTS) {
         })
 
         it('should exclude tables in system databases', async () => {
+          const systemDatabases = [
+            'information_schema',
+            'mysql',
+            'performance_schema',
+            'sys',
+          ]
+
           for (const defaultDatabaseOnly of [true, false]) {
             const meta = await ctx.db.introspection.getTables({
               defaultDatabaseOnly,
               withInternalKyselyTables: false,
               where: ({ schema }) =>
-                sql<SqlBool>`${schema} = ${'information_schema'}`,
+                sql<SqlBool>`${schema} in (${sql.join(systemDatabases)})`,
             })
 
             expect(meta).to.eql([])

--- a/test/node/src/introspect.test.ts
+++ b/test/node/src/introspect.test.ts
@@ -974,6 +974,67 @@ for (const dialect of DIALECTS) {
           await ctx.db.schema.dropTable(internalTableName).execute()
         }
       })
+
+      if (sqlSpec === 'mysql') {
+        it('should optionally introspect tables outside the default database', async () => {
+          const otherDatabase = 'kysely_test_other'
+
+          await ctx.db.schema.createSchema(otherDatabase).execute()
+
+          try {
+            await ctx.db.schema
+              .withSchema(otherDatabase)
+              .createTable('person')
+              .addColumn('other_id', 'integer', (col) => col.notNull())
+              .execute()
+
+            const defaultDatabaseMeta = await ctx.db.introspection.getTables({
+              withInternalKyselyTables: false,
+              where: ({ table }) => sql<SqlBool>`${table} = ${'person'}`,
+            })
+            const meta = await ctx.db.introspection.getTables({
+              defaultDatabaseOnly: false,
+              withInternalKyselyTables: false,
+              where: ({ schema, table }) => {
+                if (!schema) {
+                  throw new Error(
+                    'expected the introspector to provide a schema',
+                  )
+                }
+
+                return sql<SqlBool>`${schema} in (${'kysely_test'}, ${otherDatabase}) and ${table} = ${'person'}`
+              },
+            })
+
+            expect(defaultDatabaseMeta.map((table) => table.schema)).to.eql([
+              'kysely_test',
+            ])
+            expect(meta).to.have.length(2)
+            expect(meta.map((table) => table.schema)).to.eql([
+              'kysely_test',
+              otherDatabase,
+            ])
+            expect(meta[1].columns.map((column) => column.name)).to.eql([
+              'other_id',
+            ])
+          } finally {
+            await ctx.db.schema.dropSchema(otherDatabase).execute()
+          }
+        })
+
+        it('should exclude tables in system databases', async () => {
+          for (const defaultDatabaseOnly of [true, false]) {
+            const meta = await ctx.db.introspection.getTables({
+              defaultDatabaseOnly,
+              withInternalKyselyTables: false,
+              where: ({ schema }) =>
+                sql<SqlBool>`${schema} = ${'information_schema'}`,
+            })
+
+            expect(meta).to.eql([])
+          }
+        })
+      }
     })
 
     async function createView() {

--- a/test/node/src/introspect.test.ts
+++ b/test/node/src/introspect.test.ts
@@ -989,12 +989,10 @@ for (const dialect of DIALECTS) {
               .execute()
 
             const defaultDatabaseMeta = await ctx.db.introspection.getTables({
-              withInternalKyselyTables: false,
               where: ({ table }) => sql<SqlBool>`${table} = ${'person'}`,
+              withInternalKyselyTables: false,
             })
             const meta = await ctx.db.introspection.getTables({
-              defaultDatabaseOnly: false,
-              withInternalKyselyTables: false,
               where: ({ schema, table }) => {
                 if (!schema) {
                   throw new Error(
@@ -1004,6 +1002,8 @@ for (const dialect of DIALECTS) {
 
                 return sql<SqlBool>`${schema} in (${'kysely_test'}, ${otherDatabase}) and ${table} = ${'person'}`
               },
+              withInternalKyselyTables: false,
+              withNonDefaultDatabases: true,
             })
 
             expect(defaultDatabaseMeta.map((table) => table.schema)).to.eql([
@@ -1030,12 +1030,12 @@ for (const dialect of DIALECTS) {
             'sys',
           ]
 
-          for (const defaultDatabaseOnly of [true, false]) {
+          for (const withNonDefaultDatabases of [false, true]) {
             const meta = await ctx.db.introspection.getTables({
-              defaultDatabaseOnly,
-              withInternalKyselyTables: false,
               where: ({ schema }) =>
                 sql<SqlBool>`${schema} in (${sql.join(systemDatabases)})`,
+              withInternalKyselyTables: false,
+              withNonDefaultDatabases,
             })
 
             expect(meta).to.eql([])


### PR DESCRIPTION
Hey :wave:

This PR adds `withNonDefaultDatabases` to the MySQL introspector as an opt-in for multi-database introspection.

It also brings back filtering of MySQL system databases from the results of `getTables`, regardless of `withNonDefaultDatabases`.

The default preserves the current-database isolation introduced to fix #93.

Closes #620.