### PR TITLE
fix: preserve controlled transaction column write assignability

### DIFF
--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -1369,6 +1369,20 @@ export class ControlledTransaction<
   override $pickTables<T extends keyof DB>(): ControlledTransaction<
     DB extends object ? Pick<DB, T> : DB,
     S
+  >
+
+  override $pickTables<T extends keyof DB>(): Kysely<
+    DB extends object ? Pick<DB, T> : DB
+  >
+
+  override $pickTables<T extends keyof DB>(): ControlledTransaction<
+    DB extends object ? Pick<DB, T> : DB,
+    S
+  >
+
+  override $pickTables<T extends keyof DB>(): ControlledTransaction<
+    DB extends object ? Pick<DB, T> : DB,
+    S
   > {
     return new ControlledTransaction({ ...this.#props })
   }

--- a/test/typings/vitest/kysely-column-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-column-assignability.test-d.ts
@@ -32,6 +32,7 @@ test('accepts narrower column writes while preserving nullable reads', () => {
   accept<Kysely<Target>>(source.db)
   accept<Kysely<Target>>(source.transaction)
   accept<Transaction<Target>>(source.transaction)
+  accept<Kysely<Target>>(source.controlled)
   accept<Transaction<Target>>(source.controlled)
   accept<ControlledTransaction<Target>>(source.controlled)
   accept<MergeQueryBuilder<Target, 'a', MergeResult>>(source.db.mergeInto('a'))


### PR DESCRIPTION
Hey 👋 

A ControlledTransaction whose columns allow nullable writes cannot be passed where Kysely permits only nonnullable writes, even when both schemas return the same nullable values. This assignment safely restricts the writes available to the receiving code.

This PR adds the missing assertion to the existing column assignability suite and give `ControlledTransaction.$pickTables()` the parent-return overload pattern already used by its other table helpers. The Kysely overload enables the assignment; the controlled transaction overload remains first for calls and last for ReturnType, preserving the schema and savepoint state.