### PR TITLE
fix: allow transactions with extra tables to satisfy narrower schemas

### DIFF
--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -730,6 +730,20 @@ export class Transaction<DB> extends Kysely<DB> {
    *
    * @deprecated use {@link $extendTables} instead.
    */
+  // Base return overloads allow assignment to parent classes with fewer tables.
+  // Keep the transaction overload first for calls and last for ReturnType.
+  override withTables<
+    T extends Record<string, Record<string, any>>,
+  >(): Transaction<DrainOuterGeneric<DB & T>>
+
+  override withTables<T extends Record<string, Record<string, any>>>(): Kysely<
+    DrainOuterGeneric<DB & T>
+  >
+
+  override withTables<
+    T extends Record<string, Record<string, any>>,
+  >(): Transaction<DrainOuterGeneric<DB & T>>
+
   override withTables<
     T extends Record<string, Record<string, any>>,
   >(): Transaction<DrainOuterGeneric<DB & T>> {
@@ -741,6 +755,18 @@ export class Transaction<DB> extends Kysely<DB> {
    */
   override $extendTables<
     T extends Record<string, Record<string, any>>,
+  >(): Transaction<DrainOuterGeneric<DB & T>>
+
+  override $extendTables<
+    T extends Record<string, Record<string, any>>,
+  >(): Kysely<DrainOuterGeneric<DB & T>>
+
+  override $extendTables<
+    T extends Record<string, Record<string, any>>,
+  >(): Transaction<DrainOuterGeneric<DB & T>>
+
+  override $extendTables<
+    T extends Record<string, Record<string, any>>,
   >(): Transaction<DrainOuterGeneric<DB & T>> {
     return new Transaction({ ...this.#props })
   }
@@ -750,6 +776,18 @@ export class Transaction<DB> extends Kysely<DB> {
    */
   override $omitTables<T extends keyof DB>(): Transaction<
     DB extends object ? Omit<DB, T> : DB
+  >
+
+  override $omitTables<T extends keyof DB>(): Kysely<
+    DB extends object ? Omit<DB, T> : DB
+  >
+
+  override $omitTables<T extends keyof DB>(): Transaction<
+    DB extends object ? Omit<DB, T> : DB
+  >
+
+  override $omitTables<T extends keyof DB>(): Transaction<
+    DB extends object ? Omit<DB, T> : DB
   > {
     return new Transaction({ ...this.#props })
   }
@@ -757,6 +795,18 @@ export class Transaction<DB> extends Kysely<DB> {
   /**
    * Similar to {@link Kysely.$pickTables} but returns the transaction.
    */
+  override $pickTables<T extends keyof DB>(): Transaction<
+    DB extends object ? Pick<DB, T> : DB
+  >
+
+  override $pickTables<T extends keyof DB>(): Kysely<
+    DB extends object ? Pick<DB, T> : DB
+  >
+
+  override $pickTables<T extends keyof DB>(): Transaction<
+    DB extends object ? Pick<DB, T> : DB
+  >
+
   override $pickTables<T extends keyof DB>(): Transaction<
     DB extends object ? Pick<DB, T> : DB
   > {

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -1303,6 +1303,20 @@ export class ControlledTransaction<
     })
   }
 
+  // Base return overloads allow assignment to Kysely with fewer tables.
+  // Keep the controlled transaction overload first for calls and last for ReturnType.
+  override withTables<
+    T extends Record<string, Record<string, any>>,
+  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+
+  override withTables<T extends Record<string, Record<string, any>>>(): Kysely<
+    DrainOuterGeneric<DB & T>
+  >
+
+  override withTables<
+    T extends Record<string, Record<string, any>>,
+  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+
   override withTables<
     T extends Record<string, Record<string, any>>,
   >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S> {
@@ -1311,9 +1325,35 @@ export class ControlledTransaction<
 
   override $extendTables<
     T extends Record<string, Record<string, any>>,
+  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+
+  override $extendTables<
+    T extends Record<string, Record<string, any>>,
+  >(): Kysely<DrainOuterGeneric<DB & T>>
+
+  override $extendTables<
+    T extends Record<string, Record<string, any>>,
+  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+
+  override $extendTables<
+    T extends Record<string, Record<string, any>>,
   >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S> {
     return new ControlledTransaction({ ...this.#props })
   }
+
+  override $omitTables<T extends keyof DB>(): ControlledTransaction<
+    DB extends object ? Omit<DB, T> : DB,
+    S
+  >
+
+  override $omitTables<T extends keyof DB>(): Kysely<
+    DB extends object ? Omit<DB, T> : DB
+  >
+
+  override $omitTables<T extends keyof DB>(): ControlledTransaction<
+    DB extends object ? Omit<DB, T> : DB,
+    S
+  >
 
   override $omitTables<T extends keyof DB>(): ControlledTransaction<
     DB extends object ? Omit<DB, T> : DB,

--- a/src/query-builder/merge-query-builder.ts
+++ b/src/query-builder/merge-query-builder.ts
@@ -53,6 +53,7 @@ import type {
 import { freeze } from '../util/object-utils.js'
 import type { QueryId } from '../util/query-id.js'
 import type {
+  IsAny,
   ShallowRecord,
   SimplifyResult,
   SimplifySingleResult,
@@ -74,6 +75,11 @@ import { UpdateQueryBuilder } from './update-query-builder.js'
 export class MergeQueryBuilder<DB, TT extends keyof DB, O>
   implements MultiTableReturningInterface<DB, TT, O>, OutputInterface<DB, TT, O>
 {
+  // Keep the schema mapped for table-subset assignability on TypeScript 5.
+  declare protected readonly '~DB': IsAny<DB> extends true
+    ? DB
+    : { [T in keyof DB]: DB[T] }
+
   readonly #props: MergeQueryBuilderProps
 
   constructor(props: MergeQueryBuilderProps) {

--- a/src/query-creator.ts
+++ b/src/query-creator.ts
@@ -47,9 +47,13 @@ import type { SelectFrom } from './parser/select-from-parser.js'
 import type { DeleteFrom } from './parser/delete-from-parser.js'
 import type { UpdateTable } from './parser/update-parser.js'
 import type { MergeInto } from './parser/merge-into-parser.js'
+import type { IsAny } from './util/type-utils.js'
 
 export class QueryCreator<DB> {
-  declare protected readonly '~DB': DB
+  // Keep the schema mapped for table-subset assignability on TypeScript 5.
+  declare protected readonly '~DB': IsAny<DB> extends true
+    ? DB
+    : { [T in keyof DB]: DB[T] }
 
   readonly #props: QueryCreatorProps
 

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -158,8 +158,8 @@ bench('WheneableMergeQueryBuilder assignable to a narrower one', () => {
 
 bench('Transaction assignable to Kysely', () => {
   return acceptsKysely(transaction)
-}).types([109366, 'instantiations'])
+}).types([109536, 'instantiations'])
 
 bench('MergeQueryBuilder assignable to narrower MergeQueryBuilder', () => {
   return acceptsNarrowMergeInto(wideMergeInto)
-}).types([22733, 'instantiations'])
+}).types([22766, 'instantiations'])

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -158,7 +158,7 @@ bench('WheneableMergeQueryBuilder assignable to a narrower one', () => {
 
 bench('Transaction assignable to Kysely', () => {
   return acceptsKysely(transaction)
-}).types([160079, 'instantiations'])
+}).types([109366, 'instantiations'])
 
 bench('MergeQueryBuilder assignable to narrower MergeQueryBuilder', () => {
   return acceptsNarrowMergeInto(wideMergeInto)

--- a/test/typings/vitest/kysely-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-assignability.test-d.ts
@@ -77,10 +77,6 @@ test('rejects a database with { a } where { b } is required', () => {
   queryB(a)
 })
 
-test('accepts a database with { a, b } where { a } is required', () => {
-  queryA(ab)
-})
-
 test('accepts a database that declares both tables', () => {
   queryAB(ab)
 })
@@ -100,11 +96,6 @@ test('rejects a transaction with { a } where { b } is required', () => {
   queryB(transactionA)
   // @ts-expect-error the source transaction does not declare table b
   queryBInTransaction(transactionA)
-})
-
-test('accepts a transaction with { a, b } where { a } is required', () => {
-  queryA(transactionAB)
-  queryAInTransaction(transactionAB)
 })
 
 test('accepts a transaction that declares both tables', () => {
@@ -132,12 +123,6 @@ test('rejects a controlled transaction with { a } where { b } is required', () =
   queryBInTransaction(controlledTransactionA)
   // @ts-expect-error the source transaction does not declare table b
   queryBInControlledTransaction(controlledTransactionA)
-})
-
-test('accepts a controlled transaction with { a, b } where { a } is required', () => {
-  queryA(controlledTransactionAB)
-  queryAInTransaction(controlledTransactionAB)
-  queryAInControlledTransaction(controlledTransactionAB)
 })
 
 test('accepts a controlled transaction that declares both tables', () => {

--- a/test/typings/vitest/kysely-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-assignability.test-d.ts
@@ -77,6 +77,10 @@ test('rejects a database with { a } where { b } is required', () => {
   queryB(a)
 })
 
+test('accepts a database with { a, b } where { a } is required', () => {
+  queryA(ab)
+})
+
 test('accepts a database that declares both tables', () => {
   queryAB(ab)
 })
@@ -96,6 +100,11 @@ test('rejects a transaction with { a } where { b } is required', () => {
   queryB(transactionA)
   // @ts-expect-error the source transaction does not declare table b
   queryBInTransaction(transactionA)
+})
+
+test('accepts a transaction with { a, b } where { a } is required', () => {
+  queryA(transactionAB)
+  queryAInTransaction(transactionAB)
 })
 
 test('accepts a transaction that declares both tables', () => {
@@ -123,6 +132,12 @@ test('rejects a controlled transaction with { a } where { b } is required', () =
   queryBInTransaction(controlledTransactionA)
   // @ts-expect-error the source transaction does not declare table b
   queryBInControlledTransaction(controlledTransactionA)
+})
+
+test('accepts a controlled transaction with { a, b } where { a } is required', () => {
+  queryA(controlledTransactionAB)
+  queryAInTransaction(controlledTransactionAB)
+  queryAInControlledTransaction(controlledTransactionAB)
 })
 
 test('accepts a controlled transaction that declares both tables', () => {

--- a/test/typings/vitest/kysely-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-assignability.test-d.ts
@@ -130,6 +130,12 @@ test('rejects a controlled transaction with { a } where { b } is required', () =
   queryBInControlledTransaction(controlledTransactionA)
 })
 
+test('accepts a controlled transaction with { a, b } where { a } is required', () => {
+  queryA(controlledTransactionAB)
+  queryAInTransaction(controlledTransactionAB)
+  queryAInControlledTransaction(controlledTransactionAB)
+})
+
 test('accepts a controlled transaction that declares both tables', () => {
   queryAB(controlledTransactionAB)
   queryABInTransaction(controlledTransactionAB)

--- a/test/typings/vitest/kysely-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-assignability.test-d.ts
@@ -98,6 +98,11 @@ test('rejects a transaction with { a } where { b } is required', () => {
   queryBInTransaction(transactionA)
 })
 
+test('accepts a transaction with { a, b } where { a } is required', () => {
+  queryA(transactionAB)
+  queryAInTransaction(transactionAB)
+})
+
 test('accepts a transaction that declares both tables', () => {
   queryAB(transactionAB)
   queryABInTransaction(transactionAB)


### PR DESCRIPTION
Hey 👋 

Assigning transactions with tables `a` and `b` to transaction or parent types requiring only `a` fails on supported TypeScript versions even when the shared table has the same row type.

This PR adds `Kysely`-returning overloads to `Transaction`'s four table helpers and `ControlledTransaction`'s `withTables`, `$extendTables`, and `$omitTables`. Each method keeps its concrete transaction overload first and last, preserving call inference, savepoints, and `ReturnType`. Uses mapped schema markers in `QueryCreator` and `MergeQueryBuilder` to make the table-subset comparisons work on TypeScript 5 as well, with an `IsAny` branch preserving the schema escape hatch. All changes are declaration-only.