### PR TITLE
fix: preserve generic table extension assignability

### DIFF
--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -34,7 +34,6 @@ import { CaseNode } from './operation-node/case-node.js'
 import { parseExpression } from './parser/expression-parser.js'
 import type { Expression } from './expression/expression.js'
 import { WithSchemaPlugin } from './plugin/with-schema/with-schema-plugin.js'
-import type { DrainOuterGeneric } from './util/type-utils.js'
 import type { QueryCompiler } from './query-compiler/query-compiler.js'
 import type {
   ReleaseSavepoint,
@@ -514,7 +513,7 @@ export class Kysely<DB>
    * ```
    */
   $extendTables<T extends Record<string, Record<string, any>>>(): Kysely<
-    DrainOuterGeneric<DB & T>
+    DB & T
   > {
     return new Kysely({ ...this.#props })
   }
@@ -595,9 +594,7 @@ export class Kysely<DB>
    * @deprecated use {@link $extendTables} instead.
    */
   // TODO: remove in 0.30
-  withTables<T extends Record<string, Record<string, any>>>(): Kysely<
-    DrainOuterGeneric<DB & T>
-  > {
+  withTables<T extends Record<string, Record<string, any>>>(): Kysely<DB & T> {
     return this.$extendTables()
   }
 
@@ -738,19 +735,19 @@ export class Transaction<DB> extends Kysely<DB> {
   // Keep the transaction overload first for calls and last for ReturnType.
   override withTables<
     T extends Record<string, Record<string, any>>,
-  >(): Transaction<DrainOuterGeneric<DB & T>>
+  >(): Transaction<DB & T>
 
   override withTables<T extends Record<string, Record<string, any>>>(): Kysely<
-    DrainOuterGeneric<DB & T>
+    DB & T
   >
 
   override withTables<
     T extends Record<string, Record<string, any>>,
-  >(): Transaction<DrainOuterGeneric<DB & T>>
+  >(): Transaction<DB & T>
 
   override withTables<
     T extends Record<string, Record<string, any>>,
-  >(): Transaction<DrainOuterGeneric<DB & T>> {
+  >(): Transaction<DB & T> {
     return new Transaction({ ...this.#props })
   }
 
@@ -759,19 +756,19 @@ export class Transaction<DB> extends Kysely<DB> {
    */
   override $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): Transaction<DrainOuterGeneric<DB & T>>
+  >(): Transaction<DB & T>
 
   override $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): Kysely<DrainOuterGeneric<DB & T>>
+  >(): Kysely<DB & T>
 
   override $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): Transaction<DrainOuterGeneric<DB & T>>
+  >(): Transaction<DB & T>
 
   override $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): Transaction<DrainOuterGeneric<DB & T>> {
+  >(): Transaction<DB & T> {
     return new Transaction({ ...this.#props })
   }
 
@@ -1311,37 +1308,37 @@ export class ControlledTransaction<
   // Keep the controlled transaction overload first for calls and last for ReturnType.
   override withTables<
     T extends Record<string, Record<string, any>>,
-  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+  >(): ControlledTransaction<DB & T, S>
 
   override withTables<T extends Record<string, Record<string, any>>>(): Kysely<
-    DrainOuterGeneric<DB & T>
+    DB & T
   >
 
   override withTables<
     T extends Record<string, Record<string, any>>,
-  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+  >(): ControlledTransaction<DB & T, S>
 
   override withTables<
     T extends Record<string, Record<string, any>>,
-  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S> {
+  >(): ControlledTransaction<DB & T, S> {
     return new ControlledTransaction({ ...this.#props })
   }
 
   override $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+  >(): ControlledTransaction<DB & T, S>
 
   override $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): Kysely<DrainOuterGeneric<DB & T>>
+  >(): Kysely<DB & T>
 
   override $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+  >(): ControlledTransaction<DB & T, S>
 
   override $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S> {
+  >(): ControlledTransaction<DB & T, S> {
     return new ControlledTransaction({ ...this.#props })
   }
 

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -158,7 +158,7 @@ bench('WheneableMergeQueryBuilder assignable to a narrower one', () => {
 
 bench('Transaction assignable to Kysely', () => {
   return acceptsKysely(transaction)
-}).types([103353, 'instantiations'])
+}).types([103242, 'instantiations'])
 
 bench('MergeQueryBuilder assignable to narrower MergeQueryBuilder', () => {
   return acceptsNarrowMergeInto(wideMergeInto)

--- a/test/typings/vitest/kysely-generic-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-generic-assignability.test-d.ts
@@ -8,7 +8,6 @@ import {
   accept,
   a,
   type DatabaseA,
-  type DatabaseAB,
   type DatabaseB,
   type Instances,
 } from './assignability.fixtures.js'
@@ -85,16 +84,5 @@ test('preserves generic table extensions when assigning to parent classes', () =
     accept<Transaction<DB & DatabaseB>>(
       source.controlled.withTables<DatabaseB>(),
     )
-  }
-})
-
-test('preserves generic table selections when assigning to parent classes', () => {
-  function check<DB extends DatabaseAB>(source: Instances<DB>) {
-    accept<Kysely<Pick<DB, 'a'>>>(source.transaction.$pickTables<'a'>())
-    accept<Kysely<Pick<DB, 'a'>>>(source.controlled.$pickTables<'a'>())
-    accept<Transaction<Pick<DB, 'a'>>>(source.controlled.$pickTables<'a'>())
-    accept<Kysely<Omit<DB, 'b'>>>(source.transaction.$omitTables<'b'>())
-    accept<Kysely<Omit<DB, 'b'>>>(source.controlled.$omitTables<'b'>())
-    accept<Transaction<Omit<DB, 'b'>>>(source.controlled.$omitTables<'b'>())
   }
 })

--- a/test/typings/vitest/kysely-generic-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-generic-assignability.test-d.ts
@@ -1,0 +1,71 @@
+import { test } from 'vitest'
+import type {
+  ControlledTransaction,
+  Kysely,
+  Transaction,
+} from '../../../dist/index.js'
+import {
+  accept,
+  a,
+  type DatabaseA,
+  type Instances,
+} from './assignability.fixtures.js'
+
+test('accepts the same generic schema across classes', () => {
+  function check<DB>(source: Instances<DB>) {
+    accept<Kysely<DB>>(source.transaction)
+    accept<Kysely<DB>>(source.controlled)
+    accept<Transaction<DB>>(source.controlled)
+  }
+})
+
+test('rejects generic schema extensions across all classes', () => {
+  function check<DB, Extra>(source: Instances<DB & Extra>) {
+    // @ts-expect-error Extra may narrow existing columns and reject writes allowed by DB
+    accept<Kysely<DB>>(source.db)
+    // @ts-expect-error Extra may narrow existing columns and reject writes allowed by DB
+    accept<Kysely<DB>>(source.transaction)
+    // @ts-expect-error Extra may narrow existing columns and reject writes allowed by DB
+    accept<Transaction<DB>>(source.transaction)
+    // @ts-expect-error Extra may narrow existing columns and reject writes allowed by DB
+    accept<Kysely<DB>>(source.controlled)
+    // @ts-expect-error Extra may narrow existing columns and reject writes allowed by DB
+    accept<Transaction<DB>>(source.controlled)
+    // @ts-expect-error Extra may narrow existing columns and reject writes allowed by DB
+    accept<ControlledTransaction<DB>>(source.controlled)
+  }
+})
+
+test('rejects constrained generic schemas where their constraint is required', () => {
+  function check<DB extends DatabaseA>(source: Instances<DB>) {
+    // @ts-expect-error DB may reject writes allowed by its constraint
+    accept<Kysely<DatabaseA>>(source.db)
+    // @ts-expect-error DB may reject writes allowed by its constraint
+    accept<Kysely<DatabaseA>>(source.transaction)
+    // @ts-expect-error DB may reject writes allowed by its constraint
+    accept<Transaction<DatabaseA>>(source.transaction)
+    // @ts-expect-error DB may reject writes allowed by its constraint
+    accept<Kysely<DatabaseA>>(source.controlled)
+    // @ts-expect-error DB may reject writes allowed by its constraint
+    accept<Transaction<DatabaseA>>(source.controlled)
+    // @ts-expect-error DB may reject writes allowed by its constraint
+    accept<ControlledTransaction<DatabaseA>>(source.controlled)
+  }
+})
+
+test('rejects replacing a generic schema with only its constraint', () => {
+  function check<DB extends DatabaseA>() {
+    // @ts-expect-error DB may require more than a
+    accept<Kysely<DB>>(a.db)
+    // @ts-expect-error DB may require more than a
+    accept<Kysely<DB>>(a.transaction)
+    // @ts-expect-error DB may require more than a
+    accept<Transaction<DB>>(a.transaction)
+    // @ts-expect-error DB may require more than a
+    accept<Kysely<DB>>(a.controlled)
+    // @ts-expect-error DB may require more than a
+    accept<Transaction<DB>>(a.controlled)
+    // @ts-expect-error DB may require more than a
+    accept<ControlledTransaction<DB>>(a.controlled)
+  }
+})

--- a/test/typings/vitest/kysely-generic-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-generic-assignability.test-d.ts
@@ -8,6 +8,8 @@ import {
   accept,
   a,
   type DatabaseA,
+  type DatabaseAB,
+  type DatabaseB,
   type Instances,
 } from './assignability.fixtures.js'
 
@@ -67,5 +69,32 @@ test('rejects replacing a generic schema with only its constraint', () => {
     accept<Transaction<DB>>(a.controlled)
     // @ts-expect-error DB may require more than a
     accept<ControlledTransaction<DB>>(a.controlled)
+  }
+})
+
+test('preserves generic table extensions when assigning to parent classes', () => {
+  function check<DB>(source: Instances<DB>) {
+    accept<Kysely<DB & DatabaseB>>(
+      source.transaction.$extendTables<DatabaseB>(),
+    )
+    accept<Kysely<DB & DatabaseB>>(source.controlled.$extendTables<DatabaseB>())
+    accept<Transaction<DB & DatabaseB>>(
+      source.controlled.$extendTables<DatabaseB>(),
+    )
+    accept<Kysely<DB & DatabaseB>>(source.transaction.withTables<DatabaseB>())
+    accept<Transaction<DB & DatabaseB>>(
+      source.controlled.withTables<DatabaseB>(),
+    )
+  }
+})
+
+test('preserves generic table selections when assigning to parent classes', () => {
+  function check<DB extends DatabaseAB>(source: Instances<DB>) {
+    accept<Kysely<Pick<DB, 'a'>>>(source.transaction.$pickTables<'a'>())
+    accept<Kysely<Pick<DB, 'a'>>>(source.controlled.$pickTables<'a'>())
+    accept<Transaction<Pick<DB, 'a'>>>(source.controlled.$pickTables<'a'>())
+    accept<Kysely<Omit<DB, 'b'>>>(source.transaction.$omitTables<'b'>())
+    accept<Kysely<Omit<DB, 'b'>>>(source.controlled.$omitTables<'b'>())
+    accept<Transaction<Omit<DB, 'b'>>>(source.controlled.$omitTables<'b'>())
   }
 })


### PR DESCRIPTION
Hey 👋 

Generic `$extendTables()` and `withTables()` results cannot be assigned to parent classes parameterized by `DB & Extra` because `DrainOuterGeneric` leaves the schema behind an unresolved conditional type.

This PR returns `DB & T` directly from these helpers in `Kysely`, `Transaction`, and `ControlledTransaction`, preserving their existing overloads and transaction state. It adds five generic assignability cases covering identical schemas, unsafe schema intersections and constraints, and table extensions. It also updates the `Transaction` assignability benchmark baseline to 103242 instantiations.
