### PR TITLE
feat(introspector): add `comment` property in table metadata.

### DIFF
--- a/src/dialect/database-introspector.ts
+++ b/src/dialect/database-introspector.ts
@@ -67,10 +67,11 @@ export interface SchemaMetadata {
 }
 
 export interface TableMetadata {
-  readonly name: string
-  readonly isView: boolean
-  readonly isForeign: boolean
   readonly columns: ColumnMetadata[]
+  readonly comment?: string
+  readonly isForeign: boolean
+  readonly isView: boolean
+  readonly name: string
   readonly schema?: string
 }
 

--- a/src/dialect/mssql/mssql-introspector.ts
+++ b/src/dialect/mssql/mssql-introspector.ts
@@ -68,9 +68,17 @@ export class MssqlIntrospector implements DatabaseIntrospector {
       )
       .leftJoin('sys.extended_properties as comments', (join) =>
         join
+          .on('comments.class', '=', 1)
           .onRef('comments.major_id', '=', 'tables.object_id')
           .onRef('comments.minor_id', '=', 'columns.column_id')
           .on('comments.name', '=', 'MS_Description'),
+      )
+      .leftJoin('sys.extended_properties as table_comments', (join) =>
+        join
+          .on('table_comments.class', '=', 1)
+          .onRef('table_comments.major_id', '=', 'tables.object_id')
+          .on('table_comments.minor_id', '=', 0)
+          .on('table_comments.name', '=', 'MS_Description'),
       )
       .$if(!options.withInternalKyselyTables, (qb) =>
         qb
@@ -100,6 +108,7 @@ export class MssqlIntrospector implements DatabaseIntrospector {
         'types.name as type_name',
         'type_schemas.name as type_schema_name',
         'comments.value as column_comment',
+        'table_comments.value as table_comment',
       ])
       .unionAll(
         this.#db
@@ -126,9 +135,17 @@ export class MssqlIntrospector implements DatabaseIntrospector {
           )
           .leftJoin('sys.extended_properties as comments', (join) =>
             join
+              .on('comments.class', '=', 1)
               .onRef('comments.major_id', '=', 'views.object_id')
               .onRef('comments.minor_id', '=', 'columns.column_id')
               .on('comments.name', '=', 'MS_Description'),
+          )
+          .leftJoin('sys.extended_properties as table_comments', (join) =>
+            join
+              .on('table_comments.class', '=', 1)
+              .onRef('table_comments.major_id', '=', 'views.object_id')
+              .on('table_comments.minor_id', '=', 0)
+              .on('table_comments.name', '=', 'MS_Description'),
           )
           .$if(!!viewsWhere, (qb) => qb.where(viewsWhere!))
           .select([
@@ -146,6 +163,7 @@ export class MssqlIntrospector implements DatabaseIntrospector {
             'types.name as type_name',
             'type_schemas.name as type_schema_name',
             'comments.value as column_comment',
+            'table_comments.value as table_comment',
           ]),
       )
       .orderBy('table_schema_name')
@@ -162,6 +180,7 @@ export class MssqlIntrospector implements DatabaseIntrospector {
         tableDictionary[key] ||
         freeze({
           columns: [],
+          comment: rawColumn.table_comment ?? undefined,
           isForeign: false,
           isView: rawColumn.table_type === 'V ',
           name: rawColumn.table_name,
@@ -234,6 +253,7 @@ interface MssqlSysTables {
     system_type_id: number
   }
   'sys.extended_properties': {
+    class: number
     major_id: number
     minor_id: number
     name: string

--- a/src/dialect/mysql/mysql-introspector.ts
+++ b/src/dialect/mysql/mysql-introspector.ts
@@ -62,6 +62,7 @@ export class MysqlIntrospector implements DatabaseIntrospector {
         'columns.TABLE_NAME',
         'columns.TABLE_SCHEMA',
         'tables.TABLE_TYPE',
+        'tables.TABLE_COMMENT',
         'tables.ENGINE',
         'columns.IS_NULLABLE',
         'columns.DATA_TYPE',
@@ -105,11 +106,15 @@ export class MysqlIntrospector implements DatabaseIntrospector {
 
       if (!table) {
         table = freeze({
-          name: it.TABLE_NAME,
-          isView: it.TABLE_TYPE === 'VIEW',
-          isForeign: it.ENGINE === 'FEDERATED',
-          schema: it.TABLE_SCHEMA,
           columns: [],
+          comment:
+            it.TABLE_TYPE === 'VIEW' || it.TABLE_COMMENT === ''
+              ? undefined
+              : it.TABLE_COMMENT,
+          isForeign: it.ENGINE === 'FEDERATED',
+          isView: it.TABLE_TYPE === 'VIEW',
+          name: it.TABLE_NAME,
+          schema: it.TABLE_SCHEMA,
         })
 
         tables.push(table)
@@ -137,6 +142,7 @@ interface RawColumnMetadata {
   TABLE_NAME: string
   TABLE_SCHEMA: string
   TABLE_TYPE: string
+  TABLE_COMMENT: string
   ENGINE: string
   IS_NULLABLE: 'YES' | 'NO'
   DATA_TYPE: string

--- a/src/dialect/postgres/postgres-introspector.ts
+++ b/src/dialect/postgres/postgres-introspector.ts
@@ -62,6 +62,9 @@ export class PostgresIntrospector implements DatabaseIntrospector {
         'ns.nspname as schema',
         'typ.typname as type',
         'dtns.nspname as type_schema',
+        sql<string | null>`obj_description(c.oid, 'pg_class')`.as(
+          'table_description',
+        ),
         sql<string | null>`col_description(a.attrelid, a.attnum)`.as(
           'column_description',
         ),
@@ -128,6 +131,7 @@ export class PostgresIntrospector implements DatabaseIntrospector {
       if (!table) {
         table = freeze({
           columns: [],
+          comment: column.table_description ?? undefined,
           isForeign: column.table_type === 'f',
           isView: column.table_type === 'v',
           name: column.table,
@@ -165,4 +169,5 @@ interface RawColumnMetadata {
   type_schema: string
   auto_incrementing: string | null
   column_description: string | null
+  table_description: string | null
 }

--- a/src/dialect/sqlite/sqlite-introspector.ts
+++ b/src/dialect/sqlite/sqlite-introspector.ts
@@ -131,9 +131,6 @@ export class SqliteIntrospector implements DatabaseIntrospector {
       }
 
       return {
-        name: name,
-        isView: type === 'view',
-        isForeign: false,
         columns: columns.map((col) => ({
           name: col.name,
           dataType: col.type,
@@ -142,6 +139,10 @@ export class SqliteIntrospector implements DatabaseIntrospector {
           hasDefaultValue: col.dflt_value != null,
           comment: undefined,
         })),
+        comment: undefined,
+        isForeign: false,
+        isView: type === 'view',
+        name,
       }
     })
   }

--- a/test/node/src/introspect.test.ts
+++ b/test/node/src/introspect.test.ts
@@ -101,6 +101,7 @@ for (const dialect of DIALECTS) {
         if (sqlSpec === 'postgres') {
           expect(meta).to.eql([
             {
+              comment: undefined,
               name: 'person',
               isForeign: false,
               isView: false,
@@ -173,6 +174,7 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              comment: undefined,
               name: 'pet',
               isView: false,
               isForeign: false,
@@ -217,6 +219,7 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              comment: 'A toy owned by a pet',
               name: 'toy',
               isView: false,
               isForeign: false,
@@ -261,6 +264,7 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              comment: 'A view of toy names',
               name: 'toy_names',
               isForeign: false,
               isView: true,
@@ -278,6 +282,7 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              comment: undefined,
               name: 'MixedCaseTable',
               isForeign: false,
               isView: false,
@@ -295,6 +300,7 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              comment: undefined,
               name: 'pet',
               isForeign: false,
               isView: false,
@@ -321,6 +327,7 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              comment: undefined,
               name: 'pet_partition',
               isForeign: false,
               isView: false,
@@ -341,6 +348,7 @@ for (const dialect of DIALECTS) {
         } else if (sqlSpec === 'mysql') {
           expect(meta).to.eql([
             {
+              comment: undefined,
               name: 'person',
               isForeign: false,
               isView: false,
@@ -406,6 +414,7 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              comment: undefined,
               name: 'pet',
               isForeign: false,
               isView: false,
@@ -446,6 +455,7 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              comment: 'A toy owned by a pet',
               name: 'toy',
               isForeign: false,
               isView: false,
@@ -486,6 +496,7 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              comment: undefined,
               name: 'toy_names',
               isForeign: false,
               isView: true,
@@ -505,6 +516,7 @@ for (const dialect of DIALECTS) {
         } else if (sqlSpec === 'mssql') {
           expect(meta).to.eql([
             {
+              comment: undefined,
               isForeign: false,
               isView: false,
               name: 'person',
@@ -576,6 +588,7 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              comment: undefined,
               isForeign: false,
               isView: false,
               name: 'pet',
@@ -620,6 +633,7 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              comment: 'A toy owned by a pet',
               isForeign: false,
               isView: false,
               name: 'toy',
@@ -664,6 +678,7 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              comment: 'A view of toy names',
               isForeign: false,
               isView: true,
               name: 'toy_names',
@@ -676,11 +691,12 @@ for (const dialect of DIALECTS) {
                   isAutoIncrementing: false,
                   isNullable: false,
                   name: 'name',
-                  comment: undefined,
+                  comment: 'A toy name',
                 },
               ],
             },
             {
+              comment: undefined,
               isForeign: false,
               isView: false,
               name: 'pet',
@@ -710,6 +726,7 @@ for (const dialect of DIALECTS) {
         } else if (sqlSpec === 'sqlite') {
           expect(meta).to.eql([
             {
+              comment: undefined,
               name: 'person',
               isForeign: false,
               isView: false,
@@ -774,6 +791,7 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              comment: undefined,
               name: 'pet',
               isForeign: false,
               isView: false,
@@ -813,6 +831,7 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              comment: undefined,
               name: 'toy',
               isForeign: false,
               isView: false,
@@ -852,6 +871,7 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              comment: undefined,
               name: 'toy_names',
               isForeign: false,
               isView: true,
@@ -892,6 +912,7 @@ for (const dialect of DIALECTS) {
             )
 
             expect(testTable).to.eql({
+              comment: undefined,
               name: testTableName,
               isForeign: false,
               isView: false,
@@ -1045,10 +1066,23 @@ for (const dialect of DIALECTS) {
     })
 
     async function createView() {
-      ctx.db.schema
+      await ctx.db.schema
         .createView('toy_names')
         .as(ctx.db.selectFrom('toy').select('name'))
         .execute()
+
+      if (sqlSpec === 'postgres') {
+        await sql`COMMENT ON VIEW toy_names IS 'A view of toy names';`.execute(
+          ctx.db,
+        )
+      } else if (sqlSpec === 'mssql') {
+        await sql`EXECUTE sp_addextendedproperty N'MS_Description', N'A view of toy names', N'SCHEMA', N'dbo', N'VIEW', 'toy_names'`.execute(
+          ctx.db,
+        )
+        await sql`EXECUTE sp_addextendedproperty N'MS_Description', N'A toy name', N'SCHEMA', N'dbo', N'VIEW', 'toy_names', N'COLUMN', N'name'`.execute(
+          ctx.db,
+        )
+      }
     }
 
     async function dropView() {

--- a/test/node/src/test-setup.ts
+++ b/test/node/src/test-setup.ts
@@ -400,6 +400,7 @@ async function createDatabase(
     await createToyTableBase
       .addColumn('price', 'double precision', (col) => col.notNull())
       .execute()
+    await sql`COMMENT ON TABLE toy IS 'A toy owned by a pet';`.execute(db)
     await sql`COMMENT ON COLUMN toy.price IS 'Price in USD';`.execute(db)
   }
 
@@ -407,6 +408,9 @@ async function createDatabase(
     await createToyTableBase
       .addColumn('price', 'double precision', (col) => col.notNull())
       .execute()
+    await sql`EXECUTE sp_addextendedproperty N'MS_Description', N'A toy owned by a pet', N'SCHEMA', N'dbo', N'TABLE', 'toy'`.execute(
+      db,
+    )
     await sql`EXECUTE sp_addextendedproperty N'MS_Description', N'Price in USD', N'SCHEMA', N'dbo', N'TABLE', 'toy', N'COLUMN', N'price'`.execute(
       db,
     )
@@ -417,6 +421,7 @@ async function createDatabase(
       .addColumn('price', 'double precision', (col) =>
         col.notNull().modifyEnd(sql`comment ${sql.lit('Price in USD')}`),
       )
+      .modifyEnd(sql`comment ${sql.lit('A toy owned by a pet')}`)
       .execute()
   }
 


### PR DESCRIPTION
Hey :wave:

This PR adds the `comment` property in table metadata so you can get table and view comments when using `getTables`.

Closes #1368.