### PR TITLE
fix: allow compatible readonly transactions as database handles

### DIFF
--- a/src/readonly/readonly-kysely.ts
+++ b/src/readonly/readonly-kysely.ts
@@ -19,7 +19,6 @@ import type {
   AbortableQueryOptions,
 } from '../util/abort.js'
 import type { KyselyTypeError } from '../util/type-error.js'
-import type { DrainOuterGeneric } from '../util/type-utils.js'
 import type { ReadonlyCompiledQuery } from './readonly-compiled-query.js'
 import type { ReadonlyQueryResult } from './readonly-database-connection.js'
 import type { ReadonlyAccessMode } from './readonly-driver.js'
@@ -136,7 +135,7 @@ declare class ReadonlyKysely<DB> extends ReadonlyQueryCreator<DB> {
    * @deprecated use {@link $extendTables} instead.
    */
   withTables<T extends Record<string, Record<string, any>>>(): ReadonlyKysely<
-    DrainOuterGeneric<DB & T>
+    DB & T
   >
 
   /**
@@ -144,7 +143,7 @@ declare class ReadonlyKysely<DB> extends ReadonlyQueryCreator<DB> {
    */
   $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): ReadonlyKysely<DrainOuterGeneric<DB & T>>
+  >(): ReadonlyKysely<DB & T>
 
   /**
    * Similar to {@link Kysely.$omitTables} but read-only.
@@ -247,30 +246,30 @@ declare class ReadonlyTransaction<DB> extends ReadonlyKysely<DB> {
    */
   withTables<
     T extends Record<string, Record<string, any>>,
-  >(): ReadonlyTransaction<DrainOuterGeneric<DB & T>>
+  >(): ReadonlyTransaction<DB & T>
 
   withTables<T extends Record<string, Record<string, any>>>(): ReadonlyKysely<
-    DrainOuterGeneric<DB & T>
+    DB & T
   >
 
   withTables<
     T extends Record<string, Record<string, any>>,
-  >(): ReadonlyTransaction<DrainOuterGeneric<DB & T>>
+  >(): ReadonlyTransaction<DB & T>
 
   /**
    * Similar to {@link Transaction.$extendTables} but read-only.
    */
   $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): ReadonlyTransaction<DrainOuterGeneric<DB & T>>
+  >(): ReadonlyTransaction<DB & T>
 
   $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): ReadonlyKysely<DrainOuterGeneric<DB & T>>
+  >(): ReadonlyKysely<DB & T>
 
   $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): ReadonlyTransaction<DrainOuterGeneric<DB & T>>
+  >(): ReadonlyTransaction<DB & T>
 
   /**
    * Similar to {@link Transaction.$omitTables} but read-only.
@@ -386,14 +385,14 @@ declare class ReadonlyControlledTransaction<
    */
   withTables<
     T extends Record<string, Record<string, any>>,
-  >(): ReadonlyControlledTransaction<DrainOuterGeneric<DB & T>, S>
+  >(): ReadonlyControlledTransaction<DB & T, S>
 
   /**
    * Similar to {@link ControlledTransaction.$extendTables} but read-only.
    */
   $extendTables<
     T extends Record<string, Record<string, any>>,
-  >(): ReadonlyControlledTransaction<DrainOuterGeneric<DB & T>, S>
+  >(): ReadonlyControlledTransaction<DB & T, S>
 
   /**
    * Similar to {@link ControlledTransaction.$omitTables} but read-only.

--- a/src/readonly/readonly-kysely.ts
+++ b/src/readonly/readonly-kysely.ts
@@ -249,9 +249,25 @@ declare class ReadonlyTransaction<DB> extends ReadonlyKysely<DB> {
     T extends Record<string, Record<string, any>>,
   >(): ReadonlyTransaction<DrainOuterGeneric<DB & T>>
 
+  withTables<T extends Record<string, Record<string, any>>>(): ReadonlyKysely<
+    DrainOuterGeneric<DB & T>
+  >
+
+  withTables<
+    T extends Record<string, Record<string, any>>,
+  >(): ReadonlyTransaction<DrainOuterGeneric<DB & T>>
+
   /**
    * Similar to {@link Transaction.$extendTables} but read-only.
    */
+  $extendTables<
+    T extends Record<string, Record<string, any>>,
+  >(): ReadonlyTransaction<DrainOuterGeneric<DB & T>>
+
+  $extendTables<
+    T extends Record<string, Record<string, any>>,
+  >(): ReadonlyKysely<DrainOuterGeneric<DB & T>>
+
   $extendTables<
     T extends Record<string, Record<string, any>>,
   >(): ReadonlyTransaction<DrainOuterGeneric<DB & T>>
@@ -263,9 +279,25 @@ declare class ReadonlyTransaction<DB> extends ReadonlyKysely<DB> {
     DB extends object ? Omit<DB, T> : DB
   >
 
+  $omitTables<T extends keyof DB>(): ReadonlyKysely<
+    DB extends object ? Omit<DB, T> : DB
+  >
+
+  $omitTables<T extends keyof DB>(): ReadonlyTransaction<
+    DB extends object ? Omit<DB, T> : DB
+  >
+
   /**
    * Similar to {@link Transaction.$pickTables} but read-only.
    */
+  $pickTables<T extends keyof DB>(): ReadonlyTransaction<
+    DB extends object ? Pick<DB, T> : DB
+  >
+
+  $pickTables<T extends keyof DB>(): ReadonlyKysely<
+    DB extends object ? Pick<DB, T> : DB
+  >
+
   $pickTables<T extends keyof DB>(): ReadonlyTransaction<
     DB extends object ? Pick<DB, T> : DB
   >

--- a/test/ts-benchmarks/readonly.bench.ts
+++ b/test/ts-benchmarks/readonly.bench.ts
@@ -1,7 +1,14 @@
 import { bench } from '@ark/attest'
-import type { ReadonlyKysely } from '../../dist/readonly/index.js'
+import type {
+  ReadonlyKysely,
+  ReadonlyTransaction,
+} from '../../dist/readonly/index.js'
 
 type Person = { id: number; name: string }
+declare const transaction: ReadonlyTransaction<{
+  person: Person
+  pet: { id: number }
+}>
 declare const db: ReadonlyKysely<{ person: Person; pet: { id: number } }>
 declare function acceptsPerson(db: ReadonlyKysely<{ person: Person }>): void
 declare function acceptsNullableName(
@@ -14,8 +21,19 @@ bench.baseline(() => {})
 
 bench('ReadonlyKysely passed to a function requiring fewer tables', () => {
   return acceptsPerson(db)
-}).types([49916, 'instantiations'])
+}).types([50815, 'instantiations'])
 
 bench('ReadonlyKysely passed to a function accepting nullable reads', () => {
   return acceptsNullableName(db)
-}).types([49991, 'instantiations'])
+}).types([50890, 'instantiations'])
+
+bench('ReadonlyTransaction passed to a function requiring fewer tables', () => {
+  return acceptsPerson(transaction)
+}).types([47854, 'instantiations'])
+
+bench(
+  'ReadonlyTransaction passed to a function accepting nullable reads',
+  () => {
+    return acceptsNullableName(transaction)
+  },
+).types([47929, 'instantiations'])

--- a/test/ts-benchmarks/readonly.bench.ts
+++ b/test/ts-benchmarks/readonly.bench.ts
@@ -21,19 +21,19 @@ bench.baseline(() => {})
 
 bench('ReadonlyKysely passed to a function requiring fewer tables', () => {
   return acceptsPerson(db)
-}).types([50815, 'instantiations'])
+}).types([50398, 'instantiations'])
 
 bench('ReadonlyKysely passed to a function accepting nullable reads', () => {
   return acceptsNullableName(db)
-}).types([50890, 'instantiations'])
+}).types([50473, 'instantiations'])
 
 bench('ReadonlyTransaction passed to a function requiring fewer tables', () => {
   return acceptsPerson(transaction)
-}).types([47854, 'instantiations'])
+}).types([47743, 'instantiations'])
 
 bench(
   'ReadonlyTransaction passed to a function accepting nullable reads',
   () => {
     return acceptsNullableName(transaction)
   },
-).types([47929, 'instantiations'])
+).types([47818, 'instantiations'])

--- a/test/typings/vitest/assignability.fixtures.ts
+++ b/test/typings/vitest/assignability.fixtures.ts
@@ -1,4 +1,9 @@
 import type {
+  ReadonlyKysely,
+  ReadonlyTransaction,
+  ReadonlyControlledTransaction,
+} from '../../../dist/readonly/index.js'
+import type {
   ControlledTransaction,
   Kysely,
   Transaction,
@@ -20,3 +25,9 @@ export declare const b: Instances<DatabaseB>
 export declare const ab: Instances<DatabaseAB>
 
 export declare function accept<T>(value: T): void
+
+export type ReadonlyInstances<DB> = {
+  db: ReadonlyKysely<DB>
+  transaction: ReadonlyTransaction<DB>
+  controlled: ReadonlyControlledTransaction<DB>
+}

--- a/test/typings/vitest/kysely-generic-assignability.test-d.ts
+++ b/test/typings/vitest/kysely-generic-assignability.test-d.ts
@@ -1,3 +1,7 @@
+import type {
+  ReadonlyKysely,
+  ReadonlyTransaction,
+} from '../../../dist/readonly/index.js'
 import { expectTypeOf, test } from 'vitest'
 import type {
   ControlledTransaction,
@@ -10,6 +14,7 @@ import {
   type DatabaseA,
   type DatabaseB,
   type Instances,
+  type ReadonlyInstances,
 } from './assignability.fixtures.js'
 
 test('accepts the same generic schema across classes', () => {
@@ -142,4 +147,24 @@ test('preserves any schemas through table helpers', () => {
   db.$pickTables<'a'>().selectFrom('other').selectAll()
   tx.$pickTables<'a'>().selectFrom('other').selectAll()
   controlled.$pickTables<'a'>().selectFrom('other').selectAll()
+})
+
+test('readonly: preserves generic table extensions when assigning to parent classes', () => {
+  function check<DB>(source: ReadonlyInstances<DB>) {
+    accept<ReadonlyKysely<DB & DatabaseB>>(
+      source.transaction.$extendTables<DatabaseB>(),
+    )
+    accept<ReadonlyKysely<DB & DatabaseB>>(
+      source.controlled.$extendTables<DatabaseB>(),
+    )
+    accept<ReadonlyTransaction<DB & DatabaseB>>(
+      source.controlled.$extendTables<DatabaseB>(),
+    )
+    accept<ReadonlyKysely<DB & DatabaseB>>(
+      source.transaction.withTables<DatabaseB>(),
+    )
+    accept<ReadonlyTransaction<DB & DatabaseB>>(
+      source.controlled.withTables<DatabaseB>(),
+    )
+  }
 })

--- a/test/typings/vitest/kysely-helper-return-types.test-d.ts
+++ b/test/typings/vitest/kysely-helper-return-types.test-d.ts
@@ -199,3 +199,37 @@ test('ControlledTransaction retains schemas in uninstantiated ReturnType', () =>
   expectTypeOf<SchemaOf<Picked>>().toEqualTypeOf<{ a: Row; b: Row }>()
   expectTypeOf<SchemaOf<Omitted>>().toEqualTypeOf<{}>()
 })
+
+test('ReadonlyKysely retains schemas in uninstantiated ReturnType', () => {
+  const source = null! as ReadonlyKysely<DatabaseAB>
+  type Picked = ReturnType<typeof source.$pickTables>
+  type Omitted = ReturnType<typeof source.$omitTables>
+  expectTypeOf<SchemaOf<Picked>>().toEqualTypeOf<{ a: Row; b: Row }>()
+  expectTypeOf<SchemaOf<Omitted>>().toEqualTypeOf<{}>()
+})
+
+test('ReadonlyTransaction retains schemas in uninstantiated ReturnType', () => {
+  const source = null! as ReadonlyTransaction<DatabaseAB>
+  type Picked = ReturnType<typeof source.$pickTables>
+  type Omitted = ReturnType<typeof source.$omitTables>
+  expectTypeOf<SchemaOf<Picked>>().toEqualTypeOf<{ a: Row; b: Row }>()
+  expectTypeOf<SchemaOf<Omitted>>().toEqualTypeOf<{}>()
+})
+
+test('ReadonlyControlledTransaction retains schemas in uninstantiated ReturnType', () => {
+  const source = null! as ReadonlyControlledTransaction<DatabaseAB>
+  type Picked = ReturnType<typeof source.$pickTables>
+  type Omitted = ReturnType<typeof source.$omitTables>
+  expectTypeOf<SchemaOf<Picked>>().toEqualTypeOf<{ a: Row; b: Row }>()
+  expectTypeOf<SchemaOf<Omitted>>().toEqualTypeOf<{}>()
+})
+
+test('readonly transaction table helper calls retain transaction results', () => {
+  const source = null! as ReadonlyTransaction<DatabaseAB>
+  expectTypeOf(
+    source.$extendTables<Extra>().isTransaction,
+  ).toEqualTypeOf<true>()
+  expectTypeOf(source.withTables<Extra>().isTransaction).toEqualTypeOf<true>()
+  expectTypeOf(source.$pickTables<'a'>().isTransaction).toEqualTypeOf<true>()
+  expectTypeOf(source.$omitTables<'b'>().isTransaction).toEqualTypeOf<true>()
+})

--- a/test/typings/vitest/readonly-assignability.test-d.ts
+++ b/test/typings/vitest/readonly-assignability.test-d.ts
@@ -49,14 +49,11 @@ test('accepts identical readonly schemas', () => {
 test('accepts readonly schemas with extra tables', () => {
   const source = null! as Instances<DatabaseAB>
   accept<ReadonlyKysely<DatabaseA>>(source.db)
-  // TODO: Accept compatible schemas when assigning to readonly parents.
-  // The table-helper return types still block these assignments. Investigate
-  // removing DrainOuterGeneric from table extensions and adding parent-return
-  // overloads, checking instantiation costs before enabling these cases.
-  // accept<ReadonlyKysely<DatabaseA>>(source.transaction)
+  accept<ReadonlyKysely<DatabaseA>>(source.transaction)
   accept<ReadonlyTransaction<DatabaseA>>(source.transaction)
+  // TODO: Controlled transaction table helpers still block this assignment.
   // accept<ReadonlyKysely<DatabaseA>>(source.controlled)
-  // accept<ReadonlyTransaction<DatabaseA>>(source.controlled)
+  accept<ReadonlyTransaction<DatabaseA>>(source.controlled)
   accept<ReadonlyControlledTransaction<DatabaseA>>(source.controlled)
 })
 
@@ -121,14 +118,11 @@ test('rejects readonly schemas with incompatible column types', () => {
 test('accepts readonly column widening', () => {
   const source = null! as Instances<DatabaseA>
   accept<ReadonlyKysely<{ a: { id: number | null } }>>(source.db)
-  // TODO: Accept compatible schemas when assigning to readonly parents.
-  // The table-helper return types still block these assignments. Investigate
-  // removing DrainOuterGeneric from table extensions and adding parent-return
-  // overloads, checking instantiation costs before enabling these cases.
-  // accept<ReadonlyKysely<{ a: { id: number | null } }>>(source.transaction)
+  accept<ReadonlyKysely<{ a: { id: number | null } }>>(source.transaction)
   accept<ReadonlyTransaction<{ a: { id: number | null } }>>(source.transaction)
+  // TODO: Controlled transaction table helpers still block this assignment.
   // accept<ReadonlyKysely<{ a: { id: number | null } }>>(source.controlled)
-  // accept<ReadonlyTransaction<{ a: { id: number | null } }>>(source.controlled)
+  accept<ReadonlyTransaction<{ a: { id: number | null } }>>(source.controlled)
   accept<ReadonlyControlledTransaction<{ a: { id: number | null } }>>(
     source.controlled,
   )
@@ -140,14 +134,11 @@ test('accepts readonly schemas with identical reads and different write types', 
   const source = null! as Instances<Source>
 
   accept<ReadonlyKysely<Target>>(source.db)
-  // TODO: Accept compatible schemas when assigning to readonly parents.
-  // The table-helper return types still block these assignments. Investigate
-  // removing DrainOuterGeneric from table extensions and adding parent-return
-  // overloads, checking instantiation costs before enabling these cases.
-  // accept<ReadonlyKysely<Target>>(source.transaction)
+  accept<ReadonlyKysely<Target>>(source.transaction)
   accept<ReadonlyTransaction<Target>>(source.transaction)
+  // TODO: Controlled transaction table helpers still block this assignment.
   // accept<ReadonlyKysely<Target>>(source.controlled)
-  // accept<ReadonlyTransaction<Target>>(source.controlled)
+  accept<ReadonlyTransaction<Target>>(source.controlled)
   accept<ReadonlyControlledTransaction<Target>>(source.controlled)
 })
 
@@ -215,9 +206,9 @@ test('accepts any as an explicit readonly schema escape hatch', () => {
   const concrete = null! as Instances<DatabaseA>
 
   accept<ReadonlyKysely<DatabaseA>>(source.db)
-  // TODO: Table-helper return types also block these parent-class assignments.
-  // accept<ReadonlyKysely<DatabaseA>>(source.transaction)
+  accept<ReadonlyKysely<DatabaseA>>(source.transaction)
   accept<ReadonlyTransaction<DatabaseA>>(source.transaction)
+  // TODO: Controlled transaction table helpers still block this assignment.
   // accept<ReadonlyKysely<DatabaseA>>(source.controlled)
   // accept<ReadonlyTransaction<DatabaseA>>(source.controlled)
   accept<ReadonlyControlledTransaction<DatabaseA>>(source.controlled)


### PR DESCRIPTION
Hey 👋 

Passing a readonly transaction to a consumer requiring fewer tables, wider nullable reads, equivalent read types with different write types, or an `any` schema escape hatch currently fails through the table-helper return types.

This PR adds parent-return overloads to `ReadonlyTransaction.withTables`, `$extendTables`, `$pickTables`, and `$omitTables`. It preserves the transaction overload first for calls and last for `ReturnType`. This enables seven deferred assignments, including three controlled-transaction assignments to `ReadonlyTransaction`. It also removes `DrainOuterGeneric` from readonly table-extension return types so generic `$extendTables` and `withTables` results also assign to parents using `DB & Extra`.
