### PR TITLE
fix: allow compatible readonly controlled transactions as parent handles

### DIFF
--- a/src/readonly/readonly-kysely.ts
+++ b/src/readonly/readonly-kysely.ts
@@ -387,9 +387,25 @@ declare class ReadonlyControlledTransaction<
     T extends Record<string, Record<string, any>>,
   >(): ReadonlyControlledTransaction<DB & T, S>
 
+  withTables<T extends Record<string, Record<string, any>>>(): ReadonlyKysely<
+    DB & T
+  >
+
+  withTables<
+    T extends Record<string, Record<string, any>>,
+  >(): ReadonlyControlledTransaction<DB & T, S>
+
   /**
    * Similar to {@link ControlledTransaction.$extendTables} but read-only.
    */
+  $extendTables<
+    T extends Record<string, Record<string, any>>,
+  >(): ReadonlyControlledTransaction<DB & T, S>
+
+  $extendTables<
+    T extends Record<string, Record<string, any>>,
+  >(): ReadonlyKysely<DB & T>
+
   $extendTables<
     T extends Record<string, Record<string, any>>,
   >(): ReadonlyControlledTransaction<DB & T, S>
@@ -402,9 +418,31 @@ declare class ReadonlyControlledTransaction<
     S
   >
 
+  $omitTables<T extends keyof DB>(): ReadonlyKysely<
+    DB extends object ? Omit<DB, T> : DB
+  >
+
+  $omitTables<T extends keyof DB>(): ReadonlyTransaction<
+    DB extends object ? Omit<DB, T> : DB
+  >
+
+  $omitTables<T extends keyof DB>(): ReadonlyControlledTransaction<
+    DB extends object ? Omit<DB, T> : DB,
+    S
+  >
+
   /**
    * Similar to {@link ControlledTransaction.$pickTables} but read-only.
    */
+  $pickTables<T extends keyof DB>(): ReadonlyControlledTransaction<
+    DB extends object ? Pick<DB, T> : DB,
+    S
+  >
+
+  $pickTables<T extends keyof DB>(): ReadonlyKysely<
+    DB extends object ? Pick<DB, T> : DB
+  >
+
   $pickTables<T extends keyof DB>(): ReadonlyControlledTransaction<
     DB extends object ? Pick<DB, T> : DB,
     S

--- a/test/ts-benchmarks/readonly.bench.ts
+++ b/test/ts-benchmarks/readonly.bench.ts
@@ -2,6 +2,7 @@ import { bench } from '@ark/attest'
 import type {
   ReadonlyKysely,
   ReadonlyTransaction,
+  ReadonlyControlledTransaction,
 } from '../../dist/readonly/index.js'
 
 type Person = { id: number; name: string }
@@ -9,6 +10,10 @@ declare const transaction: ReadonlyTransaction<{
   person: Person
   pet: { id: number }
 }>
+declare const controlled: ReadonlyControlledTransaction<
+  { person: Person; pet: { id: number } },
+  ['s']
+>
 declare const db: ReadonlyKysely<{ person: Person; pet: { id: number } }>
 declare function acceptsPerson(db: ReadonlyKysely<{ person: Person }>): void
 declare function acceptsNullableName(
@@ -21,11 +26,11 @@ bench.baseline(() => {})
 
 bench('ReadonlyKysely passed to a function requiring fewer tables', () => {
   return acceptsPerson(db)
-}).types([50398, 'instantiations'])
+}).types([52001, 'instantiations'])
 
 bench('ReadonlyKysely passed to a function accepting nullable reads', () => {
   return acceptsNullableName(db)
-}).types([50473, 'instantiations'])
+}).types([52076, 'instantiations'])
 
 bench('ReadonlyTransaction passed to a function requiring fewer tables', () => {
   return acceptsPerson(transaction)
@@ -37,3 +42,17 @@ bench(
     return acceptsNullableName(transaction)
   },
 ).types([47818, 'instantiations'])
+
+bench(
+  'ReadonlyControlledTransaction passed to a function requiring fewer tables',
+  () => {
+    return acceptsPerson(controlled)
+  },
+).types([47779, 'instantiations'])
+
+bench(
+  'ReadonlyControlledTransaction passed to a function accepting nullable reads',
+  () => {
+    return acceptsNullableName(controlled)
+  },
+).types([47854, 'instantiations'])

--- a/test/typings/vitest/kysely-helper-return-types.test-d.ts
+++ b/test/typings/vitest/kysely-helper-return-types.test-d.ts
@@ -233,3 +233,45 @@ test('readonly transaction table helper calls retain transaction results', () =>
   expectTypeOf(source.$pickTables<'a'>().isTransaction).toEqualTypeOf<true>()
   expectTypeOf(source.$omitTables<'b'>().isTransaction).toEqualTypeOf<true>()
 })
+
+test('readonly controlled table helper calls retain controlled operations', () => {
+  const source = null! as ReadonlyControlledTransaction<
+    DatabaseAB,
+    ['one', 'two']
+  >
+  expectTypeOf(source.$extendTables<Extra>().commit().execute()).toEqualTypeOf<
+    Promise<void>
+  >()
+  expectTypeOf(source.withTables<Extra>().commit().execute()).toEqualTypeOf<
+    Promise<void>
+  >()
+  expectTypeOf(source.$pickTables<'a'>().commit().execute()).toEqualTypeOf<
+    Promise<void>
+  >()
+  expectTypeOf(source.$omitTables<'b'>().commit().execute()).toEqualTypeOf<
+    Promise<void>
+  >()
+})
+
+test('readonly controlled table helper ReturnType retains savepoints', () => {
+  const source = null! as ReadonlyControlledTransaction<
+    DatabaseAB,
+    ['one', 'two']
+  >
+  type ExtendedResult = ReturnType<typeof source.$extendTables<Extra>>
+  type WithTablesResult = ReturnType<typeof source.withTables<Extra>>
+  type PickedResult = ReturnType<typeof source.$pickTables<'a'>>
+  type OmittedResult = ReturnType<typeof source.$omitTables<'b'>>
+  expectTypeOf<
+    Parameters<ExtendedResult['rollbackToSavepoint']>[0]
+  >().toEqualTypeOf<'one' | 'two'>()
+  expectTypeOf<
+    Parameters<WithTablesResult['rollbackToSavepoint']>[0]
+  >().toEqualTypeOf<'one' | 'two'>()
+  expectTypeOf<
+    Parameters<PickedResult['rollbackToSavepoint']>[0]
+  >().toEqualTypeOf<'one' | 'two'>()
+  expectTypeOf<
+    Parameters<OmittedResult['rollbackToSavepoint']>[0]
+  >().toEqualTypeOf<'one' | 'two'>()
+})

--- a/test/typings/vitest/readonly-assignability.test-d.ts
+++ b/test/typings/vitest/readonly-assignability.test-d.ts
@@ -51,8 +51,7 @@ test('accepts readonly schemas with extra tables', () => {
   accept<ReadonlyKysely<DatabaseA>>(source.db)
   accept<ReadonlyKysely<DatabaseA>>(source.transaction)
   accept<ReadonlyTransaction<DatabaseA>>(source.transaction)
-  // TODO: Controlled transaction table helpers still block this assignment.
-  // accept<ReadonlyKysely<DatabaseA>>(source.controlled)
+  accept<ReadonlyKysely<DatabaseA>>(source.controlled)
   accept<ReadonlyTransaction<DatabaseA>>(source.controlled)
   accept<ReadonlyControlledTransaction<DatabaseA>>(source.controlled)
 })
@@ -120,8 +119,7 @@ test('accepts readonly column widening', () => {
   accept<ReadonlyKysely<{ a: { id: number | null } }>>(source.db)
   accept<ReadonlyKysely<{ a: { id: number | null } }>>(source.transaction)
   accept<ReadonlyTransaction<{ a: { id: number | null } }>>(source.transaction)
-  // TODO: Controlled transaction table helpers still block this assignment.
-  // accept<ReadonlyKysely<{ a: { id: number | null } }>>(source.controlled)
+  accept<ReadonlyKysely<{ a: { id: number | null } }>>(source.controlled)
   accept<ReadonlyTransaction<{ a: { id: number | null } }>>(source.controlled)
   accept<ReadonlyControlledTransaction<{ a: { id: number | null } }>>(
     source.controlled,
@@ -136,8 +134,7 @@ test('accepts readonly schemas with identical reads and different write types', 
   accept<ReadonlyKysely<Target>>(source.db)
   accept<ReadonlyKysely<Target>>(source.transaction)
   accept<ReadonlyTransaction<Target>>(source.transaction)
-  // TODO: Controlled transaction table helpers still block this assignment.
-  // accept<ReadonlyKysely<Target>>(source.controlled)
+  accept<ReadonlyKysely<Target>>(source.controlled)
   accept<ReadonlyTransaction<Target>>(source.controlled)
   accept<ReadonlyControlledTransaction<Target>>(source.controlled)
 })
@@ -208,9 +205,8 @@ test('accepts any as an explicit readonly schema escape hatch', () => {
   accept<ReadonlyKysely<DatabaseA>>(source.db)
   accept<ReadonlyKysely<DatabaseA>>(source.transaction)
   accept<ReadonlyTransaction<DatabaseA>>(source.transaction)
-  // TODO: Controlled transaction table helpers still block this assignment.
-  // accept<ReadonlyKysely<DatabaseA>>(source.controlled)
-  // accept<ReadonlyTransaction<DatabaseA>>(source.controlled)
+  accept<ReadonlyKysely<DatabaseA>>(source.controlled)
+  accept<ReadonlyTransaction<DatabaseA>>(source.controlled)
   accept<ReadonlyControlledTransaction<DatabaseA>>(source.controlled)
 
   accept<ReadonlyKysely<any>>(concrete.db)


### PR DESCRIPTION
Hey 👋 

Readonly controlled transactions fail assignment to compatible readonly database handles, and `ReadonlyControlledTransaction<any>` fails assignment to a concrete readonly transaction.

This PR adds parent-return overloads to the four controlled table helpers, including the `ReadonlyTransaction` return overload needed by `$omitTables`. It preserves the controlled overload first for calls and last for `ReturnType`, including the savepoint tuple.
