### PR TITLE
fix: preserve column read and write types in assignments

### DIFF
--- a/src/query-builder/merge-query-builder.ts
+++ b/src/query-builder/merge-query-builder.ts
@@ -45,6 +45,7 @@ import type { CompiledQuery } from '../query-compiler/compiled-query.js'
 import { NOOP_QUERY_EXECUTOR } from '../query-executor/noop-query-executor.js'
 import type { QueryExecutor } from '../query-executor/query-executor.js'
 import type { AbortableQueryOptions } from '../util/abort.js'
+import type { Insertable, Selectable, Updateable } from '../util/column-type.js'
 import type { Compilable } from '../util/compilable.js'
 import type {
   Executable,
@@ -77,8 +78,14 @@ export class MergeQueryBuilder<DB, TT extends keyof DB, O>
 {
   // Keep the schema mapped for table-subset assignability on TypeScript 5.
   declare protected readonly '~DB': IsAny<DB> extends true
-    ? DB
-    : { [T in keyof DB]: DB[T] }
+    ? any
+    : {
+        [T in keyof DB]: {
+          select: () => Selectable<DB[T]>
+          insert: (row: Insertable<DB[T]>) => void
+          update: (row: Updateable<DB[T]>) => void
+        }
+      }
 
   readonly #props: MergeQueryBuilderProps
 

--- a/src/query-creator.ts
+++ b/src/query-creator.ts
@@ -48,12 +48,19 @@ import type { DeleteFrom } from './parser/delete-from-parser.js'
 import type { UpdateTable } from './parser/update-parser.js'
 import type { MergeInto } from './parser/merge-into-parser.js'
 import type { IsAny } from './util/type-utils.js'
+import type { Insertable, Selectable, Updateable } from './util/column-type.js'
 
 export class QueryCreator<DB> {
-  // Keep the schema mapped for table-subset assignability on TypeScript 5.
+  // Preserve the target's read guarantees and allowed writes when assigning.
   declare protected readonly '~DB': IsAny<DB> extends true
-    ? DB
-    : { [T in keyof DB]: DB[T] }
+    ? any
+    : {
+        [T in keyof DB]: {
+          select: () => Selectable<DB[T]>
+          insert: (row: Insertable<DB[T]>) => void
+          update: (row: Updateable<DB[T]>) => void
+        }
+      }
 
   readonly #props: QueryCreatorProps
 

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -158,7 +158,7 @@ bench('WheneableMergeQueryBuilder assignable to a narrower one', () => {
 
 bench('Transaction assignable to Kysely', () => {
   return acceptsKysely(transaction)
-}).types([109553, 'instantiations'])
+}).types([103376, 'instantiations'])
 
 bench('MergeQueryBuilder assignable to narrower MergeQueryBuilder', () => {
   return acceptsNarrowMergeInto(wideMergeInto)

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -158,8 +158,8 @@ bench('WheneableMergeQueryBuilder assignable to a narrower one', () => {
 
 bench('Transaction assignable to Kysely', () => {
   return acceptsKysely(transaction)
-}).types([103376, 'instantiations'])
+}).types([103353, 'instantiations'])
 
 bench('MergeQueryBuilder assignable to narrower MergeQueryBuilder', () => {
   return acceptsNarrowMergeInto(wideMergeInto)
-}).types([22766, 'instantiations'])
+}).types([22917, 'instantiations'])

--- a/test/typings/vitest/kysely-column-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-column-assignability.test-d.ts
@@ -4,6 +4,8 @@ import type {
   Generated,
   ControlledTransaction,
   Kysely,
+  MergeQueryBuilder,
+  MergeResult,
   Transaction,
 } from '../../../dist/index.js'
 import {
@@ -11,6 +13,58 @@ import {
   type Instances,
   type DatabaseA,
 } from './assignability.fixtures.js'
+
+test('accepts narrower column writes while preserving nullable reads', () => {
+  type Source = {
+    a: {
+      updatedAt: ColumnType<
+        Date | null,
+        Date | string | null,
+        Date | string | null
+      >
+    }
+  }
+  type Target = {
+    a: { updatedAt: ColumnType<Date | null, Date | string, Date | string> }
+  }
+  const source = null! as Instances<Source>
+
+  accept<Kysely<Target>>(source.db)
+  accept<Kysely<Target>>(source.transaction)
+  accept<Transaction<Target>>(source.transaction)
+  accept<Transaction<Target>>(source.controlled)
+  accept<ControlledTransaction<Target>>(source.controlled)
+  accept<MergeQueryBuilder<Target, 'a', MergeResult>>(source.db.mergeInto('a'))
+
+  source.db.transaction().execute(async (transaction) => {
+    accept<Transaction<Target>>(transaction)
+  })
+})
+
+test('rejects wider column writes even when nullable reads match', () => {
+  type Source = {
+    a: { updatedAt: ColumnType<Date | null, Date | string, Date | string> }
+  }
+  type Target = {
+    a: {
+      updatedAt: ColumnType<
+        Date | null,
+        Date | string | null,
+        Date | string | null
+      >
+    }
+  }
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error the target permits writing null to the source column
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error the target permits writing null to the source column
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error the target permits writing null to the source column
+  accept<ControlledTransaction<Target>>(source.controlled)
+  // @ts-expect-error the target permits writing null to the source column
+  accept<MergeQueryBuilder<Target, 'a', MergeResult>>(source.db.mergeInto('a'))
+})
 
 test('rejects incompatible column types', () => {
   type Source = { a: { id: string } }

--- a/test/typings/vitest/kysely-column-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-column-assignability.test-d.ts
@@ -170,3 +170,41 @@ test('rejects incompatible ColumnType update types', () => {
   // @ts-expect-error the update types differ
   accept<ControlledTransaction<Target>>(source.controlled)
 })
+
+test('rejects widening writable columns to accept null', () => {
+  type Source = DatabaseA
+  type Target = { a: { id: number | null } }
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error the target permits writing null to the nonnullable source column
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error the target permits writing null to the nonnullable source column
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error the target permits writing null to the nonnullable source column
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error the target permits writing null to the nonnullable source column
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error the target permits writing null to the nonnullable source column
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error the target permits writing null to the nonnullable source column
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('rejects forgetting required insert columns', () => {
+  type Source = { a: { id: number; name: string } }
+  type Target = DatabaseA
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error the target permits inserts without the required source name
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error the target permits inserts without the required source name
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error the target permits inserts without the required source name
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error the target permits inserts without the required source name
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error the target permits inserts without the required source name
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error the target permits inserts without the required source name
+  accept<ControlledTransaction<Target>>(source.controlled)
+})

--- a/test/typings/vitest/kysely-column-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-column-assignability.test-d.ts
@@ -208,3 +208,79 @@ test('rejects forgetting required insert columns', () => {
   // @ts-expect-error the target permits inserts without the required source name
   accept<ControlledTransaction<Target>>(source.controlled)
 })
+
+test('rejects nullable selects where nonnullable selects are required', () => {
+  type Source = { a: { id: ColumnType<number | null, number, number> } }
+  type Target = { a: { id: ColumnType<number, number, number> } }
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error the source can select null but the target promises number
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error the source can select null but the target promises number
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error the source can select null but the target promises number
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error the source can select null but the target promises number
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error the source can select null but the target promises number
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error the source can select null but the target promises number
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('rejects broader select unions', () => {
+  type Source = { a: { id: ColumnType<1 | 2, number, number> } }
+  type Target = { a: { id: ColumnType<1, number, number> } }
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error the source can select 2 but the target promises 1
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error the source can select 2 but the target promises 1
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error the source can select 2 but the target promises 1
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error the source can select 2 but the target promises 1
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error the source can select 2 but the target promises 1
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error the source can select 2 but the target promises 1
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('rejects widening only update types to allow null', () => {
+  type Source = { a: { id: ColumnType<number, number, number> } }
+  type Target = { a: { id: ColumnType<number, number, number | null> } }
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error the target permits updating the source column to null
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error the target permits updating the source column to null
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error the target permits updating the source column to null
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error the target permits updating the source column to null
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error the target permits updating the source column to null
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error the target permits updating the source column to null
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('rejects widening only update unions', () => {
+  type Source = { a: { id: ColumnType<number, number, 1> } }
+  type Target = { a: { id: ColumnType<number, number, 1 | 2> } }
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error the target permits updating the source column to 2
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error the target permits updating the source column to 2
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error the target permits updating the source column to 2
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error the target permits updating the source column to 2
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error the target permits updating the source column to 2
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error the target permits updating the source column to 2
+  accept<ControlledTransaction<Target>>(source.controlled)
+})


### PR DESCRIPTION
Hey 👋 

Assignments can currently widen writable columns to accept null or hide required insert columns. `ColumnType` also allows update types to widen independently of insert types. 

This PR rejects those unsafe assignments while allowing transactions whose writes are more restricted and whose reads remain compatible.

It maps the existing protected ~DB markers in `QueryCreator` and `MergeQueryBuilder` to select, insert, and update function types per table. Select return types preserve read guarantees; insert and update parameters ensure the source supports every write allowed by the target. Both markers explicitly preserve any schemas. The declarations emit no runtime code.
