### PR TITLE
fix: accept Kysely instances with extra tables on TypeScript 5

### DIFF
--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -98,6 +98,10 @@ export class Kysely<DB>
   extends QueryCreator<DB>
   implements QueryExecutorProvider, AsyncDisposable
 {
+  // TODO: Remove when TypeScript 6.0 is the minimum supported version.
+  // TypeScript 5.x needs this inherited marker redeclared for table-subset assignability.
+  declare protected readonly '~DB': QueryCreator<DB>['~DB']
+
   readonly #props: KyselyProps
 
   constructor(args: KyselyConfig)

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -158,7 +158,7 @@ bench('WheneableMergeQueryBuilder assignable to a narrower one', () => {
 
 bench('Transaction assignable to Kysely', () => {
   return acceptsKysely(transaction)
-}).types([109536, 'instantiations'])
+}).types([109553, 'instantiations'])
 
 bench('MergeQueryBuilder assignable to narrower MergeQueryBuilder', () => {
   return acceptsNarrowMergeInto(wideMergeInto)

--- a/test/typings/vitest/assignability.fixtures.ts
+++ b/test/typings/vitest/assignability.fixtures.ts
@@ -1,0 +1,22 @@
+import type {
+  ControlledTransaction,
+  Kysely,
+  Transaction,
+} from '../../../dist/index.js'
+
+export type Row = { id: number }
+export type DatabaseA = { a: Row }
+export type DatabaseB = { b: Row }
+export type DatabaseAB = DatabaseA & DatabaseB
+
+export type Instances<DB> = {
+  db: Kysely<DB>
+  transaction: Transaction<DB>
+  controlled: ControlledTransaction<DB>
+}
+
+export declare const a: Instances<DatabaseA>
+export declare const b: Instances<DatabaseB>
+export declare const ab: Instances<DatabaseAB>
+
+export declare function accept<T>(value: T): void

--- a/test/typings/vitest/kysely-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-assignability.test-d.ts
@@ -77,6 +77,10 @@ test('rejects a database with { a } where { b } is required', () => {
   queryB(a)
 })
 
+test('accepts a database with { a, b } where { a } is required', () => {
+  queryA(ab)
+})
+
 test('accepts a database that declares both tables', () => {
   queryAB(ab)
 })

--- a/test/typings/vitest/kysely-chain-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-chain-assignability.test-d.ts
@@ -1,0 +1,130 @@
+import { test } from 'vitest'
+import type {
+  ControlledTransaction,
+  Kysely,
+  KyselyPlugin,
+  Transaction,
+} from '../../../dist/index.js'
+import type { QueryCreator } from '../../../dist/query-creator.js'
+import {
+  accept,
+  a,
+  ab,
+  type DatabaseA,
+  type DatabaseAB,
+  type DatabaseB,
+  type Row,
+} from './assignability.fixtures.js'
+
+declare const plugin: KyselyPlugin
+
+test('accepts cross-class assignment after plugin and table helper chains', () => {
+  const db = a.db
+    .$extendTables<DatabaseB>()
+    .withPlugin(plugin)
+    .withSchema('app')
+    .$pickTables<'a' | 'b'>()
+    .withoutPlugins()
+  const transaction = a.transaction
+    .$extendTables<DatabaseB>()
+    .withPlugin(plugin)
+    .withSchema('app')
+    .$pickTables<'a' | 'b'>()
+    .withoutPlugins()
+  const controlled = a.controlled
+    .withTables<DatabaseB>()
+    .withPlugin(plugin)
+    .withSchema('app')
+    .$pickTables<'a' | 'b'>()
+    .withoutPlugins()
+
+  accept<Kysely<DatabaseA>>(db)
+  accept<Kysely<DatabaseA>>(transaction)
+  accept<Transaction<DatabaseA>>(transaction)
+  accept<Kysely<DatabaseA>>(controlled)
+  accept<Transaction<DatabaseA>>(controlled)
+  accept<ControlledTransaction<DatabaseA>>(controlled)
+  accept<Kysely<DatabaseAB>>(db)
+  accept<Transaction<DatabaseAB>>(transaction)
+  accept<ControlledTransaction<DatabaseAB>>(controlled)
+})
+
+test('rejects missing tables after plugin and table helper chains', () => {
+  const db = ab.db.$omitTables<'b'>().withSchema('app').withPlugin(plugin)
+  const transaction = ab.transaction
+    .$pickTables<'a'>()
+    .withSchema('app')
+    .withoutPlugins()
+  const controlled = ab.controlled
+    .$omitTables<'b'>()
+    .withPlugin(plugin)
+    .withoutPlugins()
+
+  // @ts-expect-error the chain removed b
+  accept<Kysely<DatabaseAB>>(db)
+  // @ts-expect-error the chain removed b
+  accept<Kysely<DatabaseAB>>(transaction)
+  // @ts-expect-error the chain removed b
+  accept<Transaction<DatabaseAB>>(transaction)
+  // @ts-expect-error the chain removed b
+  accept<Kysely<DatabaseAB>>(controlled)
+  // @ts-expect-error the chain removed b
+  accept<Transaction<DatabaseAB>>(controlled)
+  // @ts-expect-error the chain removed b
+  accept<ControlledTransaction<DatabaseAB>>(controlled)
+})
+
+test('accepts CTE query creators from all three classes', () => {
+  const db = a.db.with('b', (qb) => qb.selectFrom('a').select('id'))
+  const transaction = a.transaction.with('b', (qb) =>
+    qb.selectFrom('a').select('id'),
+  )
+  const controlled = a.controlled.with('b', (qb) =>
+    qb.selectFrom('a').select('id'),
+  )
+
+  accept<QueryCreator<DatabaseAB>>(db)
+  accept<QueryCreator<DatabaseAB>>(transaction)
+  accept<QueryCreator<DatabaseAB>>(controlled)
+  accept<QueryCreator<DatabaseA>>(db)
+  accept<QueryCreator<DatabaseA>>(transaction)
+  accept<QueryCreator<DatabaseA>>(controlled)
+  // @ts-expect-error a CTE query creator does not expose transaction methods
+  accept<Transaction<DatabaseAB>>(transaction)
+  // @ts-expect-error a CTE query creator does not expose controlled operations
+  accept<ControlledTransaction<DatabaseAB>>(controlled)
+})
+
+test('rejects missing tables in CTE query creator assignments', () => {
+  const db = a.db.with('c', (qb) => qb.selectFrom('a').select('id'))
+  const transaction = a.transaction.with('c', (qb) =>
+    qb.selectFrom('a').select('id'),
+  )
+  const controlled = a.controlled.with('c', (qb) =>
+    qb.selectFrom('a').select('id'),
+  )
+  // @ts-expect-error the CTE added c, not b
+  accept<QueryCreator<DatabaseAB>>(db)
+  // @ts-expect-error the CTE added c, not b
+  accept<QueryCreator<DatabaseAB>>(transaction)
+  // @ts-expect-error the CTE added c, not b
+  accept<QueryCreator<DatabaseAB>>(controlled)
+})
+
+test('preserves schemas through table helpers and recursive CTE chains', () => {
+  const query = a.controlled
+    .$extendTables<DatabaseB>()
+    .$pickTables<'a' | 'b'>()
+    .withPlugin(plugin)
+    .withSchema('app')
+    .withRecursive('c', (qb) =>
+      qb.selectFrom('a').select('id').unionAll(qb.selectFrom('c').select('id')),
+    )
+    .with('d', (qb) => qb.selectFrom('c').select('id'))
+    .withoutPlugins()
+
+  accept<QueryCreator<DatabaseAB & { c: Row; d: Row }>>(query)
+  accept<QueryCreator<{ d: Row }>>(query)
+  // @ts-expect-error neither the helpers nor the CTEs declare e
+  accept<QueryCreator<{ e: Row }>>(query)
+})

--- a/test/typings/vitest/kysely-column-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-column-assignability.test-d.ts
@@ -1,0 +1,172 @@
+import { test } from 'vitest'
+import type {
+  ColumnType,
+  Generated,
+  ControlledTransaction,
+  Kysely,
+  Transaction,
+} from '../../../dist/index.js'
+import {
+  accept,
+  type Instances,
+  type DatabaseA,
+} from './assignability.fixtures.js'
+
+test('rejects incompatible column types', () => {
+  type Source = { a: { id: string } }
+  type Target = DatabaseA
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error id is a string in the source database
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error id is a string in the source database
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error id is a string in the source database
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error id is a string in the source database
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error id is a string in the source database
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error id is a string in the source database
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('rejects missing required columns', () => {
+  type Source = { a: { name: string } }
+  type Target = DatabaseA
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error the source table does not declare id
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error the source table does not declare id
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error the source table does not declare id
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error the source table does not declare id
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error the source table does not declare id
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error the source table does not declare id
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('rejects nullable columns where nonnullable columns are needed', () => {
+  type Source = { a: { id: number | null } }
+  type Target = DatabaseA
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error the source id can be null
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error the source id can be null
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error the source id can be null
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error the source id can be null
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error the source id can be null
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error the source id can be null
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('accepts structurally identical column declarations', () => {
+  type Source = { a: { id: number } }
+  type Target = DatabaseA
+  const source = null! as Instances<Source>
+
+  accept<Kysely<Target>>(source.db)
+  accept<Kysely<Target>>(source.transaction)
+  accept<Transaction<Target>>(source.transaction)
+  accept<Kysely<Target>>(source.controlled)
+  accept<Transaction<Target>>(source.controlled)
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('accepts equivalent generated column declarations', () => {
+  type Source = { a: { id: Generated<number> } }
+  type Target = { a: { id: ColumnType<number, number | undefined, number> } }
+  const source = null! as Instances<Source>
+
+  accept<Kysely<Target>>(source.db)
+  accept<Kysely<Target>>(source.transaction)
+  accept<Transaction<Target>>(source.transaction)
+  accept<Kysely<Target>>(source.controlled)
+  accept<Transaction<Target>>(source.controlled)
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('rejects incompatible generated column select types', () => {
+  type Source = { a: { id: Generated<string> } }
+  type Target = { a: { id: Generated<number> } }
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error generated id selects string instead of number
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error generated id selects string instead of number
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error generated id selects string instead of number
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error generated id selects string instead of number
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error generated id selects string instead of number
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error generated id selects string instead of number
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('rejects incompatible ColumnType select types', () => {
+  type Source = { a: { id: ColumnType<string, number, number> } }
+  type Target = { a: { id: ColumnType<number, number, number> } }
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error the select types differ
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error the select types differ
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error the select types differ
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error the select types differ
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error the select types differ
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error the select types differ
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('rejects incompatible ColumnType insert types', () => {
+  type Source = { a: { id: ColumnType<number, string, number> } }
+  type Target = { a: { id: ColumnType<number, number, number> } }
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error the insert types differ
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error the insert types differ
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error the insert types differ
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error the insert types differ
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error the insert types differ
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error the insert types differ
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('rejects incompatible ColumnType update types', () => {
+  type Source = { a: { id: ColumnType<number, number, string> } }
+  type Target = { a: { id: ColumnType<number, number, number> } }
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error the update types differ
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error the update types differ
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error the update types differ
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error the update types differ
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error the update types differ
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error the update types differ
+  accept<ControlledTransaction<Target>>(source.controlled)
+})


### PR DESCRIPTION
Hey 👋 

TypeScript 5 rejects passing a `Kysely` instance with tables `a` and `b` to a function requiring only table `a`, even when the shared table has the same row type. This change allows that assignment and adds a regression test.

This PR redeclares the inherited `~DB` field directly on `Kysely` using `QueryCreator<DB>['~DB']`. This is a compiler workaround: it preserves the field's type and emits no runtime code. A TODO calls for removing the redeclaration when TypeScript 6.0 becomes the minimum supported version; the supported 5.x versions still require it.

It adds five chain assignability tests covering plugin and table helper chains, cross-class assignments, missing tables, CTEs, and recursive CTEs.

It also adds nine column assignability tests covering incompatible or missing columns, nullable reads, and equivalent or incompatible generated and `ColumnType` declarations.