### PR TITLE
feat(introspection): expose database type metadata

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -268,22 +268,28 @@ jobs:
       - name: run cloudflare workers test
         run: pnpm test:cloudflare-workers
 
-  older-typescript-version:
+  typescript-version:
     concurrency:
       cancel-in-progress: ${{ github.ref_name != 'master' }}
-      group: ${{ github.workflow }}-older-typescript-version-${{ matrix.typescript-version }}-${{ github.event.pull_request.number || github.sha }}
+      group: ${{ github.workflow }}-typescript-version-${{ matrix.typescript-version }}-${{ github.event.pull_request.number || github.sha }}
 
-    name: Older TypeScript version
+    name: TypeScript (${{ matrix.typescript-version }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        typescript-version: [
-            ~5.4.0, # 6.3.2024 https://devblogs.microsoft.com/typescript/announcing-typescript-5-4/
-            ~5.8.0, # 28.2.2025 https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/ https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/ https://devblogs.microsoft.com/typescript/announcing-typescript-5-7/ https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/
-            ~5.9.0, # 1.8.2025 https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/
-          ]
+        include:
+          - typescript-version: ~5.4.0
+            tsd-version: 0.31.2
+          - typescript-version: ~5.8.0
+            tsd-version: 0.32.0
+          - typescript-version: ~5.9.0
+            tsd-version: 0.33.0
+          - typescript-version: ~6.0.0
+            tsd-version: ''
+          - typescript-version: ~7.0.0
+            tsd-version: ''
 
     steps:
       - name: harden runner
@@ -308,25 +314,36 @@ jobs:
       - name: install dependencies
         run: pnpm install
 
-      - name: run build with newer typescript
+      - name: run build with the main typescript compiler
         run: pnpm build
 
-      - name: set typeScript and tsd versions
+      - name: install typescript and matching tsd
         env:
           TS_VERSION: ${{ matrix.typescript-version }}
+          TSD_VERSION: ${{ matrix.tsd-version }}
         run: |
-          echo "TS_VERSION=$TS_VERSION" >> $GITHUB_ENV
-          TSD_VERSION=$(echo '{"~5.4.0":"0.31.2", "~5.8.0":"0.32.0", "~5.9.0":"0.33.0"}' | jq -r --arg key "$TS_VERSION" '.[$key]')
-          echo "TSD_VERSION=$TSD_VERSION" >> $GITHUB_ENV
-
-      - name: install typescript (${{ env.TS_VERSION }}) and tsd (${{ env.TSD_VERSION }})
-        run: pnpm i -D "typescript@$TS_VERSION" "tsd@$TSD_VERSION"
+          if [ -n "$TSD_VERSION" ]; then
+            pnpm i -D "typescript@$TS_VERSION" "tsd@$TSD_VERSION"
+          else
+            pnpm i -D "typescript@$TS_VERSION"
+          fi
 
       - name: make `tsconfig` backwards compatible
+        id: typecheck-setup
         run: pnpm script:override-tsconfig-target
 
-      - name: run tests with older typescript version
-        run: pnpm test:typings && pnpm test:node:build
+      - name: run vitest typing tests
+        run: |
+          node node_modules/typescript/bin/tsc --version
+          pnpm test:typings:vitest
+
+      - name: run tsd typing tests
+        if: ${{ !cancelled() && steps.typecheck-setup.outcome == 'success' && matrix.tsd-version != '' }}
+        run: pnpm test:typings
+
+      - name: build node tests with the selected typescript compiler
+        if: ${{ !cancelled() && steps.typecheck-setup.outcome == 'success' }}
+        run: pnpm test:node:build
 
   jsdocs:
     concurrency:

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ node_modules
 .vscode
 .idea
 tsconfig.tsbuildinfo
+/test/typings/tsconfig.vitest.tsbuildinfo
 /playground.ts

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "test:cloudflare-workers": "pnpm build && pnpm -r test --filter kysely-cloudflare-workers-test",
     "test:deno": "deno run --allow-env --allow-read --allow-net --no-lock test/deno/test.ts",
     "test:typings": "tsd test/typings",
+    "test:typings:vitest": "vitest run --config test/typings/vitest.config.ts",
     "test:esmimports": "node scripts/check-esm-imports.cjs",
     "test:esbuild": "esbuild --bundle --platform=node --external:pg-native dist/index.js --outfile=/dev/null",
     "test:exports": "attw --profile esm-only --pack . && node scripts/check-exports.cjs",
@@ -125,7 +126,8 @@
     "tsd": "0.33.0",
     "tsx": "4.23.12",
     "typescript": "7.0.2",
-    "typescript-6": "npm:typescript@6.0.3"
+    "typescript-6": "npm:typescript@6.0.3",
+    "vitest": "5.0.0"
   },
   "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,24 +130,27 @@ importers:
       typescript-6:
         specifier: npm:typescript@6.0.3
         version: typescript@6.0.3
+      vitest:
+        specifier: 5.0.0
+        version: 5.0.0(@types/node@26.2.0)(vite@8.2.2)
 
   site:
     dependencies:
       '@docusaurus/core':
         specifier: 3.10.2
-        version: 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+        version: 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
       '@docusaurus/plugin-vercel-analytics':
         specifier: 3.10.2
-        version: 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+        version: 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
       '@docusaurus/preset-classic':
         specifier: 3.10.2
-        version: 3.10.2(@algolia/client-search@5.39.0)(@mdx-js/react@3.1.1)(@types/react@19.2.18)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(search-insights@2.17.3)(supports-color@10.2.2)(typescript@7.0.2)
+        version: 3.10.2(@algolia/client-search@5.39.0)(@mdx-js/react@3.1.1)(@types/react@19.2.18)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(search-insights@2.17.3)(supports-color@10.2.2)(typescript@7.0.2)
       '@docusaurus/theme-common':
         specifier: 3.10.2
-        version: 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+        version: 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       '@docusaurus/theme-mermaid':
         specifier: 3.10.2
-        version: 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+        version: 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
       '@mdx-js/react':
         specifier: 3.1.1
         version: 3.1.1(@types/react@19.2.18)(react@19.2.8)
@@ -169,13 +172,13 @@ importers:
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: 3.10.2
-        version: 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+        version: 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       '@docusaurus/tsconfig':
         specifier: 3.10.2
         version: 3.10.2
       '@docusaurus/types':
         specifier: 3.10.2
-        version: 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+        version: 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       '@signalwire/docusaurus-plugin-llms-txt':
         specifier: 1.2.2
         version: 1.2.2(@docusaurus/core@3.10.2)(supports-color@10.2.2)
@@ -2042,6 +2045,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.30':
     resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
 
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
@@ -2117,6 +2123,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@oxc-project/types@0.148.0':
+    resolution: {integrity: sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==}
 
   '@pagefind/darwin-arm64@1.5.2':
     resolution: {integrity: sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==}
@@ -2225,6 +2234,105 @@ packages:
 
   '@radix-ui/colors@3.0.0':
     resolution: {integrity: sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg==}
+
+  '@rolldown/binding-android-arm-eabi@1.2.7':
+    resolution: {integrity: sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.2.7':
+    resolution: {integrity: sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.7':
+    resolution: {integrity: sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.7':
+    resolution: {integrity: sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.7':
+    resolution: {integrity: sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.7':
+    resolution: {integrity: sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.7':
+    resolution: {integrity: sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.7':
+    resolution: {integrity: sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.7':
+    resolution: {integrity: sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.7':
+    resolution: {integrity: sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.7':
+    resolution: {integrity: sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.2.7':
+    resolution: {integrity: sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.2.7':
+    resolution: {integrity: sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.7':
+    resolution: {integrity: sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.7':
+    resolution: {integrity: sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@shikijs/core@4.4.3':
     resolution: {integrity: sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==}
@@ -2841,6 +2949,20 @@ packages:
         optional: true
       vue-router:
         optional: true
+
+  '@vitest/mocker@5.0.0':
+    resolution: {integrity: sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/spy@5.0.0':
+    resolution: {integrity: sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -4005,6 +4127,9 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -4129,6 +4254,10 @@ packages:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
 
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
   express@4.22.2:
     resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
     engines: {node: '>= 0.10.0'}
@@ -4162,6 +4291,15 @@ packages:
   faye-websocket@0.11.4:
     resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
     engines: {node: '>=0.8.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   feed@4.2.2:
     resolution: {integrity: sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==}
@@ -4918,6 +5056,80 @@ packages:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
 
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
@@ -5022,6 +5234,9 @@ packages:
   lru.min@1.1.4:
     resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+
+  magic-string@1.2.3:
+    resolution: {integrity: sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==}
 
   make-synchronized@0.8.0:
     resolution: {integrity: sha512-DZu4lwc0ffoFz581BSQa/BJl+1ZqIkoRQ+VejMlH0VrP4E86StAODnZujZ4sepumQj8rcP7wUnUBGM8Gu+zKUA==}
@@ -5476,6 +5691,10 @@ packages:
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -5707,6 +5926,10 @@ packages:
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
+    engines: {node: '>=12'}
 
   pkg-dir@7.0.0:
     resolution: {integrity: sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==}
@@ -6127,6 +6350,10 @@ packages:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
@@ -6471,6 +6698,11 @@ packages:
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
+  rolldown@1.2.7:
+    resolution: {integrity: sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
@@ -6623,6 +6855,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -6721,6 +6956,9 @@ packages:
   srcset@4.0.0:
     resolution: {integrity: sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==}
     engines: {node: '>=12'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
@@ -6925,9 +7163,21 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tinybench@6.1.4:
+    resolution: {integrity: sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==}
+    engines: {node: '>=20.0.0'}
+
   tinyexec@1.1.2:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
     engines: {node: '>=18'}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
@@ -7176,6 +7426,90 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite@8.2.2:
+    resolution: {integrity: sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0 || ^0.5.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@5.0.0:
+    resolution: {integrity: sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==}
+    engines: {node: ^22.12.0 || ^24.0.0 || >=26.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 5.0.0
+      '@vitest/browser-preview': 5.0.0
+      '@vitest/browser-webdriverio': ^5.0.0-beta.5 || >=5.0.0
+      '@vitest/coverage-istanbul': 5.0.0
+      '@vitest/coverage-v8': 5.0.0
+      '@vitest/ui': 5.0.0
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.4.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   watchpack@2.4.4:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
     engines: {node: '>=10.13.0'}
@@ -7258,6 +7592,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   widest-line@4.0.1:
@@ -8804,7 +9143,7 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@docusaurus/babel@3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)':
+  '@docusaurus/babel@3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)':
     dependencies:
       '@babel/core': 7.29.6(supports-color@10.2.2)
       '@babel/generator': 7.29.7
@@ -8816,7 +9155,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@docusaurus/logger': 3.10.2
-      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.3.1
       tslib: 2.8.1
@@ -8839,19 +9178,19 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.10.2(acorn@8.16.0)(csso@5.0.5)(esbuild@0.28.2)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
+  '@docusaurus/bundler@3.10.2(acorn@8.16.0)(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
     dependencies:
       '@babel/core': 7.29.6(supports-color@10.2.2)
-      '@docusaurus/babel': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/babel': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       '@docusaurus/cssnano-preset': 3.10.2
       '@docusaurus/logger': 3.10.2
-      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       babel-loader: 9.2.1(@babel/core@7.29.6)(webpack@5.104.1)
       clean-css: 5.3.3
       copy-webpack-plugin: 11.0.0(webpack@5.104.1)
       css-loader: 6.11.0(webpack@5.104.1)
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.2)(webpack@5.104.1)
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(webpack@5.104.1)
       cssnano: 6.1.2(postcss@8.5.23)
       file-loader: 6.2.0(webpack@5.104.1)
       html-minifier-terser: 7.2.0
@@ -8860,10 +9199,10 @@ snapshots:
       postcss: 8.5.23
       postcss-loader: 7.3.4(postcss@8.5.23)(typescript@7.0.2)(webpack@5.104.1)
       postcss-preset-env: 10.2.4(postcss@8.5.23)
-      terser-webpack-plugin: 5.6.0(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(webpack@5.104.1)
+      terser-webpack-plugin: 5.6.0(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack@5.104.1)
       tslib: 2.8.1
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.104.1)
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
       webpackbar: 7.0.0(webpack@5.104.1)
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -8883,15 +9222,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/core@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
+  '@docusaurus/core@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
     dependencies:
-      '@docusaurus/babel': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/bundler': 3.10.2(acorn@8.16.0)(csso@5.0.5)(esbuild@0.28.2)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/babel': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/bundler': 3.10.2(acorn@8.16.0)(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
       '@docusaurus/logger': 3.10.2
-      '@docusaurus/mdx-loader': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-common': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/mdx-loader': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-common': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -8926,7 +9265,7 @@ snapshots:
       tinypool: 1.1.1
       tslib: 2.8.1
       update-notifier: 6.0.2
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
       webpack-bundle-analyzer: 4.10.2
       webpack-dev-server: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(webpack@5.104.1)
       webpack-merge: 6.0.1
@@ -8965,11 +9304,11 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  '@docusaurus/mdx-loader@3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)':
+  '@docusaurus/mdx-loader@3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)':
     dependencies:
       '@docusaurus/logger': 3.10.2
-      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       '@mdx-js/mdx': 3.1.0(acorn@8.16.0)(supports-color@10.2.2)
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
@@ -8992,7 +9331,7 @@ snapshots:
       unist-util-visit: 5.0.0
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.104.1)
       vfile: 6.0.3
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -9010,9 +9349,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)':
+  '@docusaurus/module-type-aliases@3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)':
     dependencies:
-      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       '@types/history': 4.7.11
       '@types/react': 19.2.18
       '@types/react-router-config': 5.0.11
@@ -9038,17 +9377,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.10.2(@docusaurus/plugin-content-docs@3.10.2)(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
+  '@docusaurus/plugin-content-blog@3.10.2(@docusaurus/plugin-content-docs@3.10.2)(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
       '@docusaurus/logger': 3.10.2
-      '@docusaurus/mdx-loader': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-common': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/mdx-loader': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-common': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       cheerio: 1.0.0-rc.12
       combine-promises: 1.2.0
       feed: 4.2.2
@@ -9061,7 +9400,7 @@ snapshots:
       tslib: 2.8.1
       unist-util-visit: 5.0.0
       utility-types: 3.11.0
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -9087,17 +9426,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
+  '@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
       '@docusaurus/logger': 3.10.2
-      '@docusaurus/mdx-loader': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/module-type-aliases': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-common': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/mdx-loader': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/module-type-aliases': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-common': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.1
@@ -9108,7 +9447,7 @@ snapshots:
       schema-dts: 1.1.5
       tslib: 2.8.1
       utility-types: 3.11.0
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -9134,18 +9473,18 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
+  '@docusaurus/plugin-content-pages@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/mdx-loader': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/mdx-loader': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       fs-extra: 11.3.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -9171,12 +9510,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-css-cascade-layers@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
+  '@docusaurus/plugin-css-cascade-layers@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
@@ -9205,11 +9544,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
+  '@docusaurus/plugin-debug@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       fs-extra: 11.3.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -9240,11 +9579,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
+  '@docusaurus/plugin-google-analytics@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
@@ -9273,11 +9612,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
+  '@docusaurus/plugin-google-gtag@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
@@ -9306,11 +9645,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
+  '@docusaurus/plugin-google-tag-manager@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
@@ -9339,14 +9678,14 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
+  '@docusaurus/plugin-sitemap@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
       '@docusaurus/logger': 3.10.2
-      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-common': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-common': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       fs-extra: 11.3.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -9377,18 +9716,18 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
+  '@docusaurus/plugin-svgr@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       '@svgr/core': 8.1.0(supports-color@10.2.2)(typescript@7.0.2)
       '@svgr/webpack': 8.1.0(supports-color@10.2.2)(typescript@7.0.2)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -9414,13 +9753,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-vercel-analytics@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
+  '@docusaurus/plugin-vercel-analytics@3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
       '@docusaurus/logger': 3.10.2
-      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       '@vercel/analytics': 1.5.0(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -9456,23 +9795,23 @@ snapshots:
       - vue-router
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.10.2(@algolia/client-search@5.39.0)(@mdx-js/react@3.1.1)(@types/react@19.2.18)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(search-insights@2.17.3)(supports-color@10.2.2)(typescript@7.0.2)':
+  '@docusaurus/preset-classic@3.10.2(@algolia/client-search@5.39.0)(@mdx-js/react@3.1.1)(@types/react@19.2.18)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(search-insights@2.17.3)(supports-color@10.2.2)(typescript@7.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/plugin-content-blog': 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/plugin-content-pages': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/plugin-css-cascade-layers': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/plugin-debug': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/plugin-google-analytics': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/plugin-google-gtag': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/plugin-google-tag-manager': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/plugin-sitemap': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/plugin-svgr': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/theme-classic': 3.10.2(@types/react@19.2.18)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/theme-search-algolia': 3.10.2(@algolia/client-search@5.39.0)(@mdx-js/react@3.1.1)(@types/react@19.2.18)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(search-insights@2.17.3)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/plugin-content-blog': 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/plugin-content-pages': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/plugin-css-cascade-layers': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/plugin-debug': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/plugin-google-analytics': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/plugin-google-gtag': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/plugin-google-tag-manager': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/plugin-sitemap': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/plugin-svgr': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/theme-classic': 3.10.2(@types/react@19.2.18)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/theme-search-algolia': 3.10.2(@algolia/client-search@5.39.0)(@mdx-js/react@3.1.1)(@types/react@19.2.18)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(search-insights@2.17.3)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     transitivePeerDependencies:
@@ -9508,21 +9847,21 @@ snapshots:
       '@types/react': 19.2.18
       react: 19.2.8
 
-  '@docusaurus/theme-classic@3.10.2(@types/react@19.2.18)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
+  '@docusaurus/theme-classic@3.10.2(@types/react@19.2.18)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
       '@docusaurus/logger': 3.10.2
-      '@docusaurus/mdx-loader': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/module-type-aliases': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/plugin-content-blog': 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/plugin-content-pages': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/mdx-loader': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/module-type-aliases': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/plugin-content-blog': 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/plugin-content-pages': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       '@docusaurus/theme-translations': 3.10.2
-      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-common': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-common': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.2
@@ -9562,13 +9901,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-common@3.10.2(@docusaurus/plugin-content-docs@3.10.2)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)':
+  '@docusaurus/theme-common@3.10.2(@docusaurus/plugin-content-docs@3.10.2)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/module-type-aliases': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-common': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/mdx-loader': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/module-type-aliases': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-common': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       '@types/history': 4.7.11
       '@types/react': 19.2.18
       '@types/react-router-config': 5.0.11
@@ -9596,13 +9935,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-mermaid@3.10.2(@docusaurus/plugin-content-docs@3.10.2)(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
+  '@docusaurus/theme-mermaid@3.10.2(@docusaurus/plugin-content-docs@3.10.2)(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/module-type-aliases': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/module-type-aliases': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       mermaid: 11.16.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -9633,17 +9972,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.10.2(@algolia/client-search@5.39.0)(@mdx-js/react@3.1.1)(@types/react@19.2.18)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(search-insights@2.17.3)(supports-color@10.2.2)(typescript@7.0.2)':
+  '@docusaurus/theme-search-algolia@3.10.2(@algolia/client-search@5.39.0)(@mdx-js/react@3.1.1)(@types/react@19.2.18)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(search-insights@2.17.3)(supports-color@10.2.2)(typescript@7.0.2)':
     dependencies:
       '@algolia/autocomplete-core': 1.19.8(@algolia/client-search@5.39.0)(algoliasearch@5.39.0)(search-insights@2.17.3)
       '@docsearch/react': 3.9.0(@algolia/client-search@5.39.0)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(search-insights@2.17.3)
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
       '@docusaurus/logger': 3.10.2
-      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
-      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       '@docusaurus/theme-translations': 3.10.2
-      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-validation': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       algoliasearch: 5.39.0
       algoliasearch-helper: 3.26.0(algoliasearch@5.39.0)
       clsx: 2.1.1
@@ -9689,7 +10028,7 @@ snapshots:
 
   '@docusaurus/tsconfig@3.10.2': {}
 
-  '@docusaurus/types@3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)':
+  '@docusaurus/types@3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)':
     dependencies:
       '@mdx-js/mdx': 3.1.0(acorn@8.16.0)(supports-color@10.2.2)
       '@types/history': 4.7.11
@@ -9701,7 +10040,7 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.2.8)(react@19.2.8)'
       utility-types: 3.11.0
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -9720,9 +10059,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)':
+  '@docusaurus/utils-common@3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)':
     dependencies:
-      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -9743,11 +10082,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-validation@3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)':
+  '@docusaurus/utils-validation@3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)':
     dependencies:
       '@docusaurus/logger': 3.10.2
-      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-common': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-common': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       fs-extra: 11.3.1
       joi: 17.13.4
       js-yaml: 4.3.1
@@ -9772,12 +10111,12 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)':
+  '@docusaurus/utils@3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)':
     dependencies:
       '@11ty/gray-matter': 1.0.0
       '@docusaurus/logger': 3.10.2
-      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
-      '@docusaurus/utils-common': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/types': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
+      '@docusaurus/utils-common': 3.10.2(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
       file-loader: 6.2.0(webpack@5.104.1)
@@ -9794,7 +10133,7 @@ snapshots:
       tslib: 2.8.1
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.104.1)
       utility-types: 3.11.0
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -10143,6 +10482,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
@@ -10244,6 +10588,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@oxc-project/types@0.148.0': {}
 
   '@pagefind/darwin-arm64@1.5.2':
     optional: true
@@ -10396,6 +10742,53 @@ snapshots:
 
   '@radix-ui/colors@3.0.0': {}
 
+  '@rolldown/binding-android-arm-eabi@1.2.7':
+    optional: true
+
+  '@rolldown/binding-android-arm64@1.2.7':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.7':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.7':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.7':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.7':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.7':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.7':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.7':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.7':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.7':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.7':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.7':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.7':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.7':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@shikijs/core@4.4.3':
     dependencies:
       '@shikijs/primitive': 4.4.3
@@ -10446,7 +10839,7 @@ snapshots:
 
   '@signalwire/docusaurus-plugin-llms-txt@1.2.2(@docusaurus/core@3.10.2)(supports-color@10.2.2)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.1)(acorn@8.16.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.4.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(typescript@7.0.2)
       fs-extra: 11.3.1
       hast-util-select: 6.0.4
       hast-util-to-html: 9.0.5
@@ -11038,6 +11431,17 @@ snapshots:
     optionalDependencies:
       react: 19.2.8
 
+  '@vitest/mocker@5.0.0(vite@8.2.2)':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@vitest/spy': 5.0.0
+      estree-walker: 3.0.3
+      magic-string: 1.2.3
+    optionalDependencies:
+      vite: 8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.43.1)(tsx@4.23.12)
+
+  '@vitest/spy@5.0.0': {}
+
   '@webassemblyjs/ast@1.14.1':
     dependencies:
       '@webassemblyjs/helper-numbers': 1.13.2
@@ -11279,7 +11683,7 @@ snapshots:
       '@babel/core': 7.29.6(supports-color@10.2.2)
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
@@ -11695,7 +12099,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
 
   core-js-compat@3.45.1:
     dependencies:
@@ -11759,9 +12163,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.8.5
     optionalDependencies:
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.2)(webpack@5.104.1):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(webpack@5.104.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.30
       cssnano: 6.1.2(postcss@8.5.23)
@@ -11769,11 +12173,12 @@ snapshots:
       postcss: 8.5.23
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
     optionalDependencies:
       clean-css: 5.3.3
       csso: 5.0.5
       esbuild: 0.28.2
+      lightningcss: 1.33.0
 
   css-prefers-color-scheme@10.0.0(postcss@8.5.23):
     dependencies:
@@ -12274,6 +12679,8 @@ snapshots:
 
   es-module-lexer@2.1.0: {}
 
+  es-module-lexer@2.3.2: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -12456,6 +12863,8 @@ snapshots:
 
   exit@0.1.2: {}
 
+  expect-type@1.4.0: {}
+
   express@4.22.2(supports-color@10.2.2):
     dependencies:
       accepts: 1.3.8
@@ -12524,6 +12933,10 @@ snapshots:
     dependencies:
       websocket-driver: 0.7.5
 
+  fdir@6.5.0(picomatch@4.0.7):
+    optionalDependencies:
+      picomatch: 4.0.7
+
   feed@4.2.2:
     dependencies:
       xml-js: 1.6.11
@@ -12534,7 +12947,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
 
   fill-range@7.1.1:
     dependencies:
@@ -12989,7 +13402,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -13384,6 +13797,55 @@ snapshots:
 
   leven@3.1.0: {}
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
@@ -13466,6 +13928,10 @@ snapshots:
       yallist: 4.0.0
 
   lru.min@1.1.4: {}
+
+  magic-string@1.2.3:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   make-synchronized@0.8.0: {}
 
@@ -14076,7 +14542,7 @@ snapshots:
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.3
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
 
   miniflare@5.20260801.1-alpha:
     dependencies:
@@ -14228,7 +14694,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
 
   object-assign@4.1.1: {}
 
@@ -14246,6 +14712,8 @@ snapshots:
       object-keys: 1.1.1
 
   obuf@1.1.2: {}
+
+  obug@2.1.4: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -14480,6 +14948,8 @@ snapshots:
 
   picomatch@2.3.2: {}
 
+  picomatch@4.0.7: {}
+
   pkg-dir@7.0.0:
     dependencies:
       find-up: 6.3.0
@@ -14660,7 +15130,7 @@ snapshots:
       jiti: 1.21.7
       postcss: 8.5.23
       semver: 7.8.5
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
     transitivePeerDependencies:
       - typescript
 
@@ -14946,6 +15416,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postgres-array@2.0.0: {}
 
   postgres-bytea@1.0.1: {}
@@ -15066,7 +15542,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.7
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.8)'
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
 
   react-router-config@5.1.1(react-router@5.3.4)(react@19.2.8):
     dependencies:
@@ -15360,6 +15836,27 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
+  rolldown@1.2.7:
+    dependencies:
+      '@oxc-project/types': 0.148.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm-eabi': 1.2.7
+      '@rolldown/binding-android-arm64': 1.2.7
+      '@rolldown/binding-darwin-arm64': 1.2.7
+      '@rolldown/binding-darwin-x64': 1.2.7
+      '@rolldown/binding-freebsd-x64': 1.2.7
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.7
+      '@rolldown/binding-linux-arm64-gnu': 1.2.7
+      '@rolldown/binding-linux-arm64-musl': 1.2.7
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.7
+      '@rolldown/binding-linux-s390x-gnu': 1.2.7
+      '@rolldown/binding-linux-x64-gnu': 1.2.7
+      '@rolldown/binding-linux-x64-musl': 1.2.7
+      '@rolldown/binding-openharmony-arm64': 1.2.7
+      '@rolldown/binding-win32-arm64-msvc': 1.2.7
+      '@rolldown/binding-win32-x64-msvc': 1.2.7
+
   roughjs@4.6.6:
     dependencies:
       hachure-fill: 0.5.2
@@ -15582,6 +16079,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -15688,6 +16187,8 @@ snapshots:
   sql-escaper@1.5.1: {}
 
   srcset@4.0.0: {}
+
+  stackback@0.0.2: {}
 
   statuses@1.5.0: {}
 
@@ -15823,19 +16324,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  terser-webpack-plugin@5.6.0(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(webpack@5.104.1):
+  terser-webpack-plugin@5.6.0(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack@5.104.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.30
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.43.1
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
     optionalDependencies:
       clean-css: 5.3.3
       cssnano: 6.1.2(postcss@8.5.23)
       csso: 5.0.5
       esbuild: 0.28.2
       html-minifier-terser: 7.2.0
+      lightningcss: 1.33.0
       postcss: 8.5.23
 
   terser@5.43.1:
@@ -15867,7 +16369,16 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinybench@6.1.4: {}
+
   tinyexec@1.1.2: {}
+
+  tinyexec@1.3.0: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
 
   tinypool@1.1.1: {}
 
@@ -16074,7 +16585,7 @@ snapshots:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
     optionalDependencies:
       file-loader: 6.2.0(webpack@5.104.1)
 
@@ -16114,6 +16625,42 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.43.1)(tsx@4.23.12):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.7
+      postcss: 8.5.26
+      rolldown: 1.2.7
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.2.0
+      esbuild: 0.28.2
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      terser: 5.43.1
+      tsx: 4.23.12
+
+  vitest@5.0.0(@types/node@26.2.0)(vite@8.2.2):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/mocker': 5.0.0(vite@8.2.2)
+      chai: 6.2.2
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 1.2.3
+      obug: 2.1.4
+      picomatch: 4.0.7
+      std-env: 4.2.0
+      tinybench: 6.1.4
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      vite: 8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.43.1)(tsx@4.23.12)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.2.0
+    transitivePeerDependencies:
+      - msw
+
   watchpack@2.4.4:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -16152,7 +16699,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
 
   webpack-dev-server@5.2.6(debug@4.4.3)(supports-color@10.2.2)(webpack@5.104.1):
     dependencies:
@@ -16185,7 +16732,7 @@ snapshots:
       webpack-dev-middleware: 7.4.5(webpack@5.104.1)
       ws: 8.21.0
     optionalDependencies:
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -16206,7 +16753,7 @@ snapshots:
 
   webpack-sources@3.3.3: {}
 
-  webpack@5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23):
+  webpack@5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -16230,7 +16777,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)(webpack@5.104.1)
+      terser-webpack-plugin: 5.6.0(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack@5.104.1)
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     transitivePeerDependencies:
@@ -16254,7 +16801,7 @@ snapshots:
       pretty-time: 1.1.0
       std-env: 3.10.0
     optionalDependencies:
-      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.23)
 
   websocket-driver@0.7.5:
     dependencies:
@@ -16267,6 +16814,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@4.0.1:
     dependencies:

--- a/src/dialect/database-introspector.ts
+++ b/src/dialect/database-introspector.ts
@@ -11,6 +11,13 @@ export interface DatabaseIntrospector {
    * Get tables and views metadata.
    */
   getTables(options?: DatabaseMetadataOptions): Promise<TableMetadata[]>
+
+  /**
+   * Get named database types.
+   *
+   * Dialects that don't support named types return an empty array.
+   */
+  getTypes(): Promise<TypeMetadata[]>
 }
 
 export interface DatabaseMetadataOptions {
@@ -24,6 +31,26 @@ export interface DatabaseMetadataOptions {
 export interface SchemaMetadata {
   readonly name: string
 }
+
+export interface TypeMetadata {
+  readonly name: string
+  readonly schema?: string
+  readonly kind: TypeMetadataKind
+  readonly values?: string[]
+  readonly baseType?: string
+  readonly baseTypeSchema?: string
+}
+
+export type TypeMetadataKind =
+  | 'base'
+  | 'enum'
+  | 'composite'
+  | 'domain'
+  | 'range'
+  | 'multirange'
+  | 'pseudo'
+  | 'array'
+  | 'unknown'
 
 export interface TableMetadata {
   readonly name: string

--- a/src/dialect/mssql/mssql-introspector.ts
+++ b/src/dialect/mssql/mssql-introspector.ts
@@ -4,6 +4,7 @@ import type {
   DatabaseMetadataOptions,
   SchemaMetadata,
   TableMetadata,
+  TypeMetadata,
 } from '../database-introspector.js'
 import {
   DEFAULT_MIGRATION_LOCK_TABLE,
@@ -20,6 +21,10 @@ export class MssqlIntrospector implements DatabaseIntrospector {
 
   async getSchemas(): Promise<SchemaMetadata[]> {
     return await this.#db.selectFrom('sys.schemas').select('name').execute()
+  }
+
+  async getTypes(): Promise<TypeMetadata[]> {
+    return []
   }
 
   async getTables(

--- a/src/dialect/mysql/mysql-introspector.ts
+++ b/src/dialect/mysql/mysql-introspector.ts
@@ -3,6 +3,7 @@ import type {
   DatabaseMetadataOptions,
   SchemaMetadata,
   TableMetadata,
+  TypeMetadata,
 } from '../database-introspector.js'
 import {
   DEFAULT_MIGRATION_LOCK_TABLE,
@@ -27,6 +28,10 @@ export class MysqlIntrospector implements DatabaseIntrospector {
       .execute()
 
     return rawSchemas.map((it) => ({ name: it.SCHEMA_NAME }))
+  }
+
+  async getTypes(): Promise<TypeMetadata[]> {
+    return []
   }
 
   async getTables(

--- a/src/dialect/postgres/postgres-introspector.ts
+++ b/src/dialect/postgres/postgres-introspector.ts
@@ -3,6 +3,8 @@ import type {
   DatabaseMetadataOptions,
   SchemaMetadata,
   TableMetadata,
+  TypeMetadata,
+  TypeMetadataKind,
 } from '../database-introspector.js'
 import {
   DEFAULT_MIGRATION_LOCK_TABLE,
@@ -27,6 +29,64 @@ export class PostgresIntrospector implements DatabaseIntrospector {
       .execute()
 
     return rawSchemas.map((it) => ({ name: it.nspname }))
+  }
+
+  async getTypes(): Promise<TypeMetadata[]> {
+    const rawTypes = await this.#db
+      .selectFrom('pg_catalog.pg_type as typ')
+      .innerJoin('pg_catalog.pg_namespace as ns', 'typ.typnamespace', 'ns.oid')
+      .leftJoin('pg_catalog.pg_type as base', 'typ.typbasetype', 'base.oid')
+      .leftJoin(
+        'pg_catalog.pg_namespace as basens',
+        'base.typnamespace',
+        'basens.oid',
+      )
+      .leftJoin('pg_catalog.pg_enum as enum', 'typ.oid', 'enum.enumtypid')
+      .select([
+        'typ.typname as name',
+        'ns.nspname as schema',
+        'typ.typtype as type_kind',
+        'typ.typcategory as type_category',
+        'base.typname as base_type',
+        'basens.nspname as base_type_schema',
+        'enum.enumlabel as enum_value',
+        'enum.enumsortorder as enum_sort_order',
+      ])
+      .where('ns.nspname', 'not in', ['pg_catalog', 'information_schema'])
+      .orderBy('ns.nspname')
+      .orderBy('typ.typname')
+      .orderBy('enum.enumsortorder')
+      .$castTo<RawTypeMetadata>()
+      .execute()
+
+    const types: TypeMetadata[] = []
+
+    for (const rawType of rawTypes) {
+      let type = types.find(
+        (it) => it.name === rawType.name && it.schema === rawType.schema,
+      )
+
+      if (!type) {
+        type = {
+          name: rawType.name,
+          schema: rawType.schema,
+          kind: parseTypeKind(rawType.type_kind, rawType.type_category),
+          ...(rawType.base_type && { baseType: rawType.base_type }),
+          ...(rawType.base_type_schema && {
+            baseTypeSchema: rawType.base_type_schema,
+          }),
+          ...(rawType.enum_value && { values: [] }),
+        }
+
+        types.push(type)
+      }
+
+      if (rawType.enum_value) {
+        type.values?.push(rawType.enum_value)
+      }
+    }
+
+    return types
   }
 
   async getTables(
@@ -141,6 +201,45 @@ export class PostgresIntrospector implements DatabaseIntrospector {
 
 interface RawSchemaMetadata {
   nspname: string
+}
+
+interface RawTypeMetadata {
+  name: string
+  schema: string
+  type_kind: string
+  type_category: string
+  base_type: string | null
+  base_type_schema: string | null
+  enum_value: string | null
+  enum_sort_order: number | null
+}
+
+function parseTypeKind(
+  typeKind: string,
+  typeCategory: string,
+): TypeMetadataKind {
+  if (typeCategory === 'A') {
+    return 'array'
+  }
+
+  switch (typeKind) {
+    case 'b':
+      return 'base'
+    case 'c':
+      return 'composite'
+    case 'd':
+      return 'domain'
+    case 'e':
+      return 'enum'
+    case 'm':
+      return 'multirange'
+    case 'p':
+      return 'pseudo'
+    case 'r':
+      return 'range'
+    default:
+      return 'unknown'
+  }
 }
 
 interface RawColumnMetadata {

--- a/src/dialect/sqlite/sqlite-introspector.ts
+++ b/src/dialect/sqlite/sqlite-introspector.ts
@@ -3,6 +3,7 @@ import type {
   DatabaseMetadataOptions,
   SchemaMetadata,
   TableMetadata,
+  TypeMetadata,
 } from '../database-introspector.js'
 import type { Kysely } from '../../kysely.js'
 import {
@@ -45,6 +46,10 @@ export class SqliteIntrospector implements DatabaseIntrospector {
 
   async getSchemas(): Promise<SchemaMetadata[]> {
     // Sqlite doesn't support schemas.
+    return []
+  }
+
+  async getTypes(): Promise<TypeMetadata[]> {
     return []
   }
 

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -98,6 +98,10 @@ export class Kysely<DB>
   extends QueryCreator<DB>
   implements QueryExecutorProvider, AsyncDisposable
 {
+  // TODO: Remove when TypeScript 6.0 is the minimum supported version.
+  // TypeScript 5.x needs this inherited marker redeclared for table-subset assignability.
+  declare protected readonly '~DB': QueryCreator<DB>['~DB']
+
   readonly #props: KyselyProps
 
   constructor(args: KyselyConfig)

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -730,6 +730,20 @@ export class Transaction<DB> extends Kysely<DB> {
    *
    * @deprecated use {@link $extendTables} instead.
    */
+  // Base return overloads allow assignment to parent classes with fewer tables.
+  // Keep the transaction overload first for calls and last for ReturnType.
+  override withTables<
+    T extends Record<string, Record<string, any>>,
+  >(): Transaction<DrainOuterGeneric<DB & T>>
+
+  override withTables<T extends Record<string, Record<string, any>>>(): Kysely<
+    DrainOuterGeneric<DB & T>
+  >
+
+  override withTables<
+    T extends Record<string, Record<string, any>>,
+  >(): Transaction<DrainOuterGeneric<DB & T>>
+
   override withTables<
     T extends Record<string, Record<string, any>>,
   >(): Transaction<DrainOuterGeneric<DB & T>> {
@@ -741,6 +755,18 @@ export class Transaction<DB> extends Kysely<DB> {
    */
   override $extendTables<
     T extends Record<string, Record<string, any>>,
+  >(): Transaction<DrainOuterGeneric<DB & T>>
+
+  override $extendTables<
+    T extends Record<string, Record<string, any>>,
+  >(): Kysely<DrainOuterGeneric<DB & T>>
+
+  override $extendTables<
+    T extends Record<string, Record<string, any>>,
+  >(): Transaction<DrainOuterGeneric<DB & T>>
+
+  override $extendTables<
+    T extends Record<string, Record<string, any>>,
   >(): Transaction<DrainOuterGeneric<DB & T>> {
     return new Transaction({ ...this.#props })
   }
@@ -750,6 +776,18 @@ export class Transaction<DB> extends Kysely<DB> {
    */
   override $omitTables<T extends keyof DB>(): Transaction<
     DB extends object ? Omit<DB, T> : DB
+  >
+
+  override $omitTables<T extends keyof DB>(): Kysely<
+    DB extends object ? Omit<DB, T> : DB
+  >
+
+  override $omitTables<T extends keyof DB>(): Transaction<
+    DB extends object ? Omit<DB, T> : DB
+  >
+
+  override $omitTables<T extends keyof DB>(): Transaction<
+    DB extends object ? Omit<DB, T> : DB
   > {
     return new Transaction({ ...this.#props })
   }
@@ -757,6 +795,18 @@ export class Transaction<DB> extends Kysely<DB> {
   /**
    * Similar to {@link Kysely.$pickTables} but returns the transaction.
    */
+  override $pickTables<T extends keyof DB>(): Transaction<
+    DB extends object ? Pick<DB, T> : DB
+  >
+
+  override $pickTables<T extends keyof DB>(): Kysely<
+    DB extends object ? Pick<DB, T> : DB
+  >
+
+  override $pickTables<T extends keyof DB>(): Transaction<
+    DB extends object ? Pick<DB, T> : DB
+  >
+
   override $pickTables<T extends keyof DB>(): Transaction<
     DB extends object ? Pick<DB, T> : DB
   > {
@@ -1253,6 +1303,20 @@ export class ControlledTransaction<
     })
   }
 
+  // Base return overloads allow assignment to Kysely with fewer tables.
+  // Keep the controlled transaction overload first for calls and last for ReturnType.
+  override withTables<
+    T extends Record<string, Record<string, any>>,
+  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+
+  override withTables<T extends Record<string, Record<string, any>>>(): Kysely<
+    DrainOuterGeneric<DB & T>
+  >
+
+  override withTables<
+    T extends Record<string, Record<string, any>>,
+  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+
   override withTables<
     T extends Record<string, Record<string, any>>,
   >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S> {
@@ -1261,9 +1325,35 @@ export class ControlledTransaction<
 
   override $extendTables<
     T extends Record<string, Record<string, any>>,
+  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+
+  override $extendTables<
+    T extends Record<string, Record<string, any>>,
+  >(): Kysely<DrainOuterGeneric<DB & T>>
+
+  override $extendTables<
+    T extends Record<string, Record<string, any>>,
+  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+
+  override $extendTables<
+    T extends Record<string, Record<string, any>>,
   >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S> {
     return new ControlledTransaction({ ...this.#props })
   }
+
+  override $omitTables<T extends keyof DB>(): ControlledTransaction<
+    DB extends object ? Omit<DB, T> : DB,
+    S
+  >
+
+  override $omitTables<T extends keyof DB>(): Kysely<
+    DB extends object ? Omit<DB, T> : DB
+  >
+
+  override $omitTables<T extends keyof DB>(): ControlledTransaction<
+    DB extends object ? Omit<DB, T> : DB,
+    S
+  >
 
   override $omitTables<T extends keyof DB>(): ControlledTransaction<
     DB extends object ? Omit<DB, T> : DB,

--- a/src/query-builder/merge-query-builder.ts
+++ b/src/query-builder/merge-query-builder.ts
@@ -53,6 +53,7 @@ import type {
 import { freeze } from '../util/object-utils.js'
 import type { QueryId } from '../util/query-id.js'
 import type {
+  IsAny,
   ShallowRecord,
   SimplifyResult,
   SimplifySingleResult,
@@ -74,6 +75,11 @@ import { UpdateQueryBuilder } from './update-query-builder.js'
 export class MergeQueryBuilder<DB, TT extends keyof DB, O>
   implements MultiTableReturningInterface<DB, TT, O>, OutputInterface<DB, TT, O>
 {
+  // Keep the schema mapped for table-subset assignability on TypeScript 5.
+  declare protected readonly '~DB': IsAny<DB> extends true
+    ? DB
+    : { [T in keyof DB]: DB[T] }
+
   readonly #props: MergeQueryBuilderProps
 
   constructor(props: MergeQueryBuilderProps) {

--- a/src/query-creator.ts
+++ b/src/query-creator.ts
@@ -49,6 +49,8 @@ import type { UpdateTable } from './parser/update-parser.js'
 import type { MergeInto } from './parser/merge-into-parser.js'
 
 export class QueryCreator<DB> {
+  declare protected readonly '~DB': DB
+
   readonly #props: QueryCreatorProps
 
   constructor(props: QueryCreatorProps) {

--- a/src/query-creator.ts
+++ b/src/query-creator.ts
@@ -47,9 +47,13 @@ import type { SelectFrom } from './parser/select-from-parser.js'
 import type { DeleteFrom } from './parser/delete-from-parser.js'
 import type { UpdateTable } from './parser/update-parser.js'
 import type { MergeInto } from './parser/merge-into-parser.js'
+import type { IsAny } from './util/type-utils.js'
 
 export class QueryCreator<DB> {
-  declare protected readonly '~DB': DB
+  // Keep the schema mapped for table-subset assignability on TypeScript 5.
+  declare protected readonly '~DB': IsAny<DB> extends true
+    ? DB
+    : { [T in keyof DB]: DB[T] }
 
   readonly #props: QueryCreatorProps
 

--- a/test/node/src/introspect.test.ts
+++ b/test/node/src/introspect.test.ts
@@ -79,6 +79,25 @@ for (const dialect of DIALECTS) {
       })
     })
 
+    describe('getTypes', () => {
+      it('should get type metadata', async () => {
+        const types = await ctx.db.introspection.getTypes()
+
+        if (sqlSpec === 'postgres') {
+          expect(types).to.containSubset([
+            {
+              name: 'species',
+              schema: 'dtype_schema',
+              kind: 'enum',
+              values: ['cat', 'dog', 'frog'],
+            },
+          ])
+        } else {
+          expect(types).to.eql([])
+        }
+      })
+    })
+
     describe('getTables', () => {
       it('should get table metadata', async () => {
         const meta = await ctx.db.introspection.getTables()

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -158,8 +158,8 @@ bench('WheneableMergeQueryBuilder assignable to a narrower one', () => {
 
 bench('Transaction assignable to Kysely', () => {
   return acceptsKysely(transaction)
-}).types([160079, 'instantiations'])
+}).types([109536, 'instantiations'])
 
 bench('MergeQueryBuilder assignable to narrower MergeQueryBuilder', () => {
   return acceptsNarrowMergeInto(wideMergeInto)
-}).types([22733, 'instantiations'])
+}).types([22766, 'instantiations'])

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -158,7 +158,7 @@ bench('WheneableMergeQueryBuilder assignable to a narrower one', () => {
 
 bench('Transaction assignable to Kysely', () => {
   return acceptsKysely(transaction)
-}).types([109536, 'instantiations'])
+}).types([109553, 'instantiations'])
 
 bench('MergeQueryBuilder assignable to narrower MergeQueryBuilder', () => {
   return acceptsNarrowMergeInto(wideMergeInto)

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -158,7 +158,7 @@ bench('WheneableMergeQueryBuilder assignable to a narrower one', () => {
 
 bench('Transaction assignable to Kysely', () => {
   return acceptsKysely(transaction)
-}).types([162352, 'instantiations'])
+}).types([160079, 'instantiations'])
 
 bench('MergeQueryBuilder assignable to narrower MergeQueryBuilder', () => {
   return acceptsNarrowMergeInto(wideMergeInto)

--- a/test/typings/tsconfig.vitest.json
+++ b/test/typings/tsconfig.vitest.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "incremental": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "skipLibCheck": true
+  },
+  "include": ["vitest/**/*.test-d.ts"]
+}

--- a/test/typings/vitest.config.ts
+++ b/test/typings/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    passWithNoTests: true,
+    typecheck: {
+      checker: './node_modules/typescript/bin/tsc',
+      enabled: true,
+      only: true,
+      // Avoid Vitest's shared incremental cache and honor the tsconfig setting.
+      build: true,
+      include: ['test/typings/vitest/**/*.test-d.ts'],
+      tsconfig: './test/typings/tsconfig.vitest.json',
+    },
+  },
+})

--- a/test/typings/vitest/assignability.fixtures.ts
+++ b/test/typings/vitest/assignability.fixtures.ts
@@ -1,0 +1,22 @@
+import type {
+  ControlledTransaction,
+  Kysely,
+  Transaction,
+} from '../../../dist/index.js'
+
+export type Row = { id: number }
+export type DatabaseA = { a: Row }
+export type DatabaseB = { b: Row }
+export type DatabaseAB = DatabaseA & DatabaseB
+
+export type Instances<DB> = {
+  db: Kysely<DB>
+  transaction: Transaction<DB>
+  controlled: ControlledTransaction<DB>
+}
+
+export declare const a: Instances<DatabaseA>
+export declare const b: Instances<DatabaseB>
+export declare const ab: Instances<DatabaseAB>
+
+export declare function accept<T>(value: T): void

--- a/test/typings/vitest/kysely-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-assignability.test-d.ts
@@ -1,0 +1,199 @@
+import { expectTypeOf, test } from 'vitest'
+import type {
+  ControlledTransaction,
+  Kysely,
+  Transaction,
+} from '../../../dist/index.js'
+
+declare const a: Kysely<{ a: { id: number } }>
+declare const ab: Kysely<{ a: { id: number }; b: { id: number } }>
+declare const transactionA: Transaction<{ a: { id: number } }>
+declare const transactionAB: Transaction<{
+  a: { id: number }
+  b: { id: number }
+}>
+declare const controlledTransactionA: ControlledTransaction<{
+  a: { id: number }
+}>
+declare const controlledTransactionAB: ControlledTransaction<{
+  a: { id: number }
+  b: { id: number }
+}>
+declare const controlledTransactionWithSavepoint: ControlledTransaction<
+  { a: { id: number }; b: { id: number } },
+  ['savepoint']
+>
+
+function queryA(db: Kysely<{ a: { id: number } }>) {
+  return db.selectFrom('a').selectAll().execute()
+}
+
+function queryB(db: Kysely<{ b: { id: number } }>) {
+  return db.selectFrom('b').selectAll().execute()
+}
+
+function queryAB(db: Kysely<{ a: { id: number }; b: { id: number } }>) {
+  return db.selectFrom('b').selectAll().execute()
+}
+
+function queryAInTransaction(trx: Transaction<{ a: { id: number } }>) {
+  return queryA(trx)
+}
+
+function queryBInTransaction(trx: Transaction<{ b: { id: number } }>) {
+  return queryB(trx)
+}
+
+function queryABInTransaction(
+  trx: Transaction<{ a: { id: number }; b: { id: number } }>,
+) {
+  return queryAB(trx)
+}
+
+function queryAInControlledTransaction(
+  trx: ControlledTransaction<{ a: { id: number } }>,
+) {
+  return queryA(trx)
+}
+
+function queryBInControlledTransaction(
+  trx: ControlledTransaction<{ b: { id: number } }>,
+) {
+  return queryB(trx)
+}
+
+function queryABInControlledTransaction(
+  trx: ControlledTransaction<{ a: { id: number }; b: { id: number } }>,
+) {
+  return queryAB(trx)
+}
+
+test('accepts a database with { a } where { a } is required', () => {
+  queryA(a)
+})
+
+test('rejects a database with { a } where { b } is required', () => {
+  // @ts-expect-error the source database does not declare table b
+  queryB(a)
+})
+
+test('accepts a database that declares both tables', () => {
+  queryAB(ab)
+})
+
+test('rejects a database that does not declare table b', () => {
+  // @ts-expect-error the source database does not declare table b
+  queryAB(a)
+})
+
+test('accepts a transaction with { a } where { a } is required', () => {
+  queryA(transactionA)
+  queryAInTransaction(transactionA)
+})
+
+test('rejects a transaction with { a } where { b } is required', () => {
+  // @ts-expect-error the source transaction does not declare table b
+  queryB(transactionA)
+  // @ts-expect-error the source transaction does not declare table b
+  queryBInTransaction(transactionA)
+})
+
+test('accepts a transaction that declares both tables', () => {
+  queryAB(transactionAB)
+  queryABInTransaction(transactionAB)
+})
+
+test('rejects a transaction that does not declare table b', () => {
+  // @ts-expect-error the source transaction does not declare table b
+  queryAB(transactionA)
+  // @ts-expect-error the source transaction does not declare table b
+  queryABInTransaction(transactionA)
+})
+
+test('accepts a controlled transaction with { a } where { a } is required', () => {
+  queryA(controlledTransactionA)
+  queryAInTransaction(controlledTransactionA)
+  queryAInControlledTransaction(controlledTransactionA)
+})
+
+test('rejects a controlled transaction with { a } where { b } is required', () => {
+  // @ts-expect-error the source transaction does not declare table b
+  queryB(controlledTransactionA)
+  // @ts-expect-error the source transaction does not declare table b
+  queryBInTransaction(controlledTransactionA)
+  // @ts-expect-error the source transaction does not declare table b
+  queryBInControlledTransaction(controlledTransactionA)
+})
+
+test('accepts a controlled transaction that declares both tables', () => {
+  queryAB(controlledTransactionAB)
+  queryABInTransaction(controlledTransactionAB)
+  queryABInControlledTransaction(controlledTransactionAB)
+})
+
+test('rejects a controlled transaction that does not declare table b', () => {
+  // @ts-expect-error the source transaction does not declare table b
+  queryAB(controlledTransactionA)
+  // @ts-expect-error the source transaction does not declare table b
+  queryABInTransaction(controlledTransactionA)
+  // @ts-expect-error the source transaction does not declare table b
+  queryABInControlledTransaction(controlledTransactionA)
+})
+
+test('preserves transaction types when changing tables', () => {
+  queryABInTransaction(transactionA.$extendTables<{ b: { id: number } }>())
+  queryABInTransaction(transactionA.withTables<{ b: { id: number } }>())
+  queryAInTransaction(transactionAB.$pickTables<'a'>())
+  queryAInTransaction(transactionAB.$omitTables<'b'>())
+
+  // @ts-expect-error the picked database does not declare table b
+  queryABInTransaction(transactionAB.$pickTables<'a'>())
+  // @ts-expect-error the omitted database does not declare table b
+  queryABInTransaction(transactionAB.$omitTables<'b'>())
+})
+
+test('preserves controlled transaction types when changing tables', () => {
+  queryABInControlledTransaction(
+    controlledTransactionA.$extendTables<{ b: { id: number } }>(),
+  )
+  queryABInControlledTransaction(
+    controlledTransactionA.withTables<{ b: { id: number } }>(),
+  )
+  queryAInControlledTransaction(controlledTransactionAB.$pickTables<'a'>())
+  queryAInControlledTransaction(controlledTransactionAB.$omitTables<'b'>())
+
+  // @ts-expect-error the picked database does not declare table b
+  queryABInControlledTransaction(controlledTransactionAB.$pickTables<'a'>())
+  // @ts-expect-error the omitted database does not declare table b
+  queryABInControlledTransaction(controlledTransactionAB.$omitTables<'b'>())
+})
+
+test('preserves savepoints when changing tables', () => {
+  for (const trx of [
+    controlledTransactionWithSavepoint.$extendTables<{ c: { id: number } }>(),
+    controlledTransactionWithSavepoint.withTables<{ c: { id: number } }>(),
+    controlledTransactionWithSavepoint.$pickTables<'a'>(),
+    controlledTransactionWithSavepoint.$omitTables<'b'>(),
+  ]) {
+    trx.rollbackToSavepoint('savepoint')
+    // @ts-expect-error the transaction does not declare this savepoint
+    trx.rollbackToSavepoint('missing')
+  }
+})
+
+test('preserves transaction helper types in ReturnType', () => {
+  type TableHelpers =
+    '$extendTables' | 'withTables' | '$pickTables' | '$omitTables'
+  type ReturnedTransaction = ReturnType<(typeof transactionA)[TableHelpers]>
+  type ReturnedControlledTransaction = ReturnType<
+    (typeof controlledTransactionWithSavepoint)[TableHelpers]
+  >
+
+  expectTypeOf<ReturnedTransaction['isTransaction']>().toEqualTypeOf<true>()
+  expectTypeOf<
+    ReturnedControlledTransaction['isTransaction']
+  >().toEqualTypeOf<true>()
+  expectTypeOf<
+    Parameters<ReturnedControlledTransaction['rollbackToSavepoint']>[0]
+  >().toEqualTypeOf<'savepoint'>()
+})

--- a/test/typings/vitest/kysely-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-assignability.test-d.ts
@@ -77,6 +77,10 @@ test('rejects a database with { a } where { b } is required', () => {
   queryB(a)
 })
 
+test('accepts a database with { a, b } where { a } is required', () => {
+  queryA(ab)
+})
+
 test('accepts a database that declares both tables', () => {
   queryAB(ab)
 })

--- a/test/typings/vitest/kysely-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-assignability.test-d.ts
@@ -98,6 +98,11 @@ test('rejects a transaction with { a } where { b } is required', () => {
   queryBInTransaction(transactionA)
 })
 
+test('accepts a transaction with { a, b } where { a } is required', () => {
+  queryA(transactionAB)
+  queryAInTransaction(transactionAB)
+})
+
 test('accepts a transaction that declares both tables', () => {
   queryAB(transactionAB)
   queryABInTransaction(transactionAB)
@@ -123,6 +128,12 @@ test('rejects a controlled transaction with { a } where { b } is required', () =
   queryBInTransaction(controlledTransactionA)
   // @ts-expect-error the source transaction does not declare table b
   queryBInControlledTransaction(controlledTransactionA)
+})
+
+test('accepts a controlled transaction with { a, b } where { a } is required', () => {
+  queryA(controlledTransactionAB)
+  queryAInTransaction(controlledTransactionAB)
+  queryAInControlledTransaction(controlledTransactionAB)
 })
 
 test('accepts a controlled transaction that declares both tables', () => {

--- a/test/typings/vitest/kysely-chain-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-chain-assignability.test-d.ts
@@ -1,0 +1,130 @@
+import { test } from 'vitest'
+import type {
+  ControlledTransaction,
+  Kysely,
+  KyselyPlugin,
+  Transaction,
+} from '../../../dist/index.js'
+import type { QueryCreator } from '../../../dist/query-creator.js'
+import {
+  accept,
+  a,
+  ab,
+  type DatabaseA,
+  type DatabaseAB,
+  type DatabaseB,
+  type Row,
+} from './assignability.fixtures.js'
+
+declare const plugin: KyselyPlugin
+
+test('accepts cross-class assignment after plugin and table helper chains', () => {
+  const db = a.db
+    .$extendTables<DatabaseB>()
+    .withPlugin(plugin)
+    .withSchema('app')
+    .$pickTables<'a' | 'b'>()
+    .withoutPlugins()
+  const transaction = a.transaction
+    .$extendTables<DatabaseB>()
+    .withPlugin(plugin)
+    .withSchema('app')
+    .$pickTables<'a' | 'b'>()
+    .withoutPlugins()
+  const controlled = a.controlled
+    .withTables<DatabaseB>()
+    .withPlugin(plugin)
+    .withSchema('app')
+    .$pickTables<'a' | 'b'>()
+    .withoutPlugins()
+
+  accept<Kysely<DatabaseA>>(db)
+  accept<Kysely<DatabaseA>>(transaction)
+  accept<Transaction<DatabaseA>>(transaction)
+  accept<Kysely<DatabaseA>>(controlled)
+  accept<Transaction<DatabaseA>>(controlled)
+  accept<ControlledTransaction<DatabaseA>>(controlled)
+  accept<Kysely<DatabaseAB>>(db)
+  accept<Transaction<DatabaseAB>>(transaction)
+  accept<ControlledTransaction<DatabaseAB>>(controlled)
+})
+
+test('rejects missing tables after plugin and table helper chains', () => {
+  const db = ab.db.$omitTables<'b'>().withSchema('app').withPlugin(plugin)
+  const transaction = ab.transaction
+    .$pickTables<'a'>()
+    .withSchema('app')
+    .withoutPlugins()
+  const controlled = ab.controlled
+    .$omitTables<'b'>()
+    .withPlugin(plugin)
+    .withoutPlugins()
+
+  // @ts-expect-error the chain removed b
+  accept<Kysely<DatabaseAB>>(db)
+  // @ts-expect-error the chain removed b
+  accept<Kysely<DatabaseAB>>(transaction)
+  // @ts-expect-error the chain removed b
+  accept<Transaction<DatabaseAB>>(transaction)
+  // @ts-expect-error the chain removed b
+  accept<Kysely<DatabaseAB>>(controlled)
+  // @ts-expect-error the chain removed b
+  accept<Transaction<DatabaseAB>>(controlled)
+  // @ts-expect-error the chain removed b
+  accept<ControlledTransaction<DatabaseAB>>(controlled)
+})
+
+test('accepts CTE query creators from all three classes', () => {
+  const db = a.db.with('b', (qb) => qb.selectFrom('a').select('id'))
+  const transaction = a.transaction.with('b', (qb) =>
+    qb.selectFrom('a').select('id'),
+  )
+  const controlled = a.controlled.with('b', (qb) =>
+    qb.selectFrom('a').select('id'),
+  )
+
+  accept<QueryCreator<DatabaseAB>>(db)
+  accept<QueryCreator<DatabaseAB>>(transaction)
+  accept<QueryCreator<DatabaseAB>>(controlled)
+  accept<QueryCreator<DatabaseA>>(db)
+  accept<QueryCreator<DatabaseA>>(transaction)
+  accept<QueryCreator<DatabaseA>>(controlled)
+  // @ts-expect-error a CTE query creator does not expose transaction methods
+  accept<Transaction<DatabaseAB>>(transaction)
+  // @ts-expect-error a CTE query creator does not expose controlled operations
+  accept<ControlledTransaction<DatabaseAB>>(controlled)
+})
+
+test('rejects missing tables in CTE query creator assignments', () => {
+  const db = a.db.with('c', (qb) => qb.selectFrom('a').select('id'))
+  const transaction = a.transaction.with('c', (qb) =>
+    qb.selectFrom('a').select('id'),
+  )
+  const controlled = a.controlled.with('c', (qb) =>
+    qb.selectFrom('a').select('id'),
+  )
+  // @ts-expect-error the CTE added c, not b
+  accept<QueryCreator<DatabaseAB>>(db)
+  // @ts-expect-error the CTE added c, not b
+  accept<QueryCreator<DatabaseAB>>(transaction)
+  // @ts-expect-error the CTE added c, not b
+  accept<QueryCreator<DatabaseAB>>(controlled)
+})
+
+test('preserves schemas through table helpers and recursive CTE chains', () => {
+  const query = a.controlled
+    .$extendTables<DatabaseB>()
+    .$pickTables<'a' | 'b'>()
+    .withPlugin(plugin)
+    .withSchema('app')
+    .withRecursive('c', (qb) =>
+      qb.selectFrom('a').select('id').unionAll(qb.selectFrom('c').select('id')),
+    )
+    .with('d', (qb) => qb.selectFrom('c').select('id'))
+    .withoutPlugins()
+
+  accept<QueryCreator<DatabaseAB & { c: Row; d: Row }>>(query)
+  accept<QueryCreator<{ d: Row }>>(query)
+  // @ts-expect-error neither the helpers nor the CTEs declare e
+  accept<QueryCreator<{ e: Row }>>(query)
+})

--- a/test/typings/vitest/kysely-column-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-column-assignability.test-d.ts
@@ -1,0 +1,172 @@
+import { test } from 'vitest'
+import type {
+  ColumnType,
+  Generated,
+  ControlledTransaction,
+  Kysely,
+  Transaction,
+} from '../../../dist/index.js'
+import {
+  accept,
+  type Instances,
+  type DatabaseA,
+} from './assignability.fixtures.js'
+
+test('rejects incompatible column types', () => {
+  type Source = { a: { id: string } }
+  type Target = DatabaseA
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error id is a string in the source database
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error id is a string in the source database
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error id is a string in the source database
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error id is a string in the source database
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error id is a string in the source database
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error id is a string in the source database
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('rejects missing required columns', () => {
+  type Source = { a: { name: string } }
+  type Target = DatabaseA
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error the source table does not declare id
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error the source table does not declare id
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error the source table does not declare id
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error the source table does not declare id
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error the source table does not declare id
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error the source table does not declare id
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('rejects nullable columns where nonnullable columns are needed', () => {
+  type Source = { a: { id: number | null } }
+  type Target = DatabaseA
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error the source id can be null
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error the source id can be null
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error the source id can be null
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error the source id can be null
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error the source id can be null
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error the source id can be null
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('accepts structurally identical column declarations', () => {
+  type Source = { a: { id: number } }
+  type Target = DatabaseA
+  const source = null! as Instances<Source>
+
+  accept<Kysely<Target>>(source.db)
+  accept<Kysely<Target>>(source.transaction)
+  accept<Transaction<Target>>(source.transaction)
+  accept<Kysely<Target>>(source.controlled)
+  accept<Transaction<Target>>(source.controlled)
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('accepts equivalent generated column declarations', () => {
+  type Source = { a: { id: Generated<number> } }
+  type Target = { a: { id: ColumnType<number, number | undefined, number> } }
+  const source = null! as Instances<Source>
+
+  accept<Kysely<Target>>(source.db)
+  accept<Kysely<Target>>(source.transaction)
+  accept<Transaction<Target>>(source.transaction)
+  accept<Kysely<Target>>(source.controlled)
+  accept<Transaction<Target>>(source.controlled)
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('rejects incompatible generated column select types', () => {
+  type Source = { a: { id: Generated<string> } }
+  type Target = { a: { id: Generated<number> } }
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error generated id selects string instead of number
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error generated id selects string instead of number
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error generated id selects string instead of number
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error generated id selects string instead of number
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error generated id selects string instead of number
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error generated id selects string instead of number
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('rejects incompatible ColumnType select types', () => {
+  type Source = { a: { id: ColumnType<string, number, number> } }
+  type Target = { a: { id: ColumnType<number, number, number> } }
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error the select types differ
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error the select types differ
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error the select types differ
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error the select types differ
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error the select types differ
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error the select types differ
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('rejects incompatible ColumnType insert types', () => {
+  type Source = { a: { id: ColumnType<number, string, number> } }
+  type Target = { a: { id: ColumnType<number, number, number> } }
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error the insert types differ
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error the insert types differ
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error the insert types differ
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error the insert types differ
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error the insert types differ
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error the insert types differ
+  accept<ControlledTransaction<Target>>(source.controlled)
+})
+
+test('rejects incompatible ColumnType update types', () => {
+  type Source = { a: { id: ColumnType<number, number, string> } }
+  type Target = { a: { id: ColumnType<number, number, number> } }
+  const source = null! as Instances<Source>
+
+  // @ts-expect-error the update types differ
+  accept<Kysely<Target>>(source.db)
+  // @ts-expect-error the update types differ
+  accept<Kysely<Target>>(source.transaction)
+  // @ts-expect-error the update types differ
+  accept<Transaction<Target>>(source.transaction)
+  // @ts-expect-error the update types differ
+  accept<Kysely<Target>>(source.controlled)
+  // @ts-expect-error the update types differ
+  accept<Transaction<Target>>(source.controlled)
+  // @ts-expect-error the update types differ
+  accept<ControlledTransaction<Target>>(source.controlled)
+})


### PR DESCRIPTION
## Summary

  - Add `getTypes()` to `DatabaseIntrospector`
  - Add PostgreSQL support for named type introspection
  - Expose type schemas, kinds, enum values, and base types
  - Add introspection test coverage

## Explication 

In our school project, we use PostgreSQL enums to represent the possible states of a Visio room. Omni Visio is an open-source alternative to Google Meet.

We created a `room_state` enum with three possible values:

- `private`
- `protected`
- `public`

Kysely already allows us to create this enum during a migration:

### code exemple 

migration :

```typescript 
import type { Kysely } from 'kysely';
import { sql } from 'kysely';

export async function up(db: Kysely<any>): Promise<void> {
  await db.schema.createType('room_state').asEnum(['private', 'protected', 'public']).execute();

  await db.schema
    .alterTable('rooms')
    // withSchema() auto-qualifies table/type names it creates, but not raw sql
    // fragments, so the enum type must be schema-qualified explicitly here.
    .addColumn('state', sql.id('visio', 'room_state'), (col) => col.notNull().defaultTo('private'))
    .execute();
}

export async function down(db: Kysely<any>): Promise<void> {
  await db.schema.alterTable('rooms').dropColumn('state').execute();
  await db.schema.dropType('room_state').execute();
}
``` 

request to get type : 

```typescript
import type { Kysely } from 'kysely';
import { sql } from 'kysely';

import type { DB, RoomState } from '#/db/database.gen.js';

export function StatesRepository(db: Kysely<DB>) {
  return {
    async findAll() {
      const result = await sql<{ value: RoomState }>`
        select e.enumlabel as value
        from pg_enum e
        join pg_type t on t.oid = e.enumtypid
        where t.typname = 'room_state'
        order by e.enumsortorder
      `.execute(db);

      return result.rows.map(({ value }) => value);
    },
```

## Objective

My PR transform the brut sql in 

```typescript
import type { Kysely } from 'kysely'

  import type { DB } from '#/db/database.gen.js'

  export function StatesRepository(db: Kysely<DB>) {
    return {
      async findAll() {
        const type = (
          await db.introspection.getTypes()
        ).find(
          (type) =>
            type.schema === 'visio' &&
            type.name === 'room_state' &&
            type.kind === 'enum',
        )

        return type?.values ?? []
      },
    }
  }
```