### PR TITLE
fix: preserve generic table extension assignability

### DIFF
--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -34,7 +34,6 @@ import { CaseNode } from './operation-node/case-node.js'
 import { parseExpression } from './parser/expression-parser.js'
 import type { Expression } from './expression/expression.js'
 import { WithSchemaPlugin } from './plugin/with-schema/with-schema-plugin.js'
-import type { DrainOuterGeneric } from './util/type-utils.js'
 import type { QueryCompiler } from './query-compiler/query-compiler.js'
 import type {
   ReleaseSavepoint,
@@ -514,7 +513,7 @@ export class Kysely<DB>
    * ```
    */
   $extendTables<T extends Record<string, Record<string, any>>>(): Kysely<
-    DrainOuterGeneric<DB & T>
+    DB & T
   > {
     return new Kysely({ ...this.#props })
   }
@@ -595,9 +594,7 @@ export class Kysely<DB>
    * @deprecated use {@link $extendTables} instead.
    */
   // TODO: remove in 0.30
-  withTables<T extends Record<string, Record<string, any>>>(): Kysely<
-    DrainOuterGeneric<DB & T>
-  > {
+  withTables<T extends Record<string, Record<string, any>>>(): Kysely<DB & T> {
     return this.$extendTables()
   }
 
@@ -738,19 +735,19 @@ export class Transaction<DB> extends Kysely<DB> {
   // Keep the transaction overload first for calls and last for ReturnType.
   override withTables<
     T extends Record<string, Record<string, any>>,
-  >(): Transaction<DrainOuterGeneric<DB & T>>
+  >(): Transaction<DB & T>
 
   override withTables<T extends Record<string, Record<string, any>>>(): Kysely<
-    DrainOuterGeneric<DB & T>
+    DB & T
   >
 
   override withTables<
     T extends Record<string, Record<string, any>>,
-  >(): Transaction<DrainOuterGeneric<DB & T>>
+  >(): Transaction<DB & T>
 
   override withTables<
     T extends Record<string, Record<string, any>>,
-  >(): Transaction<DrainOuterGeneric<DB & T>> {
+  >(): Transaction<DB & T> {
     return new Transaction({ ...this.#props })
   }
 
@@ -759,19 +756,19 @@ export class Transaction<DB> extends Kysely<DB> {
    */
   override $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): Transaction<DrainOuterGeneric<DB & T>>
+  >(): Transaction<DB & T>
 
   override $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): Kysely<DrainOuterGeneric<DB & T>>
+  >(): Kysely<DB & T>
 
   override $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): Transaction<DrainOuterGeneric<DB & T>>
+  >(): Transaction<DB & T>
 
   override $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): Transaction<DrainOuterGeneric<DB & T>> {
+  >(): Transaction<DB & T> {
     return new Transaction({ ...this.#props })
   }
 
@@ -1311,37 +1308,37 @@ export class ControlledTransaction<
   // Keep the controlled transaction overload first for calls and last for ReturnType.
   override withTables<
     T extends Record<string, Record<string, any>>,
-  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+  >(): ControlledTransaction<DB & T, S>
 
   override withTables<T extends Record<string, Record<string, any>>>(): Kysely<
-    DrainOuterGeneric<DB & T>
+    DB & T
   >
 
   override withTables<
     T extends Record<string, Record<string, any>>,
-  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+  >(): ControlledTransaction<DB & T, S>
 
   override withTables<
     T extends Record<string, Record<string, any>>,
-  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S> {
+  >(): ControlledTransaction<DB & T, S> {
     return new ControlledTransaction({ ...this.#props })
   }
 
   override $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+  >(): ControlledTransaction<DB & T, S>
 
   override $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): Kysely<DrainOuterGeneric<DB & T>>
+  >(): Kysely<DB & T>
 
   override $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+  >(): ControlledTransaction<DB & T, S>
 
   override $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S> {
+  >(): ControlledTransaction<DB & T, S> {
     return new ControlledTransaction({ ...this.#props })
   }
 

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -158,7 +158,7 @@ bench('WheneableMergeQueryBuilder assignable to a narrower one', () => {
 
 bench('Transaction assignable to Kysely', () => {
   return acceptsKysely(transaction)
-}).types([103353, 'instantiations'])
+}).types([103242, 'instantiations'])
 
 bench('MergeQueryBuilder assignable to narrower MergeQueryBuilder', () => {
   return acceptsNarrowMergeInto(wideMergeInto)

--- a/test/typings/vitest/kysely-generic-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-generic-assignability.test-d.ts
@@ -8,7 +8,6 @@ import {
   accept,
   a,
   type DatabaseA,
-  type DatabaseAB,
   type DatabaseB,
   type Instances,
 } from './assignability.fixtures.js'
@@ -85,16 +84,5 @@ test('preserves generic table extensions when assigning to parent classes', () =
     accept<Transaction<DB & DatabaseB>>(
       source.controlled.withTables<DatabaseB>(),
     )
-  }
-})
-
-test('preserves generic table selections when assigning to parent classes', () => {
-  function check<DB extends DatabaseAB>(source: Instances<DB>) {
-    accept<Kysely<Pick<DB, 'a'>>>(source.transaction.$pickTables<'a'>())
-    accept<Kysely<Pick<DB, 'a'>>>(source.controlled.$pickTables<'a'>())
-    accept<Transaction<Pick<DB, 'a'>>>(source.controlled.$pickTables<'a'>())
-    accept<Kysely<Omit<DB, 'b'>>>(source.transaction.$omitTables<'b'>())
-    accept<Kysely<Omit<DB, 'b'>>>(source.controlled.$omitTables<'b'>())
-    accept<Transaction<Omit<DB, 'b'>>>(source.controlled.$omitTables<'b'>())
   }
 })

--- a/test/typings/vitest/kysely-generic-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-generic-assignability.test-d.ts
@@ -8,6 +8,8 @@ import {
   accept,
   a,
   type DatabaseA,
+  type DatabaseAB,
+  type DatabaseB,
   type Instances,
 } from './assignability.fixtures.js'
 
@@ -67,5 +69,32 @@ test('rejects replacing a generic schema with only its constraint', () => {
     accept<Transaction<DB>>(a.controlled)
     // @ts-expect-error DB may require more than a
     accept<ControlledTransaction<DB>>(a.controlled)
+  }
+})
+
+test('preserves generic table extensions when assigning to parent classes', () => {
+  function check<DB>(source: Instances<DB>) {
+    accept<Kysely<DB & DatabaseB>>(
+      source.transaction.$extendTables<DatabaseB>(),
+    )
+    accept<Kysely<DB & DatabaseB>>(source.controlled.$extendTables<DatabaseB>())
+    accept<Transaction<DB & DatabaseB>>(
+      source.controlled.$extendTables<DatabaseB>(),
+    )
+    accept<Kysely<DB & DatabaseB>>(source.transaction.withTables<DatabaseB>())
+    accept<Transaction<DB & DatabaseB>>(
+      source.controlled.withTables<DatabaseB>(),
+    )
+  }
+})
+
+test('preserves generic table selections when assigning to parent classes', () => {
+  function check<DB extends DatabaseAB>(source: Instances<DB>) {
+    accept<Kysely<Pick<DB, 'a'>>>(source.transaction.$pickTables<'a'>())
+    accept<Kysely<Pick<DB, 'a'>>>(source.controlled.$pickTables<'a'>())
+    accept<Transaction<Pick<DB, 'a'>>>(source.controlled.$pickTables<'a'>())
+    accept<Kysely<Omit<DB, 'b'>>>(source.transaction.$omitTables<'b'>())
+    accept<Kysely<Omit<DB, 'b'>>>(source.controlled.$omitTables<'b'>())
+    accept<Transaction<Omit<DB, 'b'>>>(source.controlled.$omitTables<'b'>())
   }
 })


### PR DESCRIPTION
Generic $extendTables() and withTables() results cannot be assigned to parent classes parameterized by DB & Extra because DrainOuterGeneric leaves the schema behind an unresolved conditional type.

Return DB & T directly from these helpers in Kysely, Transaction, and ControlledTransaction, preserving their existing overloads and transaction state. Add the generic table-extension regression case and update the Transaction assignability benchmark baseline to 103242 instantiations.

Validation: 46 Vitest typings tests pass. The extension case and existing suites typecheck on TypeScript 5.4, 5.8, 5.9, 6.0, and 7.0; tsd and formatting pass. The focused TS6 benchmark matches its new baseline (103353 → 103242, -0.11%). Native TS7 diagnostics report Transaction instantiations 58678 → 58455 (-0.38%); MergeQueryBuilder counts are unchanged. TS7 diagnostics are measurements, not an attest baseline.

Stacked on #2025. The still-failing generic pick/omit case is moved to a separate follow-up PR in the same suite.
